### PR TITLE
Set up Domain events using MediatR

### DIFF
--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -68,7 +68,5 @@ jobs:
       with:
         solutionPath: account-management/AccountManagement.sln
         minimumSeverity: warning
-        # Add the ignore patterns for the specific warning
-        customArgs: '--properties:IgnorePatterns=SuggestBaseTypeForParameterInConstructor'
         # Ignore cases where property getters are not called directly (e.g., on DTOs that are serialized)
         ignoreIssueType: UnusedAutoPropertyAccessor.Global

--- a/account-management/src/Application/Application.csproj
+++ b/account-management/src/Application/Application.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1"/>
         <PackageReference Include="Mapster" Version="7.3.0"/>
         <PackageReference Include="MediatR" Version="12.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0"/>
     </ItemGroup>
 
 </Project>

--- a/account-management/src/Application/ApplicationConfiguration.cs
+++ b/account-management/src/Application/ApplicationConfiguration.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using PlatformPlatform.AccountManagement.Application.Shared.DomainEvents;
 using PlatformPlatform.AccountManagement.Application.Shared.Persistence;
 using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 
@@ -20,6 +21,7 @@ public static class ApplicationConfiguration
         services.AddMediatR(configuration => configuration.RegisterServicesFromAssemblies(Assembly));
 
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(UnitOfWorkPipelineBehavior<,>));
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(PublishDomainEventsPipelineBehavior<,>));
 
         services.AddValidatorsFromAssembly(Assembly);
 

--- a/account-management/src/Application/Shared/DomainEvents/PublishDomainEventsPipelineBehavior.cs
+++ b/account-management/src/Application/Shared/DomainEvents/PublishDomainEventsPipelineBehavior.cs
@@ -1,0 +1,67 @@
+using MediatR;
+using PlatformPlatform.AccountManagement.Domain.Shared;
+
+namespace PlatformPlatform.AccountManagement.Application.Shared.DomainEvents;
+
+/// <summary>
+///     This method publishes any domain events that were generated during the execution of a command (and added to
+///     aggregates). It's crucial to understand that domain event handlers are not supposed to produce any external side
+///     effects outside the current transaction/UnitOfWork. For instance, they can be utilized to create, update, or
+///     delete aggregates, or they could be used to update read models. However, they should not be used to invoke other
+///     services (e.g., send emails) that are not part of the same database transaction. For such tasks, use Integration
+///     Events instead.
+/// </summary>
+public sealed class PublishDomainEventsPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly IPublisher _publisher;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public PublishDomainEventsPipelineBehavior(IUnitOfWork unitOfWork, IPublisher publisher)
+    {
+        _unitOfWork = unitOfWork;
+        _publisher = publisher;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var response = await next();
+
+        var domainEvents = new Queue<IDomainEvent>();
+
+        EnqueueAndClearDomainEvents(domainEvents);
+
+        while (domainEvents.Any())
+        {
+            var domainEvent = domainEvents.Dequeue();
+
+            // Publish the domain event to the MediatR pipeline. Any registered event handlers will be invoked. These
+            // event handlers can then carry out any necessary actions, such as managing side effects, updating read
+            // models, and so forth.
+            await _publisher.Publish(domainEvent, cancellationToken);
+
+            // It is possible that a domain event handler creates a new domain event, so we need to check if there are
+            // any new domain events that need to be published and handled before continuing.
+            EnqueueAndClearDomainEvents(domainEvents);
+        }
+
+        return response;
+    }
+
+    /// <summary>
+    ///     Adds any new domain events to the processing queue and clears them from the originating aggregates.
+    /// </summary>
+    private void EnqueueAndClearDomainEvents(Queue<IDomainEvent> domainEvents)
+    {
+        foreach (var aggregate in _unitOfWork.GetAggregatesWithDomainEvents())
+        {
+            foreach (var domainEvent in aggregate.DomainEvents)
+            {
+                domainEvents.Enqueue(domainEvent);
+            }
+
+            aggregate.ClearDomainEvents();
+        }
+    }
+}

