### PR TITLE
Delete TenantDto.CreateFrom(tenant) method

### DIFF
--- a/account-management/src/Application/Tenants/Dtos/TenantDto.cs
+++ b/account-management/src/Application/Tenants/Dtos/TenantDto.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using PlatformPlatform.AccountManagement.Application.Tenants.Commands.CreateTenant;
 using PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
@@ -8,6 +9,7 @@ namespace PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 ///     A shared DTO for used both in <see cref="GetTenantByIdQuery" /> and <see cref="CreateTenantCommand" />.
 ///     This class is returned by the WebAPI, making it a public contract, so it should be changed with care.
 /// </summary>
+[UsedImplicitly]
 public sealed record TenantDto
 {
     /// <summary>
@@ -43,19 +45,5 @@ public sealed record TenantDto
     /// <summary>
     ///     The phone number of the tenant owner (optional).
     /// </summary>
-    public string? Phone { get; private set; }
-
-    public static TenantDto CreateFrom(Tenant tenant)
-    {
-        return new TenantDto
-        {
-            Id = tenant.Id.AsRawString()!,
-            CreatedAt = tenant.CreatedAt,
-            ModifiedAt = tenant.ModifiedAt,
-            Name = tenant.Name,
-            State = tenant.State,
-            Email = tenant.Email,
-            Phone = tenant.Phone
-        };
-    }
+    public string? Phone { get; init; }
 }


### PR DESCRIPTION
### Summary & Motivation

Remove the unused TenantDto.CreateFrom(tenant) method after introducing Mapster as the mapping framework.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
