### PR TITLE
Add update and delete tenant endpoints

### DIFF
--- a/account-management/src/Application/Tenants/Commands/CreateTenant/CreateTenantCommand.cs
+++ b/account-management/src/Application/Tenants/Commands/CreateTenant/CreateTenantCommand.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Mapster;
 using MediatR;
 using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
@@ -37,7 +38,7 @@ public sealed class CreateTenantCommandHandler : IRequestHandler<CreateTenantCom
 
         if (propertyErrors.Any())
         {
-            return CommandResult<TenantDto>.Failure(propertyErrors);
+            return CommandResult<TenantDto>.Failure(propertyErrors, HttpStatusCode.BadRequest);
         }
 
         var tenant = Tenant.Create(command.Name, command.Subdomain, command.Email, command.Phone);

--- a/account-management/src/Application/Tenants/Commands/DeleteTenant/DeleteTenantCommand.cs
+++ b/account-management/src/Application/Tenants/Commands/DeleteTenant/DeleteTenantCommand.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using JetBrains.Annotations;
 using MediatR;
 using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
@@ -10,7 +9,6 @@ namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands.Delete
 
 public sealed record DeleteTenantCommand(TenantId Id) : IRequest<CommandResult<TenantDto>>;
 
-[UsedImplicitly]
 public sealed class DeleteTenantCommandHandler : IRequestHandler<DeleteTenantCommand, CommandResult<TenantDto>>
 {
     private readonly ITenantRepository _tenantRepository;

--- a/account-management/src/Application/Tenants/Commands/DeleteTenant/DeleteTenantCommand.cs
+++ b/account-management/src/Application/Tenants/Commands/DeleteTenant/DeleteTenantCommand.cs
@@ -1,0 +1,34 @@
+using JetBrains.Annotations;
+using MediatR;
+using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
+using PlatformPlatform.AccountManagement.Domain.Tenants;
+using PlatformPlatform.Foundation.Application;
+using PlatformPlatform.Foundation.Domain;
+
+namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands.DeleteTenant;
+
+public sealed record DeleteTenantCommand(TenantId Id) : IRequest<CommandResult<TenantDto>>;
+
+[UsedImplicitly]
+public sealed class DeleteTenantCommandHandler : IRequestHandler<DeleteTenantCommand, CommandResult<TenantDto>>
+{
+    private readonly ITenantRepository _tenantRepository;
+
+    public DeleteTenantCommandHandler(ITenantRepository tenantRepository)
+    {
+        _tenantRepository = tenantRepository;
+    }
+
+    public async Task<CommandResult<TenantDto>> Handle(DeleteTenantCommand command, CancellationToken cancellationToken)
+    {
+        var tenant = await _tenantRepository.GetByIdAsync(command.Id, cancellationToken);
+        if (tenant is null)
+        {
+            return CommandResult<TenantDto>.Failure(new[] {new PropertyError("TenantId", "Tenant not found.")});
+        }
+
+        _tenantRepository.Remove(tenant);
+
+        return CommandResult<TenantDto>.Success(null);
+    }
+}

--- a/account-management/src/Application/Tenants/Commands/DeleteTenant/DeleteTenantCommand.cs
+++ b/account-management/src/Application/Tenants/Commands/DeleteTenant/DeleteTenantCommand.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using JetBrains.Annotations;
 using MediatR;
 using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
@@ -24,7 +25,8 @@ public sealed class DeleteTenantCommandHandler : IRequestHandler<DeleteTenantCom
         var tenant = await _tenantRepository.GetByIdAsync(command.Id, cancellationToken);
         if (tenant is null)
         {
-            return CommandResult<TenantDto>.Failure(new[] {new PropertyError("TenantId", "Tenant not found.")});
+            return CommandResult<TenantDto>.Failure(new[] {new PropertyError("TenantId", "Tenant not found.")},
+                HttpStatusCode.NotFound);
         }
 
         _tenantRepository.Remove(tenant);

--- a/account-management/src/Application/Tenants/Commands/UpdateTenant/UpdateTenantCommand.cs
+++ b/account-management/src/Application/Tenants/Commands/UpdateTenant/UpdateTenantCommand.cs
@@ -1,0 +1,48 @@
+using JetBrains.Annotations;
+using Mapster;
+using MediatR;
+using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
+using PlatformPlatform.AccountManagement.Domain.Tenants;
+using PlatformPlatform.Foundation.Application;
+using PlatformPlatform.Foundation.Domain;
+
+namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands.UpdateTenant;
+
+public sealed record UpdateTenantCommand(TenantId TenantId, string Name, string Email, string? Phone)
+    : IRequest<CommandResult<TenantDto>>;
+
+[UsedImplicitly]
+public sealed class UpdateTenantCommandHandler : IRequestHandler<UpdateTenantCommand, CommandResult<TenantDto>>
+{
+    private readonly ITenantRepository _tenantRepository;
+
+    public UpdateTenantCommandHandler(ITenantRepository tenantRepository)
+    {
+        _tenantRepository = tenantRepository;
+    }
+
+    public async Task<CommandResult<TenantDto>> Handle(UpdateTenantCommand command, CancellationToken cancellationToken)
+    {
+        var tenant = await _tenantRepository.GetByIdAsync(command.TenantId, cancellationToken);
+        if (tenant is null)
+        {
+            return CommandResult<TenantDto>.Failure(new[] {new PropertyError("TenantId", "Tenant not found.")});
+        }
+
+        var propertyErrors = TenantValidation.ValidateName(command.Name).Errors
+            .Concat(TenantValidation.ValidateEmail(command.Email).Errors)
+            .Concat(TenantValidation.ValidatePhone(command.Phone).Errors)
+            .ToArray();
+
+        if (propertyErrors.Any())
+        {
+            return CommandResult<TenantDto>.Failure(propertyErrors);
+        }
+
+        tenant.Update(command.Name, command.Email, command.Phone);
+
+        _tenantRepository.Update(tenant);
+
+        return tenant.Adapt<TenantDto>();
+    }
+}

--- a/account-management/src/Application/Tenants/Commands/UpdateTenant/UpdateTenantCommand.cs
+++ b/account-management/src/Application/Tenants/Commands/UpdateTenant/UpdateTenantCommand.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using JetBrains.Annotations;
 using Mapster;
 using MediatR;
 using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
@@ -12,7 +11,6 @@ namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands.Update
 public sealed record UpdateTenantCommand(TenantId TenantId, string Name, string Email, string? Phone)
     : IRequest<CommandResult<TenantDto>>;
 
-[UsedImplicitly]
 public sealed class UpdateTenantCommandHandler : IRequestHandler<UpdateTenantCommand, CommandResult<TenantDto>>
 {
     private readonly ITenantRepository _tenantRepository;

--- a/account-management/src/Domain/Tenants/Tenant.cs
+++ b/account-management/src/Domain/Tenants/Tenant.cs
@@ -6,24 +6,27 @@ public sealed record TenantId(long Value) : StronglyTypedId<TenantId>(Value);
 
 public sealed class Tenant : AggregateRoot<TenantId>
 {
-    internal Tenant() : base(TenantId.NewId())
+    internal Tenant(string name, string email, string? phone) : base(TenantId.NewId())
     {
+        Name = name;
+        Email = email;
+        Phone = phone;
         State = TenantState.Trial;
     }
 
-    public required string Name { get; set; }
+    public string Name { get; private set; }
 
-    public required string Subdomain { get; set; }
+    public required string Subdomain { get; init; }
 
     public TenantState State { get; private set; }
 
-    public required string Email { get; set; }
+    public string Email { get; private set; }
 
-    public string? Phone { get; set; }
+    public string? Phone { get; private set; }
 
     public static Tenant Create(string tenantName, string subdomain, string email, string? phone)
     {
-        var tenant = new Tenant {Name = tenantName, Subdomain = subdomain, Email = email, Phone = phone};
+        var tenant = new Tenant(tenantName, email, phone) {Subdomain = subdomain};
 
         tenant.EnsureTenantInputHasBeenValidated();
 
@@ -43,5 +46,14 @@ public sealed class Tenant : AggregateRoot<TenantId>
         if (allErrors.Length == 0) return;
 
         throw new InvalidOperationException("Ensure that there is logic in place to never create an invalid tenant.");
+    }
+
+    public void Update(string tenantName, string email, string? phone)
+    {
+        Name = tenantName;
+        Email = email;
+        Phone = phone;
+
+        EnsureTenantInputHasBeenValidated();
     }
 }

--- a/account-management/src/Foundation/Application/CommandResult.cs
+++ b/account-management/src/Foundation/Application/CommandResult.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using JetBrains.Annotations;
 using PlatformPlatform.Foundation.Domain;
 
@@ -10,25 +11,28 @@ namespace PlatformPlatform.Foundation.Application;
 /// </summary>
 public sealed class CommandResult<T>
 {
-    private CommandResult(bool isSuccess, T? value, PropertyError[] errors)
+    private CommandResult(bool isSuccess, T? value, PropertyError[] errors, HttpStatusCode statusCode)
     {
         IsSuccess = isSuccess;
         Value = value;
         Errors = errors;
+        StatusCode = statusCode;
     }
 
     public bool IsSuccess { get; }
 
     public T? Value { get; private set; }
 
+    public HttpStatusCode StatusCode { get; private set; }
+
     public PropertyError[] Errors { get; }
 
     /// <summary>
     ///     Use this to indicate a failed command, with a collection of <see cref="PropertyError" />.
     /// </summary>
-    public static CommandResult<T> Failure(PropertyError[] errors)
+    public static CommandResult<T> Failure(PropertyError[] errors, HttpStatusCode statusCode)
     {
-        return new CommandResult<T>(false, default!, errors);
+        return new CommandResult<T>(false, default!, errors, statusCode);
     }
 
     /// <summary>
@@ -36,9 +40,9 @@ public sealed class CommandResult<T>
     ///     <see cref="CommandResult{T}" />, so you can also just return T from a Command handler.
     /// </summary>
     [UsedImplicitly]
-    public static CommandResult<T> Success(T? value)
+    public static CommandResult<T> Success(T? value, HttpStatusCode statusCode = HttpStatusCode.OK)
     {
-        return new CommandResult<T>(true, value, Array.Empty<PropertyError>());
+        return new CommandResult<T>(true, value, Array.Empty<PropertyError>(), statusCode);
     }
 
     /// <summary>

--- a/account-management/src/Foundation/Application/CommandResult.cs
+++ b/account-management/src/Foundation/Application/CommandResult.cs
@@ -10,7 +10,7 @@ namespace PlatformPlatform.Foundation.Application;
 /// </summary>
 public sealed class CommandResult<T>
 {
-    private CommandResult(bool isSuccess, T value, PropertyError[] errors)
+    private CommandResult(bool isSuccess, T? value, PropertyError[] errors)
     {
         IsSuccess = isSuccess;
         Value = value;
@@ -19,7 +19,7 @@ public sealed class CommandResult<T>
 
     public bool IsSuccess { get; }
 
-    public T Value { get; private set; }
+    public T? Value { get; private set; }
 
     public PropertyError[] Errors { get; }
 
@@ -36,7 +36,7 @@ public sealed class CommandResult<T>
     ///     <see cref="CommandResult{T}" />, so you can also just return T from a Command handler.
     /// </summary>
     [UsedImplicitly]
-    public static CommandResult<T> Success(T value)
+    public static CommandResult<T> Success(T? value)
     {
         return new CommandResult<T>(true, value, Array.Empty<PropertyError>());
     }

--- a/account-management/src/Foundation/Foundation.csproj
+++ b/account-management/src/Foundation/Foundation.csproj
@@ -9,6 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="IdGen" Version="3.0.3"/>
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1"/>
         <PackageReference Include="MediatR" Version="12.0.1"/>

--- a/account-management/src/Foundation/WebApi/CommandResultExtensions.cs
+++ b/account-management/src/Foundation/WebApi/CommandResultExtensions.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Http;
+using PlatformPlatform.Foundation.Application;
+
+namespace PlatformPlatform.Foundation.WebApi;
+
+public static class CommandResultExtensions
+{
+    public static IResult AsHttpResult<T>(this CommandResult<T> result)
+    {
+        return Results.Json(result.IsSuccess ? result.Value : result.Errors, statusCode: (int) result.StatusCode);
+    }
+
+    public static IResult AsHttpResult<T>(this CommandResult<T> result, string uri)
+    {
+        return result.IsSuccess
+            ? Results.Created(uri, result.Value)
+            : Results.Json(result.Errors, statusCode: (int) result.StatusCode);
+    }
+}

--- a/account-management/src/WebApi/Endpoints/TenantEndpoints.cs
+++ b/account-management/src/WebApi/Endpoints/TenantEndpoints.cs
@@ -4,6 +4,7 @@ using PlatformPlatform.AccountManagement.Application.Tenants.Commands.DeleteTena
 using PlatformPlatform.AccountManagement.Application.Tenants.Commands.UpdateTenant;
 using PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
+using PlatformPlatform.Foundation.WebApi;
 
 namespace PlatformPlatform.AccountManagement.WebApi.Endpoints;
 
@@ -29,26 +30,19 @@ public static class TenantEndpoints
     private static async Task<IResult> CreateTenant(CreateTenantCommand command, ISender sender)
     {
         var result = await sender.Send(command);
-        return result.IsSuccess
-            ? Results.Created($"/tenants/{result.Value!.Id}", result.Value)
-            : Results.BadRequest(result.Errors);
+        return result.AsHttpResult($"/tenants/{result.Value?.Id}");
     }
 
     private static async Task<IResult> UpdateTenant(string id, UpdateTenantRequest request, ISender sender)
     {
         var command = new UpdateTenantCommand(TenantId.FromString(id), request.Name, request.Email, request.Phone);
-        var result = await sender.Send(command);
-        return result.IsSuccess
-            ? Results.Ok(result.Value)
-            : Results.BadRequest(result.Errors);
+        return (await sender.Send(command)).AsHttpResult();
     }
 
     private static async Task<IResult> DeleteTenant(string id, ISender sender)
     {
-        var result = await sender.Send(new DeleteTenantCommand(TenantId.FromString(id)));
-        return result.IsSuccess
-            ? Results.Ok(result.Value)
-            : Results.BadRequest(result.Errors);
+        var command = new DeleteTenantCommand(TenantId.FromString(id));
+        return (await sender.Send(command)).AsHttpResult();
     }
 }
 

--- a/account-management/src/WebApi/Endpoints/TenantEndpoints.cs
+++ b/account-management/src/WebApi/Endpoints/TenantEndpoints.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using PlatformPlatform.AccountManagement.Application.Tenants.Commands.CreateTenant;
 using PlatformPlatform.AccountManagement.Application.Tenants.Commands.DeleteTenant;
+using PlatformPlatform.AccountManagement.Application.Tenants.Commands.UpdateTenant;
 using PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 
@@ -13,6 +14,7 @@ public static class TenantEndpoints
         var group = routes.MapGroup("/tenants");
         group.MapGet("/{id}", GetTenant);
         group.MapPost("/", CreateTenant);
+        group.MapPut("/{id}", UpdateTenant);
         group.MapDelete("/{id}", DeleteTenant);
     }
 
@@ -32,6 +34,15 @@ public static class TenantEndpoints
             : Results.BadRequest(createTenantCommandResult.Errors);
     }
 
+    private static async Task<IResult> UpdateTenant(string id, UpdateTenantRequest request, ISender sender)
+    {
+        var command = new UpdateTenantCommand(TenantId.FromString(id), request.Name, request.Email, request.Phone);
+        var result = await sender.Send(command);
+        return result.IsSuccess
+            ? Results.Ok(result.Value)
+            : Results.BadRequest(result.Errors);
+    }
+
     private static async Task<IResult> DeleteTenant(string id, ISender sender)
     {
         var result = await sender.Send(new DeleteTenantCommand(TenantId.FromString(id)));
@@ -40,3 +51,5 @@ public static class TenantEndpoints
             : Results.BadRequest(result.Errors);
     }
 }
+
+public sealed record UpdateTenantRequest(string Name, string Email, string? Phone);

--- a/account-management/src/WebApi/Endpoints/TenantEndpoints.cs
+++ b/account-management/src/WebApi/Endpoints/TenantEndpoints.cs
@@ -20,18 +20,18 @@ public static class TenantEndpoints
 
     private static async Task<IResult> GetTenant(string id, ISender sender)
     {
-        var getTenantByIdQueryResult = await sender.Send(new GetTenantByIdQuery(TenantId.FromString(id)));
-        return getTenantByIdQueryResult.IsSuccess
-            ? Results.Ok(getTenantByIdQueryResult.Value)
-            : Results.NotFound(getTenantByIdQueryResult.Error);
+        var result = await sender.Send(new GetTenantByIdQuery(TenantId.FromString(id)));
+        return result.IsSuccess
+            ? Results.Ok(result.Value)
+            : Results.NotFound(result.Error);
     }
 
-    private static async Task<IResult> CreateTenant(CreateTenantCommand createTenantCommand, ISender sender)
+    private static async Task<IResult> CreateTenant(CreateTenantCommand command, ISender sender)
     {
-        var createTenantCommandResult = await sender.Send(createTenantCommand);
-        return createTenantCommandResult.IsSuccess
-            ? Results.Created($"/tenants/{createTenantCommandResult.Value.Id}", createTenantCommandResult.Value)
-            : Results.BadRequest(createTenantCommandResult.Errors);
+        var result = await sender.Send(command);
+        return result.IsSuccess
+            ? Results.Created($"/tenants/{result.Value!.Id}", result.Value)
+            : Results.BadRequest(result.Errors);
     }
 
     private static async Task<IResult> UpdateTenant(string id, UpdateTenantRequest request, ISender sender)

--- a/account-management/src/WebApi/Endpoints/TenantEndpoints.cs
+++ b/account-management/src/WebApi/Endpoints/TenantEndpoints.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using PlatformPlatform.AccountManagement.Application.Tenants.Commands.CreateTenant;
+using PlatformPlatform.AccountManagement.Application.Tenants.Commands.DeleteTenant;
 using PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 
@@ -12,6 +13,7 @@ public static class TenantEndpoints
         var group = routes.MapGroup("/tenants");
         group.MapGet("/{id}", GetTenant);
         group.MapPost("/", CreateTenant);
+        group.MapDelete("/{id}", DeleteTenant);
     }
 
     private static async Task<IResult> GetTenant(string id, ISender sender)
