### PR TITLE
Create unique .NET build version number as YYYY.M.D.REV

### DIFF
--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -46,8 +46,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
-        export PATH="$HOME/.dotnet/tools:$PATH"
-        mkdir coverage
         dotnet sonarscanner begin /k:"${{ vars.SONAR_PROJECT_KEY }}" /o:"${{ vars.SONAR_ORGANIZATION }}" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.dotcover.reportsPaths="coverage/dotCover.html"
         dotnet dotcover test AccountManagement.sln --dcOutput="coverage/dotCover.html" --dcReportType=HTML
         dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -17,12 +17,17 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.0.x
+    - name: Generate version
+      run: |
+        VERSION=$(date +"%Y.%m.%d").$GITHUB_RUN_NUMBER
+        echo "Generated version: $VERSION"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Restore dependencies
       working-directory: account-management
       run: dotnet restore AccountManagement.sln
     - name: Build
       working-directory: account-management
-      run: dotnet build AccountManagement.sln --no-restore
+      run: dotnet build AccountManagement.sln --no-restore --configuration Release /p:Version=$VERSION
 
   test-with-code-coverage:
     needs: build
@@ -44,7 +49,7 @@ jobs:
         export PATH="$HOME/.dotnet/tools:$PATH"
         mkdir coverage
         dotnet sonarscanner begin /k:"${{ vars.SONAR_PROJECT_KEY }}" /o:"${{ vars.SONAR_ORGANIZATION }}" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.dotcover.reportsPaths="coverage/dotCover.html"
-        dotnet dotcover test --dcOutput="coverage/dotCover.html" --dcReportType=HTML -- AccountManagement.sln
+        dotnet dotcover test AccountManagement.sln --dcOutput="coverage/dotCover.html" --dcReportType=HTML
         dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
 
   jetbrains-code-inspection:

--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,9 @@ $tf/
 # Guidance Automation Toolkit
 *.gpState
 
+# Visual Studio Code
+.vscode
+
 # ReSharper is a .NET coding add-in
 _ReSharper*/
 *.[Rr]e[Ss]harper


### PR DESCRIPTION
### Summary & Motivation

Generate unique version numbers in the format YYYY.M.D.REV, where REV represents the count of GitHub Action runs. Apply this version number to both the .NET AssemblyVersion and AssemblyFileVersion.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
