### PR TITLE
Extract reusable backend foundation

### DIFF
--- a/account-management/Application/ApplicationConfiguration.cs
+++ b/account-management/Application/ApplicationConfiguration.cs
@@ -16,9 +16,8 @@ public static class ApplicationConfiguration
     public static IServiceCollection AddApplicationServices(this IServiceCollection services)
     {
         services
-            .AddDomainModelingServices()
-            .ConfigureMappings()
-            .AddMediatR(configuration => configuration.RegisterServicesFromAssemblies(Assembly));
+            .AddDomainModelingServices(Assembly)
+            .ConfigureMappings();
 
         return services;
     }

--- a/account-management/Application/ApplicationConfiguration.cs
+++ b/account-management/Application/ApplicationConfiguration.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 using PlatformPlatform.Foundation.DomainModeling;
@@ -27,6 +28,7 @@ public static class ApplicationConfiguration
     ///     convention-based mapping, which means no configuration is needed if properties are named the same in both
     ///     the DTO and the Entity. However, it can be configured to use explicit mappings.
     /// </summary>
+    [UsedImplicitly]
     private static IServiceCollection ConfigureMappings(this IServiceCollection services)
     {
         TenantDto.ConfigureTenantDtoMapping();

--- a/account-management/Infrastructure/InfrastructureConfiguration.cs
+++ b/account-management/Infrastructure/InfrastructureConfiguration.cs
@@ -16,9 +16,7 @@ public static class InfrastructureConfiguration
     public static IServiceCollection AddInfrastructureServices(this IServiceCollection services,
         IConfiguration configuration)
     {
-        services
-            .ConfigureDatabaseContext<ApplicationDbContext>(configuration)
-            .RegisterRepositories(Assembly);
+        services.ConfigurePersistence<ApplicationDbContext>(configuration, Assembly);
 
         return services;
     }

--- a/account-management/WebApi/Endpoints/TenantEndpoints.cs
+++ b/account-management/WebApi/Endpoints/TenantEndpoints.cs
@@ -4,7 +4,6 @@ using PlatformPlatform.AccountManagement.Application.Tenants.Commands.DeleteTena
 using PlatformPlatform.AccountManagement.Application.Tenants.Commands.UpdateTenant;
 using PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
-using PlatformPlatform.Foundation.AspNetCoreUtils;
 using PlatformPlatform.Foundation.AspNetCoreUtils.Extensions;
 
 namespace PlatformPlatform.AccountManagement.WebApi.Endpoints;

--- a/account-management/WebApi/Endpoints/TenantEndpoints.cs
+++ b/account-management/WebApi/Endpoints/TenantEndpoints.cs
@@ -5,6 +5,7 @@ using PlatformPlatform.AccountManagement.Application.Tenants.Commands.UpdateTena
 using PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.AspNetCoreUtils;
+using PlatformPlatform.Foundation.AspNetCoreUtils.Extensions;
 
 namespace PlatformPlatform.AccountManagement.WebApi.Endpoints;
 

--- a/account-management/WebApi/Program.cs
+++ b/account-management/WebApi/Program.cs
@@ -3,7 +3,6 @@ using PlatformPlatform.AccountManagement.Infrastructure;
 using PlatformPlatform.AccountManagement.WebApi;
 using PlatformPlatform.AccountManagement.WebApi.Endpoints;
 using PlatformPlatform.Foundation.AspNetCoreUtils;
-using PlatformPlatform.Foundation.AspNetCoreUtils.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,27 +14,8 @@ builder.Services
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
-{
-    // Enable the developer exception page, which displays detailed information about exceptions that occur.
-    app.UseDeveloperExceptionPage();
-
-    // Enable Swagger UI in the development environment.
-    app.UseSwagger();
-    app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "AccountManagement API - Unstable"));
-}
-else
-{
-    // Adds middleware for using HSTS, which adds the Strict-Transport-Security header
-    // Defaults to 30 days. See https://aka.ms/aspnetcore-hsts, so be careful during development.
-    app.UseHsts();
-
-    // Adds middleware for redirecting HTTP Requests to HTTPS.
-    app.UseHttpsRedirection();
-
-    // Configure global exception handling for the production environment.
-    app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
-}
+// Add configuration common for all web applications like Swagger, HSTS, and UseDeveloperExceptionPage.
+app.AddCommonConfiguration();
 
 // Map tenant-related endpoints.
 app.MapTenantEndpoints();