--- a/account-management/src/Application/Shared/Persistence/UnitOfWorkPipelineBehavior.cs
+++ b/account-management/src/Application/Shared/Persistence/UnitOfWorkPipelineBehavior.cs
@@ -5,8 +5,10 @@ namespace PlatformPlatform.AccountManagement.Application.Shared.Persistence;
 
 /// <summary>
 ///     The UnitOfWorkPipelineBehavior class is a MediatR pipeline behavior that encapsulates the unit of work pattern.
-///     It is called after the handling of a Command, and ensures that any changes are committed to the database only
-///     after the command is successfully handled. If an exception occurs the UnitOfWork.Commit will never be called.
+///     It is called after the handling of a Command and after handling all Domain Events. The pipeline ensures that all
+///     changes to all aggregates and entities are committed to the database only after the command and domain events
+///     are successfully handled. If an exception occurs the UnitOfWork.Commit will never be called, and all changes
+///     will be lost.
 /// </summary>
 public sealed class UnitOfWorkPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
     where TRequest : notnull

--- a/account-management/src/Application/Tenants/Commands/CreateTenant/TenantCreatedEventHandler.cs
+++ b/account-management/src/Application/Tenants/Commands/CreateTenant/TenantCreatedEventHandler.cs
@@ -1,0 +1,26 @@
+using JetBrains.Annotations;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using PlatformPlatform.AccountManagement.Domain.Tenants;
+
+namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands.CreateTenant;
+
+[UsedImplicitly]
+public sealed class TenantCreatedEventHandler : INotificationHandler<TenantCreatedEvent>
+{
+    private readonly ILogger<TenantCreatedEventHandler> _logger;
+    private readonly ITenantRepository _tenantRepository;
+
+    public TenantCreatedEventHandler(ILogger<TenantCreatedEventHandler> logger, ITenantRepository tenantRepository)
+    {
+        _logger = logger;
+        _tenantRepository = tenantRepository;
+    }
+
+    public async Task Handle(TenantCreatedEvent notification, CancellationToken cancellationToken)
+    {
+        var tenant = (await _tenantRepository.GetByIdAsync(notification.TenantId, cancellationToken))!;
+
+        _logger.LogInformation(@"Raise event to send Welcome mail to {TenantName}", tenant.Name);
+    }
+}

--- a/account-management/src/Domain/Domain.csproj
+++ b/account-management/src/Domain/Domain.csproj
@@ -17,6 +17,7 @@
     <ItemGroup>
         <PackageReference Include="IdGen" Version="3.0.3"/>
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1"/>
+        <PackageReference Include="MediatR" Version="12.0.1"/>
     </ItemGroup>
 
 </Project>

--- a/account-management/src/Domain/Shared/AggregateRoot.cs
+++ b/account-management/src/Domain/Shared/AggregateRoot.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace PlatformPlatform.AccountManagement.Domain.Shared;
 
 /// <summary>
@@ -11,4 +13,29 @@ namespace PlatformPlatform.AccountManagement.Domain.Shared;
 /// </summary>
 public interface IAggregateRoot : IAuditableEntity
 {
+    IReadOnlyList<IDomainEvent> DomainEvents { get; }
+
+    void ClearDomainEvents();
+}
+
+public abstract class AggregateRoot<T> : AudibleEntity<T>, IAggregateRoot where T : IComparable<T>
+{
+    private readonly List<IDomainEvent> _domainEvents = new();
+
+    protected AggregateRoot(T id) : base(id)
+    {
+    }
+
+    [NotMapped]
+    public IReadOnlyList<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    public void ClearDomainEvents()
+    {
+        _domainEvents.Clear();
+    }
+
+    protected void AddDomainEvent(IDomainEvent domainEvent)
+    {
+        _domainEvents.Add(domainEvent);
+    }
 }