@@ -28,5 +30,13 @@ public static class TenantEndpoints
         return createTenantCommandResult.IsSuccess
             ? Results.Created($"/tenants/{createTenantCommandResult.Value.Id}", createTenantCommandResult.Value)
             : Results.BadRequest(createTenantCommandResult.Errors);
+    }
+
+    private static async Task<IResult> DeleteTenant(string id, ISender sender)
+    {
+        var result = await sender.Send(new DeleteTenantCommand(TenantId.FromString(id)));
+        return result.IsSuccess
+            ? Results.Ok(result.Value)
+            : Results.BadRequest(result.Errors);
     }
 }

--- a/account-management/tests/Tests/Application/Tenants/Commands/CreateTenant/CreateTenantCommandHandlerTests.cs
+++ b/account-management/tests/Tests/Application/Tenants/Commands/CreateTenant/CreateTenantCommandHandlerTests.cs
@@ -35,7 +35,7 @@ public class CreateTenantCommandHandlerTests
 
         // Assert
         createTenantCommandResult.IsSuccess.Should().BeTrue();
-        var tenantResponseDto = createTenantCommandResult.Value;
+        var tenantResponseDto = createTenantCommandResult.Value!;
         var tenantId = TenantId.FromString(tenantResponseDto.Id);
         _tenantRepository.Received()
             .Add(Arg.Is<Tenant>(t => t.Name == command.Name && t.Id > startId && t.Id == tenantId));
