### PR TITLE
Add mapster for mapping dto objects

### DIFF
--- a/account-management/src/Application/Application.csproj
+++ b/account-management/src/Application/Application.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1"/>
+        <PackageReference Include="Mapster" Version="7.3.0"/>
         <PackageReference Include="MediatR" Version="12.0.1"/>
     </ItemGroup>
 

--- a/account-management/src/Application/ApplicationConfiguration.cs
+++ b/account-management/src/Application/ApplicationConfiguration.cs
@@ -1,8 +1,11 @@
 using System.Reflection;
 using FluentValidation;
+using Mapster;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using PlatformPlatform.AccountManagement.Application.Shared.Persistence;
+using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
+using PlatformPlatform.AccountManagement.Domain.Tenants;
 
 namespace PlatformPlatform.AccountManagement.Application;
 
@@ -22,6 +25,17 @@ public static class ApplicationConfiguration
 
         services.AddValidatorsFromAssembly(Assembly);
 
+        ConfigureMappings();
+
         return services;
+    }
+
+    /// <summary>
+    ///     Configures the mappings between domain entities and DTOs.
+    /// </summary>
+    public static void ConfigureMappings()
+    {
+        TypeAdapterConfig<Tenant, TenantDto>.NewConfig()
+            .Map(destination => destination.Id, source => source.Id.AsRawString());
     }
 }

--- a/account-management/src/Application/Tenants/Commands/CreateTenant/CreateTenantCommand.cs
+++ b/account-management/src/Application/Tenants/Commands/CreateTenant/CreateTenantCommand.cs
@@ -1,3 +1,4 @@
+using Mapster;
 using MediatR;
 using PlatformPlatform.AccountManagement.Application.Shared;
 using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
@@ -43,7 +44,7 @@ public sealed class CreateTenantCommandHandler : IRequestHandler<CreateTenantCom
 
         await _tenantRepository.AddAsync(tenant, cancellationToken);
 
-        return TenantDto.CreateFrom(tenant);
+        return tenant.Adapt<TenantDto>();
     }
 
     private async Task<Result> IsSubdomainUniqueAsync(string subdomain, CancellationToken cancellationToken)

--- a/account-management/src/Application/Tenants/Queries/GetTenantByIdQuery.cs
+++ b/account-management/src/Application/Tenants/Queries/GetTenantByIdQuery.cs
@@ -1,3 +1,4 @@
+using Mapster;
 using MediatR;
 using PlatformPlatform.AccountManagement.Application.Shared;
 using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
@@ -25,6 +26,6 @@ public sealed class GetTenantQueryHandler : IRequestHandler<GetTenantByIdQuery, 
         var tenant = await _tenantRepository.GetByIdAsync(request.Id, cancellationToken);
         return tenant == null
             ? QueryResult<TenantDto>.Failure($"Tenant with id '{request.Id.AsRawString()}' not found.")
-            : TenantDto.CreateFrom(tenant);
+            : tenant.Adapt<TenantDto>();
     }
 }

--- a/account-management/tests/Tests/Application/Tenants/Commands/CreateTenant/CreateTenantCommandHandlerTests.cs
+++ b/account-management/tests/Tests/Application/Tenants/Commands/CreateTenant/CreateTenantCommandHandlerTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using PlatformPlatform.AccountManagement.Application;
 using PlatformPlatform.AccountManagement.Application.Tenants.Commands.CreateTenant;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using Xunit;
@@ -12,6 +14,9 @@ public class CreateTenantCommandHandlerTests
 
     public CreateTenantCommandHandlerTests()
     {
+        var services = new ServiceCollection();
+        services.AddApplicationServices();
+
         _tenantRepository = Substitute.For<ITenantRepository>();
     }
 

--- a/account-management/tests/Tests/Application/Tenants/Queries/GetTenantByIdQueryTests.cs
+++ b/account-management/tests/Tests/Application/Tenants/Queries/GetTenantByIdQueryTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using PlatformPlatform.AccountManagement.Application;
 using PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using Xunit;
@@ -8,6 +10,12 @@ namespace PlatformPlatform.AccountManagement.Tests.Application.Tenants.Queries;
 
 public class GetTenantByIdQueryTests
 {
+    public GetTenantByIdQueryTests()
+    {
+        var services = new ServiceCollection();
+        services.AddApplicationServices();
+    }
+
     [Fact]
     public async Task GetTenantByIdQuery_WhenTenantFound_ShouldReturnTenantResponseDto()
     {


### PR DESCRIPTION
### Summary & Motivation

Introduce [Mapster](https://www.nuget.org/packages/Mapster/) as a mapping framework. Mapster offers automatic mapping between entities and DTOs with minimal configuration for basic mapping, while still allowing customized mapping when necessary. This eliminates the need for manual mapping, so the TenantDto.CreateFrom(tenant) method and its calls are removed.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