--- a/account-management/src/Domain/Shared/IDomainEvent.cs
+++ b/account-management/src/Domain/Shared/IDomainEvent.cs
@@ -1,0 +1,21 @@
+using MediatR;
+
+namespace PlatformPlatform.AccountManagement.Domain.Shared;
+
+/// <summary>
+///     The DomainEvent interface represents a domain event that occurred in the domain. The DomainEvent implements the
+///     <see cref="INotification" /> interface from MediatR. To configure an event handler, you need to create a class
+///     that implements the <see cref="INotificationHandler{TNotification}" /> interface. This should be done in the
+///     Application Layer. Any event that occurs in the domain can be handled by one or more domain event handlers.
+///     Domain events are happening in the context of an aggregate. Events are published by the
+///     PublishDomainEventsPipelineBehavior in the Application Layer, before the UnitOfWork is committed and the parent
+///     aggregate that raises the event is saved to the database. That means that the EventHandler also runs before
+///     changes are saved to the database. It's crucial to understand that domain event handlers are not supposed to
+///     produce any external side effects outside the current transaction/UnitOfWork. For instance, they can be utilized
+///     to create, update, or delete aggregates, or they could be used to update read models. However, they should not
+///     be used to invoke other services (e.g., send emails) that are not part of the same database transaction. For
+///     such tasks, use Integration Events instead.
+/// </summary>
+public interface IDomainEvent : INotification
+{
+}

--- a/account-management/src/Domain/Shared/IUnitOfWork.cs
+++ b/account-management/src/Domain/Shared/IUnitOfWork.cs
@@ -11,4 +11,6 @@ namespace PlatformPlatform.AccountManagement.Domain.Shared;
 public interface IUnitOfWork
 {
     Task CommitAsync(CancellationToken cancellationToken);
+
+    IEnumerable<IAggregateRoot> GetAggregatesWithDomainEvents();
 }

--- a/account-management/src/Domain/Tenants/Tenant.cs
+++ b/account-management/src/Domain/Tenants/Tenant.cs
@@ -4,7 +4,7 @@ namespace PlatformPlatform.AccountManagement.Domain.Tenants;
 
 public sealed record TenantId(long Value) : StronglyTypedId<TenantId>(Value);
 
-public sealed class Tenant : AudibleEntity<TenantId>, IAggregateRoot
+public sealed class Tenant : AggregateRoot<TenantId>
 {
     internal Tenant() : base(TenantId.NewId())
     {

--- a/account-management/src/Domain/Tenants/Tenant.cs
+++ b/account-management/src/Domain/Tenants/Tenant.cs
@@ -27,6 +27,8 @@ public sealed class Tenant : AggregateRoot<TenantId>
 
         tenant.EnsureTenantInputHasBeenValidated();
 
+        tenant.AddDomainEvent(new TenantCreatedEvent(tenant.Id, tenant.Name));
+
         return tenant;
     }
 

--- a/account-management/src/Domain/Tenants/TenantCreatedEvent.cs
+++ b/account-management/src/Domain/Tenants/TenantCreatedEvent.cs
@@ -1,0 +1,7 @@
+using JetBrains.Annotations;
+using PlatformPlatform.AccountManagement.Domain.Shared;
+
+namespace PlatformPlatform.AccountManagement.Domain.Tenants;
+
+[UsedImplicitly]
+public sealed record TenantCreatedEvent(TenantId TenantId, string Name) : IDomainEvent;

--- a/account-management/src/Infrastructure/Shared/UnitOfWork.cs
+++ b/account-management/src/Infrastructure/Shared/UnitOfWork.cs
@@ -23,4 +23,12 @@ public class UnitOfWork : IUnitOfWork
     {
         await _applicationDbContext.SaveChangesAsync(cancellationToken);
     }
+
+    public IEnumerable<IAggregateRoot> GetAggregatesWithDomainEvents()
+    {
+        return _applicationDbContext.ChangeTracker
+            .Entries<IAggregateRoot>()
+            .Where(e => e.Entity.DomainEvents.Any())
+            .Select(e => e.Entity);
+    }
 }