@@ -55,7 +55,7 @@ public class CreateTenantCommandHandlerTests
 
         // Assert
         createTenantCommandResult.IsSuccess.Should().BeTrue();
-        var tenantResponseDto = createTenantCommandResult.Value;
+        var tenantResponseDto = createTenantCommandResult.Value!;
         tenantResponseDto.Name.Should().Be(command.Name);
         tenantResponseDto.Email.Should().Be(command.Email);
         tenantResponseDto.Phone.Should().Be(command.Phone);

--- a/account-management/tests/Tests/Application/Tenants/Commands/DeleteTenant/DeleteTenantCommandHandlerTests.cs
+++ b/account-management/tests/Tests/Application/Tenants/Commands/DeleteTenant/DeleteTenantCommandHandlerTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using PlatformPlatform.AccountManagement.Application;
+using PlatformPlatform.AccountManagement.Application.Tenants.Commands.DeleteTenant;
+using PlatformPlatform.AccountManagement.Domain.Tenants;
+using Xunit;
+
+namespace PlatformPlatform.AccountManagement.Tests.Application.Tenants.Commands.DeleteTenant;
+
+public class DeleteTenantCommandHandlerTests
+{
+    private readonly ITenantRepository _tenantRepository;
+
+    public DeleteTenantCommandHandlerTests()
+    {
+        var services = new ServiceCollection();
+        services.AddApplicationServices();
+
+        _tenantRepository = Substitute.For<ITenantRepository>();
+    }
+
+    [Fact]
+    public async Task DeleteTenantCommandHandler_WhenTenantExists_ShouldDeleteTenantFromRepository()
+    {
+        // Arrange
+        var existingTenant = Tenant.Create("ExistingTenant", "tenant1", "foo@tenant1.com", "1234567890");
+        var existingTenantId = existingTenant.Id;
+        _tenantRepository.GetByIdAsync(existingTenantId, Arg.Any<CancellationToken>()).Returns(existingTenant);
+        var handler = new DeleteTenantCommandHandler(_tenantRepository);
+
+        // Act
+        var command = new DeleteTenantCommand(existingTenantId);
+        var deleteTenantCommandResult = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        deleteTenantCommandResult.IsSuccess.Should().BeTrue();
+        _tenantRepository.Received().Remove(existingTenant);
+    }
+
+    [Fact]
+    public async Task DeleteTenantCommandHandler_WhenTenantDoesNotExist_ShouldReturnFailure()
+    {
+        // Arrange
+        var nonExistingTenantId = TenantId.NewId();
+        _tenantRepository.GetByIdAsync(nonExistingTenantId, Arg.Any<CancellationToken>()).Returns(null as Tenant);
+        var handler = new DeleteTenantCommandHandler(_tenantRepository);
+
+        // Act
+        var command = new DeleteTenantCommand(nonExistingTenantId);
+        var deleteTenantCommandResult = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        deleteTenantCommandResult.IsSuccess.Should().BeFalse();
+    }
+}