--- a/account-management/WebApi/Program.cs
+++ b/account-management/WebApi/Program.cs
@@ -3,6 +3,7 @@ using PlatformPlatform.AccountManagement.Infrastructure;
 using PlatformPlatform.AccountManagement.WebApi;
 using PlatformPlatform.AccountManagement.WebApi.Endpoints;
 using PlatformPlatform.Foundation.AspNetCoreUtils;
+using PlatformPlatform.Foundation.AspNetCoreUtils.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/account-management/WebApi/Program.cs
+++ b/account-management/WebApi/Program.cs
@@ -20,8 +20,5 @@ app.AddCommonConfiguration();
 // Map tenant-related endpoints.
 app.MapTenantEndpoints();
 
-// Add test-specific endpoints when running tests, such as /throwException.
-app.MapTestEndpoints();
-
 // Run the web application.
 app.Run();

--- a/account-management/WebApi/WebApi.csproj
+++ b/account-management/WebApi/WebApi.csproj
@@ -18,12 +18,4 @@
         <InternalsVisibleTo Include="PlatformPlatform.AccountManagement.Tests"/>
     </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
-    </ItemGroup>
-
 </Project>

--- a/account-management/WebApi/WebApiConfiguration.cs
+++ b/account-management/WebApi/WebApiConfiguration.cs
@@ -1,8 +1,6 @@
 using System.Reflection;
 using JetBrains.Annotations;
-using Microsoft.OpenApi.Models;
 using PlatformPlatform.Foundation.AspNetCoreUtils;
-using PlatformPlatform.Foundation.AspNetCoreUtils.Middleware;
 
 namespace PlatformPlatform.AccountManagement.WebApi;
 
@@ -17,14 +15,7 @@ public static class WebApiConfiguration
     [UsedImplicitly]
     public static IServiceCollection AddWebApiServices(this IServiceCollection services)
     {
-        services.AddTransient<GlobalExceptionHandlerMiddleware>();
-
-        services.AddEndpointsApiExplorer();
-
-        services.AddSwaggerGen(c =>
-        {
-            c.SwaggerDoc("v1", new OpenApiInfo {Title = "PlatformPlatform API", Version = "v1"});
-        });
+        services.AddCommonServices();
 
         return services;
     }

--- a/account-management/WebApi/WebApiConfiguration.cs
+++ b/account-management/WebApi/WebApiConfiguration.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.OpenApi.Models;
 using PlatformPlatform.Foundation.AspNetCoreUtils;
+using PlatformPlatform.Foundation.AspNetCoreUtils.Middleware;
 
 namespace PlatformPlatform.AccountManagement.WebApi;
 

--- a/backend-foundation/AspNetCoreUtils/AspNetCoreUtils.csproj
+++ b/backend-foundation/AspNetCoreUtils/AspNetCoreUtils.csproj
@@ -15,6 +15,11 @@
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/backend-foundation/AspNetCoreUtils/AspNetCoreUtilsConfiguration.cs
+++ b/backend-foundation/AspNetCoreUtils/AspNetCoreUtilsConfiguration.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using PlatformPlatform.Foundation.AspNetCoreUtils.Endpoints;
 using PlatformPlatform.Foundation.AspNetCoreUtils.Middleware;
 
 namespace PlatformPlatform.Foundation.AspNetCoreUtils;
@@ -48,6 +49,9 @@ public static class AspNetCoreUtilsConfiguration
             // Configure global exception handling for the production environment.
             app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
         }
+
+        // Add test-specific endpoints when running tests, such as /throwException.
+        app.MapTestEndpoints();
 
         return app;
     }

--- a/backend-foundation/AspNetCoreUtils/AspNetCoreUtilsConfiguration.cs
+++ b/backend-foundation/AspNetCoreUtils/AspNetCoreUtilsConfiguration.cs
@@ -1,0 +1,54 @@
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
+using PlatformPlatform.Foundation.AspNetCoreUtils.Middleware;
+
+namespace PlatformPlatform.Foundation.AspNetCoreUtils;
+
+public static class AspNetCoreUtilsConfiguration
+{
+    [UsedImplicitly]
+    public static IServiceCollection AddCommonServices(this IServiceCollection services)
+    {
+        services.AddTransient<GlobalExceptionHandlerMiddleware>();
+
+        services.AddEndpointsApiExplorer();
+
+        services.AddSwaggerGen(c =>
+        {
+            c.SwaggerDoc("v1", new OpenApiInfo {Title = "PlatformPlatform API", Version = "v1"});
+        });
+
+        return services;
+    }
+
+    [UsedImplicitly]
+    public static WebApplication AddCommonConfiguration(this WebApplication app)
+    {
+        if (app.Environment.IsDevelopment())
+        {
+            // Enable the developer exception page, which displays detailed information about exceptions that occur.
+            app.UseDeveloperExceptionPage();
+
+            // Enable Swagger UI in the development environment.
+            app.UseSwagger();
+            app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "API"));
+        }
+        else
+        {
+            // Adds middleware for using HSTS, which adds the Strict-Transport-Security header
+            // Defaults to 30 days. See https://aka.ms/aspnetcore-hsts, so be careful during development.
+            app.UseHsts();
+
+            // Adds middleware for redirecting HTTP Requests to HTTPS.
+            app.UseHttpsRedirection();
+
+            // Configure global exception handling for the production environment.
+            app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
+        }
+
+        return app;
+    }
+}

