### PR TITLE
Add GitHub CODEOWNERS file to mandate appropriate team approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Set the Site Reliability Team as the owner of the root files and all folders without an owner
+/* @PlatformPlatform/Site-Reliability-Team
+
+# Set the Site-Reliability-Team as the owner of the .github folder
+/.github/ @PlatformPlatform/Site-Reliability-Team
+
+# Site Reliability Team owns the 'cloud-infrastructure' directory
+/cloud-infrastructure/ @PlatformPlatform/Site-Reliability-Team
+
+# Account Team owns the 'account-management' directory
+/account-management/ @PlatformPlatform/Account-Team


### PR DESCRIPTION
### Summary & Motivation

Create a new GitHub CODEOWNERS file to enforce appropriate team approvals before merging. This pull request assumes the existence of a "Site Reliability Team" and an "Account Team" within the GitHub organization. By default, the Site Reliability Team owns all new folders, with explicit ownership of the .github and cloud-infrastructure folders. The Account Team owns the /account-management/ folder.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