--- a/account-management/tests/Tests/Application/Tenants/Commands/UpdateTenant/UpdateTenantCommandHandlerTests.cs
+++ b/account-management/tests/Tests/Application/Tenants/Commands/UpdateTenant/UpdateTenantCommandHandlerTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using PlatformPlatform.AccountManagement.Application;
+using PlatformPlatform.AccountManagement.Application.Tenants.Commands.UpdateTenant;
+using PlatformPlatform.AccountManagement.Domain.Tenants;
+using Xunit;
+
+namespace PlatformPlatform.AccountManagement.Tests.Application.Tenants.Commands.UpdateTenant;
+
+public class UpdateTenantCommandHandlerTests
+{
+    private readonly ITenantRepository _tenantRepository;
+
+    public UpdateTenantCommandHandlerTests()
+    {
+        var services = new ServiceCollection();
+        services.AddApplicationServices();
+
+        _tenantRepository = Substitute.For<ITenantRepository>();
+    }
+
+    [Fact]
+    public async Task UpdateTenantCommandHandler_WhenCommandIsValid_ShouldUpdateTenantInRepository()
+    {
+        // Arrange
+        var existingTenant = Tenant.Create("ExistingTenant", "tenant1", "foo@tenant1.com", "1234567890");
+        var existingTenantId = existingTenant.Id;
+        _tenantRepository.GetByIdAsync(existingTenantId, Arg.Any<CancellationToken>()).Returns(existingTenant);
+        var handler = new UpdateTenantCommandHandler(_tenantRepository);
+
+        // Act
+        var command = new UpdateTenantCommand(existingTenantId, "UpdatedTenant", "bar@tenant1.com", "0987654321");
+        var updateTenantCommandResult = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        updateTenantCommandResult.IsSuccess.Should().BeTrue();
+        var updatedTenant = updateTenantCommandResult.Value!;
+        updatedTenant.Name.Should().Be(command.Name);
+        updatedTenant.Email.Should().Be(command.Email);
+        updatedTenant.Phone.Should().Be(command.Phone);
+    }
+
+    [Fact]
+    public async Task UpdateTenantCommandHandler_WhenTenantDoesNotExist_ShouldReturnFailure()
+    {
+        // Arrange
+        var nonExistingTenantId = TenantId.NewId();
+        _tenantRepository.GetByIdAsync(nonExistingTenantId, Arg.Any<CancellationToken>()).Returns(null as Tenant);
+        var handler = new UpdateTenantCommandHandler(_tenantRepository);
+
+        // Act
+        var command = new UpdateTenantCommand(nonExistingTenantId, "UpdatedTenant", "bar@tenant1.com", "0987654321");
+        var updateTenantCommandResult = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        updateTenantCommandResult.IsSuccess.Should().BeFalse();
+    }
+}