--- a/account-management/src/Infrastructure/Shared/UnitOfWork.cs
+++ b/account-management/src/Infrastructure/Shared/UnitOfWork.cs
@@ -21,6 +21,11 @@ public class UnitOfWork : IUnitOfWork
 
     public async Task CommitAsync(CancellationToken cancellationToken)
     {
+        if (GetAggregatesWithDomainEvents().Any())
+        {
+            throw new InvalidOperationException("Domain events must be handled before committing the UnitOfWork.");
+        }
+
         await _applicationDbContext.SaveChangesAsync(cancellationToken);
     }
 

--- a/account-management/tests/Tests/Application/Shared/DomainEvents/PublishDomainEventsPipelineBehaviorTests.cs
+++ b/account-management/tests/Tests/Application/Shared/DomainEvents/PublishDomainEventsPipelineBehaviorTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using MediatR;
+using NSubstitute;
+using PlatformPlatform.AccountManagement.Application.Shared.DomainEvents;
+using PlatformPlatform.AccountManagement.Domain.Shared;
+using PlatformPlatform.AccountManagement.Tests.Application.Shared.Persistence;
+using PlatformPlatform.AccountManagement.Tests.Domain.Shared;
+using Xunit;
+
+namespace PlatformPlatform.AccountManagement.Tests.Application.Shared.DomainEvents;
+
+public class PublishDomainEventsPipelineBehaviorTests
+{
+    [Fact]
+    public async Task Handle_WhenCalled_ShouldPublishDomainEvents()
+    {
+        // Arrange
+        var unitOfWork = Substitute.For<IUnitOfWork>();
+        var publisher = Substitute.For<IPublisher>();
+        var behavior = new PublishDomainEventsPipelineBehavior<TestCommand, Task>(unitOfWork, publisher);
+        var request = new TestCommand();
+        var cancellationToken = new CancellationToken();
+        var next = Substitute.For<RequestHandlerDelegate<Task>>();
+        next.Invoke().Returns(Task.CompletedTask);
+
+        var testAggregate = TestAggregate.Create("test");
+        var domainEvent = testAggregate.DomainEvents.Single(); // Get the domain events that were created.
+        unitOfWork.GetAggregatesWithDomainEvents().Returns(new[] {testAggregate});
+
+        // Act
+        await behavior.Handle(request, next, cancellationToken);
+
+        // Assert
+        await publisher.Received(1).Publish(domainEvent, cancellationToken);
+        testAggregate.DomainEvents.Should().BeEmpty();
+    }
+}

--- a/account-management/tests/Tests/Application/Shared/Persistence/UnitOfWorkPipelineBehaviorTests.cs
+++ b/account-management/tests/Tests/Application/Shared/Persistence/UnitOfWorkPipelineBehaviorTests.cs
@@ -1,0 +1,35 @@
+using MediatR;
+using NSubstitute;
+using PlatformPlatform.AccountManagement.Application.Shared.Persistence;
+using PlatformPlatform.AccountManagement.Domain.Shared;
+using Xunit;
+
+namespace PlatformPlatform.AccountManagement.Tests.Application.Shared.Persistence;
+
+public class UnitOfWorkPipelineBehaviorTests
+{
+    [Fact]
+    public async Task Handle_WhenCalled_ShouldCallNextAndCommitChanges()
+    {
+        // Arrange
+        var unitOfWork = Substitute.For<IUnitOfWork>();
+        var behavior = new UnitOfWorkPipelineBehavior<TestCommand, Task>(unitOfWork);
+        var request = new TestCommand();
+        var cancellationToken = new CancellationToken();
+        var next = Substitute.For<RequestHandlerDelegate<Task>>();
+        next.Invoke().Returns(Task.CompletedTask);
+
+        // Act
+        await behavior.Handle(request, next, cancellationToken);
+
+        // Assert
+        await unitOfWork.Received().CommitAsync(cancellationToken);
+        Received.InOrder(() =>
+        {
+            next.Invoke();
+            unitOfWork.CommitAsync(cancellationToken);
+        });
+    }
+}
+
+public record TestCommand : IRequest;

