### PR TITLE
Eliminate legacy Program class

### DIFF
--- a/account-management/src/WebApi/Program.cs
+++ b/account-management/src/WebApi/Program.cs
@@ -1,53 +1,42 @@
 using PlatformPlatform.AccountManagement.Application;
 using PlatformPlatform.AccountManagement.Infrastructure;
+using PlatformPlatform.AccountManagement.WebApi;
 using PlatformPlatform.AccountManagement.WebApi.Endpoints;
 
-namespace PlatformPlatform.AccountManagement.WebApi;
+var builder = WebApplication.CreateBuilder(args);
 
-/// <summary>
-///     The Program class is the main entry point. In .NET 6 it is no longer necessary to create a Program class.
-///     However for UnitTests, to create a WebApplicationFactory we need a class that can be referenced.
-/// </summary>
-public class Program
+// Configure services for the Application, Infrastructure, and WebApi layers.
+builder.Services
+    .AddApplicationServices()
+    .AddInfrastructureServices(builder.Configuration)
+    .AddWebApiServices();
+
+var app = builder.Build();
+
+// Enable the developer exception page and Swagger UI in the development environment.
+if (app.Environment.IsDevelopment())
 {
-    internal static void Main(string[] args)
-    {
-        var builder = WebApplication.CreateBuilder(args);
-
-        // Configure services for the Application, Infrastructure, and WebApi layers.
-        builder.Services
-            .AddApplicationServices()
-            .AddInfrastructureServices(builder.Configuration)
-            .AddWebApiServices();
-
-        var app = builder.Build();
-
-        // Enable the developer exception page and Swagger UI in the development environment.
-        if (app.Environment.IsDevelopment())
-        {
-            app.UseDeveloperExceptionPage();
-            app.UseSwagger(); //Generate a swagger.json file
-            app.UseSwaggerUI(c =>
-                c.SwaggerEndpoint("/swagger/v1/swagger.json", "AccountManagement API - Unstable")
-            );
-        }
-        else
-        {
-            // Adds middleware for using HSTS, which adds the Strict-Transport-Security header
-            // Defaults to 30 days. See https://aka.ms/aspnetcore-hsts, so be careful during development.
-            app.UseHsts();
-
-            // Adds middleware for redirecting HTTP Requests to HTTPS.
-            app.UseHttpsRedirection();
-        }
-
-        // Add a default "Hello World!" endpoint at the root path.
-        app.MapGet("/", () => "Hello World!").ExcludeFromDescription();
-
-        // Map tenant-related endpoints.
-        app.MapTenantEndpoints();
-
-        // Run the web application.
-        app.Run();
-    }
+    app.UseDeveloperExceptionPage();
+    app.UseSwagger(); //Generate a swagger.json file
+    app.UseSwaggerUI(c =>
+        c.SwaggerEndpoint("/swagger/v1/swagger.json", "AccountManagement API - Unstable")
+    );
 }
+else
+{
+    // Adds middleware for using HSTS, which adds the Strict-Transport-Security header
+    // Defaults to 30 days. See https://aka.ms/aspnetcore-hsts, so be careful during development.
+    app.UseHsts();
+
+    // Adds middleware for redirecting HTTP Requests to HTTPS.
+    app.UseHttpsRedirection();
+}
+
+// Add a default "Hello World!" endpoint at the root path.
+app.MapGet("/", () => "Hello World!").ExcludeFromDescription();
+
+// Map tenant-related endpoints.
+app.MapTenantEndpoints();
+
+// Run the web application.
+app.Run();

--- a/account-management/src/WebApi/WebApi.csproj
+++ b/account-management/src/WebApi/WebApi.csproj
@@ -14,6 +14,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="PlatformPlatform.AccountManagement.Tests"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.4">
             <PrivateAssets>all</PrivateAssets>

--- a/account-management/tests/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
+++ b/account-management/tests/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
@@ -9,7 +9,6 @@ using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 using PlatformPlatform.AccountManagement.Domain.Shared;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.AccountManagement.Infrastructure;
-using PlatformPlatform.AccountManagement.WebApi;
 using Xunit;
 
 namespace PlatformPlatform.AccountManagement.Tests.WebApi.Endpoints;


### PR DESCRIPTION
### Summary & Motivation

Add InternalsVisibleTo to the WebApi project file, providing access to internal calls for the Tests project. This change enables the removal of the legacy Program class and allows for the use of top-level statements introduced in C# 9, eliminating the need for an explicit class definition.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