--- a/account-management/tests/Tests/Application/Tenants/Queries/GetTenantByIdQueryTests.cs
+++ b/account-management/tests/Tests/Application/Tenants/Queries/GetTenantByIdQueryTests.cs
@@ -23,13 +23,10 @@ public class GetTenantByIdQueryTests
         var expectedTenantId = TenantId.NewId();
         const string expectedTenantName = "TestTenant";
 
-        var tenant = new Tenant
+        var tenant = new Tenant(expectedTenantName, "foo@tenant1.com", "1234567890")
         {
             Id = expectedTenantId,
-            Name = expectedTenantName,
-            Subdomain = "tenant1",
-            Email = "foo@tenant1.com",
-            Phone = "1234567890"
+            Subdomain = "tenant1"
         };
         var tenantRepository = Substitute.For<ITenantRepository>();
         tenantRepository.GetByIdAsync(expectedTenantId, default).Returns(tenant);

--- a/account-management/tests/Tests/DatabaseSeeder.cs
+++ b/account-management/tests/Tests/DatabaseSeeder.cs
@@ -8,28 +8,24 @@ public class DatabaseSeeder
     public const string Tenant1Name = "Tenant 1";
     public static readonly TenantId Tenant1Id = TenantId.NewId();
 
-    private static readonly object Lock = new();
-    private static bool _databaseIsSeeded;
-
     private readonly ApplicationDbContext _applicationDbContext;