--- a/account-management/tests/Tests/Application/Tenants/Commands/CreateTenant/CreateTenantCommandHandlerTests.cs
+++ b/account-management/tests/Tests/Application/Tenants/Commands/CreateTenant/CreateTenantCommandHandlerTests.cs
@@ -43,7 +43,7 @@ public class CreateTenantCommandHandlerTests
     }
 
     [Fact]
-    public async Task CreateTenantCommandHandler__WhenCommandIsValid_ShouldReturnTenantDtoWithCorrectValues()
+    public async Task CreateTenantCommandHandler_WhenCommandIsValid_ShouldReturnTenantDtoWithCorrectValues()
     {
         // Arrange
         _tenantRepository.IsSubdomainFreeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -60,6 +60,22 @@ public class CreateTenantCommandHandlerTests
         tenantResponseDto.Name.Should().Be(command.Name);
         tenantResponseDto.Email.Should().Be(command.Email);
         tenantResponseDto.Phone.Should().Be(command.Phone);
+    }
+
+    [Fact]
+    public async Task CreateTenantCommandHandler_WhenCommandIsValid_ShouldRaiseTenantCreatedEvent()
+    {
+        // Arrange
+        _tenantRepository.IsSubdomainFreeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        var handler = new CreateTenantCommandHandler(_tenantRepository);
+
+        // Act
+        var command = new CreateTenantCommand("TestTenant", "tenant1", "foo@tenant1.com", "1234567890");
+        var _ = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await _tenantRepository.Received().AddAsync(Arg.Is<Tenant>(t => t.DomainEvents.Single() is TenantCreatedEvent),
+            Arg.Any<CancellationToken>());
     }
 
     [Theory]

--- a/account-management/tests/Tests/Domain/Shared/DomainEventTests.cs
+++ b/account-management/tests/Tests/Domain/Shared/DomainEventTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using JetBrains.Annotations;
+using PlatformPlatform.AccountManagement.Domain.Shared;
+using Xunit;
+
+namespace PlatformPlatform.AccountManagement.Tests.Domain.Shared;
+
+public class DomainEventTests
+{
+    [Fact]
+    public void DomainEvent_WhenCreatingDomainEvents_ShouldTrackEventWithCorrectOccurrence()
+    {
+        // Act
+        var testAggregate = TestAggregate.Create("test");
+
+        // Assert
+        testAggregate.DomainEvents.Count.Should().Be(1);
+        var domainEvent = (TestAggregateCreatedEvent) testAggregate.DomainEvents.Single();
+        domainEvent.TestAggregateId.Should().Be(testAggregate.Id);
+        domainEvent.Name.Should().Be("test");
+    }
+}
+
+public record TestAggregateCreatedEvent(long TestAggregateId, string Name) : IDomainEvent;
+
+public sealed class TestAggregate : AggregateRoot<long>
+{
+    private TestAggregate(string name) : base(IdGenerator.NewId())
+    {
+        Name = name;
+    }
+
+    [UsedImplicitly]
+    public string Name { get; }
+
+    public static TestAggregate Create(string name)
+    {
+        var testAggregate = new TestAggregate(name);
+        var testAggregateCreatedEvent = new TestAggregateCreatedEvent(testAggregate.Id, testAggregate.Name);
+        testAggregate.AddDomainEvent(testAggregateCreatedEvent);
+        return testAggregate;
+    }
+}


### PR DESCRIPTION
### Summary & Motivation

Implement DomainEvents on Aggregate Roots. Ensure these events are dispatched (by the PublishDomainEventsPipelineBehavior) and handled before the UnitOfWork is committed (within the UnitOfWorkPipelineBehavior).

Introduce a new AggregateRoot class, in addition to the existing IAggregateRoot, that holds domain events.

Implement a new TenantCreateEvent, leveraging the new DomainEvent foundation.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