--- a/backend-foundation/AspNetCoreUtils/Endpoints/TestEndpoints.cs
+++ b/backend-foundation/AspNetCoreUtils/Endpoints/TestEndpoints.cs
@@ -1,4 +1,7 @@
-namespace PlatformPlatform.AccountManagement.WebApi.Endpoints;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+namespace PlatformPlatform.Foundation.AspNetCoreUtils.Endpoints;
 
 public static class TestEndpoints
 {

--- a/backend-foundation/AspNetCoreUtils/Extensions/CommandResultExtensions.cs
+++ b/backend-foundation/AspNetCoreUtils/Extensions/CommandResultExtensions.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using PlatformPlatform.Foundation.DomainModeling.Cqrs;
 
-namespace PlatformPlatform.Foundation.AspNetCoreUtils;
+namespace PlatformPlatform.Foundation.AspNetCoreUtils.Extensions;
 
 public static class CommandResultExtensions
 {

--- a/backend-foundation/AspNetCoreUtils/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/backend-foundation/AspNetCoreUtils/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
-namespace PlatformPlatform.Foundation.AspNetCoreUtils;
+namespace PlatformPlatform.Foundation.AspNetCoreUtils.Middleware;
 
 public sealed class GlobalExceptionHandlerMiddleware : IMiddleware
 {

--- a/backend-foundation/DomainModeling/DomainModelingConfiguration.cs
+++ b/backend-foundation/DomainModeling/DomainModelingConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using PlatformPlatform.Foundation.DomainModeling.Behaviors;
@@ -6,10 +7,12 @@ namespace PlatformPlatform.Foundation.DomainModeling;
 
 public static class DomainModelingConfiguration
 {
-    public static IServiceCollection AddDomainModelingServices(this IServiceCollection services)
+    public static IServiceCollection AddDomainModelingServices(this IServiceCollection services, Assembly assembly)
     {
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(UnitOfWorkPipelineBehavior<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(PublishDomainEventsPipelineBehavior<,>));
+
+        services.AddMediatR(configuration => configuration.RegisterServicesFromAssemblies(assembly));
 
         return services;
     }

--- a/backend-foundation/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/backend-foundation/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -8,9 +8,21 @@ using PlatformPlatform.Foundation.InfrastructureCore.Persistence;
 
 namespace PlatformPlatform.Foundation.InfrastructureCore;
 
-public static class PersistenceInfrastructureConfiguration
+public static class InfrastructureCoreConfiguration
 {
-    public static IServiceCollection ConfigureDatabaseContext<T>(this IServiceCollection services,
+    [UsedImplicitly]
+    public static IServiceCollection ConfigurePersistence<T>(this IServiceCollection services,
+        IConfiguration configuration, Assembly assembly) where T : DbContext
+    {
+        services.ConfigureDatabaseContext<T>(configuration);
+
+        services.RegisterRepositories(assembly);
+
+        return services;
+    }
+
+    [UsedImplicitly]
+    private static IServiceCollection ConfigureDatabaseContext<T>(this IServiceCollection services,
         IConfiguration configuration)
         where T : DbContext
     {
@@ -31,7 +43,7 @@ public static class PersistenceInfrastructureConfiguration
     }
 
     [UsedImplicitly]
-    public static IServiceCollection RegisterRepositories(this IServiceCollection services, Assembly assembly)
+    private static IServiceCollection RegisterRepositories(this IServiceCollection services, Assembly assembly)
     {
         // Scrutor will scan the assembly for all classes that implement the IRepository
         // and register them as a service in the container.


### PR DESCRIPTION
### Summary & Motivation

Move common service registration, app configuration, and test endpoints from the Account Management to the Backend Foundation. This promotes operational consistency across different self-contained systems.

Create a new Middleware and Extensions namespace in AspNetCoreUtils for better organization and separation of concerns.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