+    private bool _databaseIsSeeded;
 
     public DatabaseSeeder(ApplicationDbContext applicationDbContext)
     {
         _applicationDbContext = applicationDbContext;
+        Seed();
     }
 
     public void Seed()
     {
-        lock (Lock)
-        {
-            if (_databaseIsSeeded) return;
+        if (_databaseIsSeeded) return;
 
-            SeedTenants();
+        SeedTenants();
 
-            _applicationDbContext.SaveChanges();
+        _applicationDbContext.SaveChanges();
 
-            _databaseIsSeeded = true;
-        }
+        _databaseIsSeeded = true;
     }
 
     private void SeedTenants()

--- a/account-management/tests/Tests/DatabaseSeeder.cs
+++ b/account-management/tests/Tests/DatabaseSeeder.cs
@@ -34,9 +34,9 @@ public class DatabaseSeeder
 
     private void SeedTenants()
     {
-        var tenant1 = new Tenant
+        var tenant1 = new Tenant(Tenant1Name, "foo@tenant1.com", "1234567890")
         {
-            Id = Tenant1Id, Name = Tenant1Name, Subdomain = "tenant1", Email = "foo@tenant1.com", Phone = "1234567890"
+            Id = Tenant1Id, Subdomain = "tenant1"
         };
 
         _applicationDbContext.Tenants.AddRange(tenant1);

--- a/account-management/tests/Tests/Infrastructure/Tenants/TenantRepositoryTests.cs
+++ b/account-management/tests/Tests/Infrastructure/Tenants/TenantRepositoryTests.cs
@@ -29,12 +29,9 @@ public sealed class TenantRepositoryTests : IDisposable
     public async Task Add_WhenTenantDoesNotExist_ShouldAddTenantToDatabase()
     {
         // Arrange
-        var tenant = new Tenant
+        var tenant = new Tenant("New Tenant", "new@test.com", "1234567890")
         {
-            Name = "New Tenant",
-            Subdomain = "new",
-            Email = "new@test.com",
-            Phone = "1234567890"
+            Subdomain = "new"
         };
 
         // Act
@@ -51,18 +48,15 @@ public sealed class TenantRepositoryTests : IDisposable
     public async Task Update_WhenTenantExists_ShouldUpdateTenantInDatabase()
     {
         // Arrange
-        var tenant = new Tenant
+        var tenant = new Tenant("Existing Tenant", "existing@test.com", "1234567890")
         {
-            Name = "Existing Tenant",
-            Subdomain = "existing",
-            Email = "existing@test.com",
-            Phone = "1234567890"
+            Subdomain = "existing"
         };
         await _applicationDbContext.Tenants.AddAsync(tenant);
         await _applicationDbContext.SaveChangesAsync();
 
         // Act
-        tenant.Name = "Updated Tenant";
+        tenant.Update("Updated Tenant", "existing@test.com", "1234567890");
         _tenantRepository.Update(tenant);
         await _applicationDbContext.SaveChangesAsync();
 
@@ -76,12 +70,9 @@ public sealed class TenantRepositoryTests : IDisposable
     public async Task Remove_WhenTenantExists_ShouldRemoveTenantFromDatabase()
     {
         // Arrange
-        var tenant = new Tenant
+        var tenant = new Tenant("Existing Tenant", "existing@test.com", "1234567890")
         {
-            Name = "Existing Tenant",
-            Subdomain = "existing",
-            Email = "existing@test.com",
-            Phone = "1234567890"
+            Subdomain = "existing"
         };
         await _applicationDbContext.Tenants.AddAsync(tenant);
         await _applicationDbContext.SaveChangesAsync();
@@ -99,12 +90,9 @@ public sealed class TenantRepositoryTests : IDisposable
     public async Task IsSubdomainFreeAsync_WhenSubdomainAlreadyExists_ShouldReturnFalse()
     {
         // Arrange  
-        var tenant = new Tenant
+        var tenant = new Tenant("Existing Tenant", "existing@test.com", "1234567890")
         {
-            Name = "Existing Tenant",
-            Subdomain = "existing",
-            Email = "existing@test.com",
-            Phone = "1234567890"
+            Subdomain = "existing"
         };
 
         await _applicationDbContext.Tenants.AddAsync(tenant);
@@ -121,12 +109,9 @@ public sealed class TenantRepositoryTests : IDisposable
     public async Task IsSubdomainFreeAsync_WhenSubdomainDoesNotExist_ShouldReturnTrue()
     {
         // Arrange
-        var tenant = new Tenant
+        var tenant = new Tenant("Existing Tenant", "existing@test.com", "1234567890")
         {
-            Name = "Existing Tenant",
-            Subdomain = "existing",
-            Email = "existing@test.com",
-            Phone = "1234567890"
+            Subdomain = "existing"
         };
 
         await _applicationDbContext.Tenants.AddAsync(tenant);


### PR DESCRIPTION
### Summary & Motivation

This pull request implements Update and Delete tenant endpoints to the WebAPI. These endpoints come with new commands, namely UpdateTenantCommand and DeleteTenantCommand, along with relevant tests.

The CommandResult has been extended to allow for a null value upon success (for the Delete scenario). Additionally, HttpStatusCode has been added to the CommandResult to allow for different HttpResults (NotFound, BadRequest, etc). An extension method has been implemented within the Foundation, which can convert a CommandResult<T> to an HttpResponseMessage. This reduces boilerplate code in the endpoints which now often can be one or two lines.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
