### PR TITLE
Move TenantDTO and flattern command and queries namespace

### DIFF
--- a/account-management/Application/ApplicationConfiguration.cs
+++ b/account-management/Application/ApplicationConfiguration.cs
@@ -1,7 +1,5 @@
 using System.Reflection;
-using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
-using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 using PlatformPlatform.Foundation.DomainModeling;
 
 namespace PlatformPlatform.AccountManagement.Application;
@@ -16,22 +14,7 @@ public static class ApplicationConfiguration
 
     public static IServiceCollection AddApplicationServices(this IServiceCollection services)
     {
-        services
-            .AddDomainModelingServices(Assembly)
-            .ConfigureMappings();
-
-        return services;
-    }
-
-    /// <summary>
-    ///     Configures the mappings between domain entities and DTOs. This is done using Mapster, which uses
-    ///     convention-based mapping, which means no configuration is needed if properties are named the same in both
-    ///     the DTO and the Entity. However, it can be configured to use explicit mappings.
-    /// </summary>
-    [UsedImplicitly]
-    private static IServiceCollection ConfigureMappings(this IServiceCollection services)
-    {
-        TenantDto.ConfigureTenantDtoMapping();
+        services.AddDomainModelingServices(Assembly);
 
         return services;
     }

--- a/account-management/Application/Tenants/Commands/CreateTenantCommand.cs
+++ b/account-management/Application/Tenants/Commands/CreateTenantCommand.cs
@@ -1,7 +1,5 @@
 using System.Net;
-using Mapster;
 using MediatR;
-using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.DomainModeling.Cqrs;
 using PlatformPlatform.Foundation.DomainModeling.Validation;
@@ -14,9 +12,9 @@ namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 ///     UnitOfWork is committed in the UnitOfWorkPipelineBehavior.
 /// </summary>
 public sealed record CreateTenantCommand(string Name, string Subdomain, string Email, string? Phone) :
-    IRequest<CommandResult<TenantDto>>;
+    IRequest<CommandResult<Tenant>>;
 
-public sealed class CreateTenantCommandHandler : IRequestHandler<CreateTenantCommand, CommandResult<TenantDto>>
+public sealed class CreateTenantCommandHandler : IRequestHandler<CreateTenantCommand, CommandResult<Tenant>>
 {
     private readonly ITenantRepository _tenantRepository;
 
@@ -25,7 +23,7 @@ public sealed class CreateTenantCommandHandler : IRequestHandler<CreateTenantCom
         _tenantRepository = tenantRepository;
     }
 
-    public async Task<CommandResult<TenantDto>> Handle(CreateTenantCommand command, CancellationToken cancellationToken)
+    public async Task<CommandResult<Tenant>> Handle(CreateTenantCommand command, CancellationToken cancellationToken)
     {
         var isUniqueSubdomain = await IsSubdomainUniqueAsync(command.Subdomain, cancellationToken);
 
@@ -38,14 +36,14 @@ public sealed class CreateTenantCommandHandler : IRequestHandler<CreateTenantCom
 
         if (propertyErrors.Any())
         {
-            return CommandResult<TenantDto>.Failure(propertyErrors, HttpStatusCode.BadRequest);
+            return CommandResult<Tenant>.Failure(propertyErrors, HttpStatusCode.BadRequest);
         }
 
         var tenant = Tenant.Create(command.Name, command.Subdomain, command.Email, command.Phone);
 
         _tenantRepository.Add(tenant);
 
-        return tenant.Adapt<TenantDto>();
+        return tenant;
     }
 
     private async Task<ValidationResult> IsSubdomainUniqueAsync(string subdomain, CancellationToken cancellationToken)

--- a/account-management/Application/Tenants/Commands/CreateTenantCommand.cs
+++ b/account-management/Application/Tenants/Commands/CreateTenantCommand.cs
@@ -6,7 +6,7 @@ using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.DomainModeling.Cqrs;
 using PlatformPlatform.Foundation.DomainModeling.Validation;
 
-namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands.CreateTenant;
+namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 
 /// <summary>
 ///     The CreateTenantCommand will create a new Tenant and add it to the repository. The command will be handled

--- a/account-management/Application/Tenants/Commands/DeleteTenantCommand.cs
+++ b/account-management/Application/Tenants/Commands/DeleteTenantCommand.cs
@@ -5,7 +5,7 @@ using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.DomainModeling.Cqrs;
 using PlatformPlatform.Foundation.DomainModeling.Validation;
 
-namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands.DeleteTenant;
+namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 
 public sealed record DeleteTenantCommand(TenantId Id) : IRequest<CommandResult<TenantDto>>;
 

--- a/account-management/Application/Tenants/Commands/DeleteTenantCommand.cs
+++ b/account-management/Application/Tenants/Commands/DeleteTenantCommand.cs
@@ -1,15 +1,14 @@
 using System.Net;
 using MediatR;
-using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.DomainModeling.Cqrs;
 using PlatformPlatform.Foundation.DomainModeling.Validation;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 
-public sealed record DeleteTenantCommand(TenantId Id) : IRequest<CommandResult<TenantDto>>;
+public sealed record DeleteTenantCommand(TenantId Id) : IRequest<CommandResult<Tenant>>;
 
-public sealed class DeleteTenantCommandHandler : IRequestHandler<DeleteTenantCommand, CommandResult<TenantDto>>
+public sealed class DeleteTenantCommandHandler : IRequestHandler<DeleteTenantCommand, CommandResult<Tenant>>
 {
     private readonly ITenantRepository _tenantRepository;
 
@@ -18,17 +17,17 @@ public sealed class DeleteTenantCommandHandler : IRequestHandler<DeleteTenantCom
         _tenantRepository = tenantRepository;
     }
 
-    public async Task<CommandResult<TenantDto>> Handle(DeleteTenantCommand command, CancellationToken cancellationToken)
+    public async Task<CommandResult<Tenant>> Handle(DeleteTenantCommand command, CancellationToken cancellationToken)
     {
         var tenant = await _tenantRepository.GetByIdAsync(command.Id, cancellationToken);
         if (tenant is null)
         {
-            return CommandResult<TenantDto>.Failure(new[] {new PropertyError("TenantId", "Tenant not found.")},
+            return CommandResult<Tenant>.Failure(new[] {new PropertyError("TenantId", "Tenant not found.")},
                 HttpStatusCode.NotFound);
         }
 
         _tenantRepository.Remove(tenant);
 
-        return CommandResult<TenantDto>.Success(null);
+        return CommandResult<Tenant>.Success(null);
     }
 }

--- a/account-management/Application/Tenants/Commands/UpdateTenantCommand.cs
+++ b/account-management/Application/Tenants/Commands/UpdateTenantCommand.cs
@@ -1,7 +1,5 @@
 using System.Net;
-using Mapster;
 using MediatR;
-using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.DomainModeling.Cqrs;
 using PlatformPlatform.Foundation.DomainModeling.Validation;
@@ -9,9 +7,9 @@ using PlatformPlatform.Foundation.DomainModeling.Validation;
 namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 
 public sealed record UpdateTenantCommand(TenantId TenantId, string Name, string Email, string? Phone)
-    : IRequest<CommandResult<TenantDto>>;
+    : IRequest<CommandResult<Tenant>>;
 
-public sealed class UpdateTenantCommandHandler : IRequestHandler<UpdateTenantCommand, CommandResult<TenantDto>>
+public sealed class UpdateTenantCommandHandler : IRequestHandler<UpdateTenantCommand, CommandResult<Tenant>>
 {
     private readonly ITenantRepository _tenantRepository;
 
@@ -20,13 +18,13 @@ public sealed class UpdateTenantCommandHandler : IRequestHandler<UpdateTenantCom
         _tenantRepository = tenantRepository;
     }
 
-    public async Task<CommandResult<TenantDto>> Handle(UpdateTenantCommand command, CancellationToken cancellationToken)
+    public async Task<CommandResult<Tenant>> Handle(UpdateTenantCommand command, CancellationToken cancellationToken)
     {
         var tenant = await _tenantRepository.GetByIdAsync(command.TenantId, cancellationToken);
 
         if (tenant is null)
         {
-            return CommandResult<TenantDto>.Failure(new[] {new PropertyError("TenantId", "Tenant not found.")},
+            return CommandResult<Tenant>.Failure(new[] {new PropertyError("TenantId", "Tenant not found.")},
                 HttpStatusCode.NotFound);
         }
 
@@ -37,13 +35,13 @@ public sealed class UpdateTenantCommandHandler : IRequestHandler<UpdateTenantCom
 
         if (propertyErrors.Any())
         {
-            return CommandResult<TenantDto>.Failure(propertyErrors, HttpStatusCode.BadRequest);
+            return CommandResult<Tenant>.Failure(propertyErrors, HttpStatusCode.BadRequest);
         }
 
         tenant.Update(command.Name, command.Email, command.Phone);
 
         _tenantRepository.Update(tenant);
 
-        return tenant.Adapt<TenantDto>();
+        return tenant;
     }
 }

--- a/account-management/Application/Tenants/Commands/UpdateTenantCommand.cs
+++ b/account-management/Application/Tenants/Commands/UpdateTenantCommand.cs
@@ -6,7 +6,7 @@ using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.DomainModeling.Cqrs;
 using PlatformPlatform.Foundation.DomainModeling.Validation;
 
-namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands.UpdateTenant;
+namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 
 public sealed record UpdateTenantCommand(TenantId TenantId, string Name, string Email, string? Phone)
     : IRequest<CommandResult<TenantDto>>;

--- a/account-management/Application/Tenants/Dtos/TenantDto.cs
+++ b/account-management/Application/Tenants/Dtos/TenantDto.cs
@@ -1,13 +1,13 @@
 using JetBrains.Annotations;
 using Mapster;
-using PlatformPlatform.AccountManagement.Application.Tenants.Commands.CreateTenant;
+using PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 using PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 
 /// <summary>
-///     A shared DTO for used both in <see cref="GetTenantByIdQuery" /> and <see cref="CreateTenantCommand" />.
+///     A shared DTO for used both in <see cref="GetTenantQuery" /> and <see cref="CreateTenantCommand" />.
 ///     This class is returned by the WebAPI, making it a public contract, so it should be changed with care.
 /// </summary>
 [UsedImplicitly]

--- a/account-management/Application/Tenants/EventHandlers/TenantCreatedEventHandler.cs
+++ b/account-management/Application/Tenants/EventHandlers/TenantCreatedEventHandler.cs
@@ -3,7 +3,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 
-namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands.CreateTenant;
+namespace PlatformPlatform.AccountManagement.Application.Tenants.EventHandlers;
 
 [UsedImplicitly]
 public sealed class TenantCreatedEventHandler : INotificationHandler<TenantCreatedEvent>

--- a/account-management/Application/Tenants/Queries/GetTenantQuery.cs
+++ b/account-management/Application/Tenants/Queries/GetTenantQuery.cs
@@ -7,12 +7,12 @@ using PlatformPlatform.Foundation.DomainModeling.Cqrs;
 namespace PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 
 /// <summary>
-///     The GetTenantByIdQuery will retrieve a Tenant with the specified TenantId from the repository. The query
+///     The GetTenantQuery will retrieve a Tenant with the specified TenantId from the repository. The query
 ///     will be handled by <see cref="GetTenantQueryHandler" />. Returns the TenantDto if found, otherwise null.
 /// </summary>
-public sealed record GetTenantByIdQuery(TenantId Id) : IRequest<QueryResult<TenantDto>>;
+public sealed record GetTenantQuery(TenantId Id) : IRequest<QueryResult<TenantDto>>;
 
-public sealed class GetTenantQueryHandler : IRequestHandler<GetTenantByIdQuery, QueryResult<TenantDto>>
+public sealed class GetTenantQueryHandler : IRequestHandler<GetTenantQuery, QueryResult<TenantDto>>
 {
     private readonly ITenantRepository _tenantRepository;
 
@@ -21,7 +21,7 @@ public sealed class GetTenantQueryHandler : IRequestHandler<GetTenantByIdQuery, 
         _tenantRepository = tenantRepository;
     }
 
-    public async Task<QueryResult<TenantDto>> Handle(GetTenantByIdQuery request, CancellationToken cancellationToken)
+    public async Task<QueryResult<TenantDto>> Handle(GetTenantQuery request, CancellationToken cancellationToken)
     {
         var tenant = await _tenantRepository.GetByIdAsync(request.Id, cancellationToken);
         return tenant == null

--- a/account-management/Application/Tenants/Queries/GetTenantQuery.cs
+++ b/account-management/Application/Tenants/Queries/GetTenantQuery.cs
@@ -1,18 +1,16 @@
-using Mapster;
 using MediatR;
-using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.DomainModeling.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 
 /// <summary>
-///     The GetTenantQuery will retrieve a Tenant with the specified TenantId from the repository. The query
-///     will be handled by <see cref="GetTenantQueryHandler" />. Returns the TenantDto if found, otherwise null.
+///     The GetTenantQuery will retrieve a Tenant with the specified TenantId from the repository. The query will
+///     be handled by <see cref="GetTenantQueryHandler" />. Returns the Tenant if found, otherwise a NotFound result.
 /// </summary>
-public sealed record GetTenantQuery(TenantId Id) : IRequest<QueryResult<TenantDto>>;
+public sealed record GetTenantQuery(TenantId Id) : IRequest<QueryResult<Tenant>>;
 
-public sealed class GetTenantQueryHandler : IRequestHandler<GetTenantQuery, QueryResult<TenantDto>>
+public sealed class GetTenantQueryHandler : IRequestHandler<GetTenantQuery, QueryResult<Tenant>>
 {
     private readonly ITenantRepository _tenantRepository;
 
@@ -21,11 +19,9 @@ public sealed class GetTenantQueryHandler : IRequestHandler<GetTenantQuery, Quer
         _tenantRepository = tenantRepository;
     }
 
-    public async Task<QueryResult<TenantDto>> Handle(GetTenantQuery request, CancellationToken cancellationToken)
+    public async Task<QueryResult<Tenant>> Handle(GetTenantQuery request, CancellationToken cancellationToken)
     {
         var tenant = await _tenantRepository.GetByIdAsync(request.Id, cancellationToken);
-        return tenant == null
-            ? QueryResult<TenantDto>.Failure($"Tenant with id '{request.Id.AsRawString()}' not found.")
-            : tenant.Adapt<TenantDto>();
+        return tenant ?? QueryResult<Tenant>.Failure($"Tenant with id '{request.Id.AsRawString()}' not found.");
     }
 }

--- a/account-management/Infrastructure/ApplicationDbContext.cs
+++ b/account-management/Infrastructure/ApplicationDbContext.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.DomainModeling.Entities;
@@ -10,7 +9,6 @@ namespace PlatformPlatform.AccountManagement.Infrastructure;
 ///     The ApplicationDbContext class represents the Entity Framework Core DbContext for managing data access to the
 ///     database, like creation, querying, and updating of <see cref="IAggregateRoot" /> entities.
 /// </summary>
-[SuppressMessage("Performance", "CA1822:Mark members as static")]
 public sealed class ApplicationDbContext : FoundationDbContext<ApplicationDbContext>
 {
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)

--- a/account-management/Tests/Application/Tenants/Commands/CreateTenantCommandTests.cs
+++ b/account-management/Tests/Application/Tenants/Commands/CreateTenantCommandTests.cs
@@ -2,17 +2,17 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using PlatformPlatform.AccountManagement.Application;
-using PlatformPlatform.AccountManagement.Application.Tenants.Commands.CreateTenant;
+using PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using Xunit;
 
-namespace PlatformPlatform.AccountManagement.Tests.Application.Tenants.Commands.CreateTenant;
+namespace PlatformPlatform.AccountManagement.Tests.Application.Tenants.Commands;
 
-public class CreateTenantCommandHandlerTests
+public class CreateTenantCommandTests
 {
     private readonly ITenantRepository _tenantRepository;
 
-    public CreateTenantCommandHandlerTests()
+    public CreateTenantCommandTests()
     {
         var services = new ServiceCollection();
         services.AddApplicationServices();

--- a/account-management/Tests/Application/Tenants/Commands/CreateTenantCommandTests.cs
+++ b/account-management/Tests/Application/Tenants/Commands/CreateTenantCommandTests.cs
@@ -35,10 +35,9 @@ public class CreateTenantCommandTests
 
         // Assert
         createTenantCommandResult.IsSuccess.Should().BeTrue();
-        var tenantResponseDto = createTenantCommandResult.Value!;
-        var tenantId = TenantId.FromString(tenantResponseDto.Id);
+        var tenantResponse = createTenantCommandResult.Value!;
         _tenantRepository.Received()
-            .Add(Arg.Is<Tenant>(t => t.Name == command.Name && t.Id > startId && t.Id == tenantId));
+            .Add(Arg.Is<Tenant>(t => t.Name == command.Name && t.Id > startId && t.Id == tenantResponse.Id));
     }
 
     [Fact]

--- a/account-management/Tests/Application/Tenants/Commands/DeleteTenantCommandTests.cs
+++ b/account-management/Tests/Application/Tenants/Commands/DeleteTenantCommandTests.cs
@@ -2,17 +2,17 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using PlatformPlatform.AccountManagement.Application;
-using PlatformPlatform.AccountManagement.Application.Tenants.Commands.DeleteTenant;
+using PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using Xunit;
 
-namespace PlatformPlatform.AccountManagement.Tests.Application.Tenants.Commands.DeleteTenant;
+namespace PlatformPlatform.AccountManagement.Tests.Application.Tenants.Commands;
 
-public class DeleteTenantCommandHandlerTests
+public class DeleteTenantCommandTests
 {
     private readonly ITenantRepository _tenantRepository;
 
-    public DeleteTenantCommandHandlerTests()
+    public DeleteTenantCommandTests()
     {
         var services = new ServiceCollection();
         services.AddApplicationServices();

--- a/account-management/Tests/Application/Tenants/Commands/UpdateTenantCommandTests.cs
+++ b/account-management/Tests/Application/Tenants/Commands/UpdateTenantCommandTests.cs
@@ -2,17 +2,17 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using PlatformPlatform.AccountManagement.Application;
-using PlatformPlatform.AccountManagement.Application.Tenants.Commands.UpdateTenant;
+using PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using Xunit;
 
-namespace PlatformPlatform.AccountManagement.Tests.Application.Tenants.Commands.UpdateTenant;
+namespace PlatformPlatform.AccountManagement.Tests.Application.Tenants.Commands;
 
-public class UpdateTenantCommandHandlerTests
+public class UpdateTenantCommandTests
 {
     private readonly ITenantRepository _tenantRepository;
 
-    public UpdateTenantCommandHandlerTests()
+    public UpdateTenantCommandTests()
     {
         var services = new ServiceCollection();
         services.AddApplicationServices();

--- a/account-management/Tests/Application/Tenants/Queries/GetTenantQueryTests.cs
+++ b/account-management/Tests/Application/Tenants/Queries/GetTenantQueryTests.cs
@@ -38,10 +38,10 @@ public class GetTenantQueryTests
 
         // Assert
         getTenantQueryResult.IsSuccess.Should().BeTrue();
-        var tenantResponseDto = getTenantQueryResult.Value;
-        tenantResponseDto.Should().NotBeNull();
-        tenantResponseDto.Id.Should().Be(expectedTenantId.AsRawString());
-        tenantResponseDto.Name.Should().Be(expectedTenantName);
+        var tenantResponse = getTenantQueryResult.Value;
+        tenantResponse.Should().NotBeNull();
+        tenantResponse.Id.Should().Be(expectedTenantId);
+        tenantResponse.Name.Should().Be(expectedTenantName);
         await tenantRepository.Received().GetByIdAsync(expectedTenantId, default);
     }
 

--- a/account-management/Tests/Application/Tenants/Queries/GetTenantQueryTests.cs
+++ b/account-management/Tests/Application/Tenants/Queries/GetTenantQueryTests.cs
@@ -8,16 +8,16 @@ using Xunit;
 
 namespace PlatformPlatform.AccountManagement.Tests.Application.Tenants.Queries;
 
-public class GetTenantByIdQueryTests
+public class GetTenantQueryTests
 {
-    public GetTenantByIdQueryTests()
+    public GetTenantQueryTests()
     {
         var services = new ServiceCollection();
         services.AddApplicationServices();
     }
 
     [Fact]
-    public async Task GetTenantByIdQuery_WhenTenantFound_ShouldReturnTenantResponseDto()
+    public async Task GetTenantQuery_WhenTenantFound_ShouldReturnTenantResponseDto()
     {
         // Arrange
         var expectedTenantId = TenantId.NewId();
@@ -33,12 +33,12 @@ public class GetTenantByIdQueryTests
         var handler = new GetTenantQueryHandler(tenantRepository);
 
         // Act
-        var query = new GetTenantByIdQuery(expectedTenantId);
-        var getTenantByIdQueryResult = await handler.Handle(query, default);
+        var query = new GetTenantQuery(expectedTenantId);
+        var getTenantQueryResult = await handler.Handle(query, default);
 
         // Assert
-        getTenantByIdQueryResult.IsSuccess.Should().BeTrue();
-        var tenantResponseDto = getTenantByIdQueryResult.Value;
+        getTenantQueryResult.IsSuccess.Should().BeTrue();
+        var tenantResponseDto = getTenantQueryResult.Value;
         tenantResponseDto.Should().NotBeNull();
         tenantResponseDto.Id.Should().Be(expectedTenantId.AsRawString());
         tenantResponseDto.Name.Should().Be(expectedTenantName);
@@ -46,7 +46,7 @@ public class GetTenantByIdQueryTests
     }
 
     [Fact]
-    public async Task GetTenantByIdQuery_WhenTenantNotFound_ShouldReturnNull()
+    public async Task GetTenantQuery_WhenTenantNotFound_ShouldReturnNull()
     {
         // Arrange
         var nonExistingTenantId = new TenantId(999);
@@ -56,11 +56,11 @@ public class GetTenantByIdQueryTests
         var handler = new GetTenantQueryHandler(tenantRepository);
 
         // Act
-        var query = new GetTenantByIdQuery(nonExistingTenantId);
-        var getTenantByIdQueryResult = await handler.Handle(query, default);
+        var query = new GetTenantQuery(nonExistingTenantId);
+        var getTenantQueryResult = await handler.Handle(query, default);
 
         // Assert
-        getTenantByIdQueryResult.IsSuccess.Should().BeFalse();
+        getTenantQueryResult.IsSuccess.Should().BeFalse();
         await tenantRepository.Received().GetByIdAsync(nonExistingTenantId, default);
     }
 }

--- a/account-management/Tests/DatabaseSeeder.cs
+++ b/account-management/Tests/DatabaseSeeder.cs
@@ -7,25 +7,13 @@ public class DatabaseSeeder
 {
     public const string Tenant1Name = "Tenant 1";
     public static readonly TenantId Tenant1Id = TenantId.NewId();
-
     private readonly ApplicationDbContext _applicationDbContext;
-    private bool _databaseIsSeeded;
 
     public DatabaseSeeder(ApplicationDbContext applicationDbContext)
     {
         _applicationDbContext = applicationDbContext;
-        Seed();
-    }
-
-    public void Seed()
-    {
-        if (_databaseIsSeeded) return;
-
         SeedTenants();
-
-        _applicationDbContext.SaveChanges();
-
-        _databaseIsSeeded = true;
+        applicationDbContext.SaveChanges();
     }
 
     private void SeedTenants()

--- a/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
+++ b/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
@@ -4,7 +4,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using PlatformPlatform.AccountManagement.Application.Tenants.Commands.CreateTenant;
+using PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.AccountManagement.Infrastructure;

--- a/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
+++ b/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
@@ -9,7 +9,7 @@ using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.AccountManagement.Infrastructure;
 using PlatformPlatform.AccountManagement.Tests.Infrastructure;
-using PlatformPlatform.AccountManagement.WebApi.Endpoints;
+using PlatformPlatform.AccountManagement.WebApi.Tenants;
 using PlatformPlatform.Foundation.DomainModeling.Validation;
 using Xunit;
 

--- a/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
+++ b/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
@@ -4,7 +4,6 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.AccountManagement.Infrastructure;
 using PlatformPlatform.AccountManagement.Tests.Infrastructure;
@@ -71,7 +70,7 @@ public sealed class TenantEndpointsTests : IDisposable
         // Assert
         response.EnsureSuccessStatusCode();
 
-        var tenantDto = await response.Content.ReadFromJsonAsync<TenantDto>();
+        var tenantDto = await response.Content.ReadFromJsonAsync<TenantResponseDto>();
         var tenantId = TenantId.FromString(tenantDto!.Id);
         tenantId.Should().BeGreaterThan(startId, "We expect a valid Tenant Id greater than the start Id");
 
@@ -117,15 +116,15 @@ public sealed class TenantEndpointsTests : IDisposable
     {
         // Arrange
         var httpClient = _webApplicationFactory.CreateClient();
+        var tenantId = DatabaseSeeder.Tenant1Id.AsRawString();
 
         // Act
-        var response = await httpClient.GetAsync($"/tenants/{DatabaseSeeder.Tenant1Id.AsRawString()}");
+        var response = await httpClient.GetAsync($"/tenants/{tenantId}");
 
         // Assert
         response.EnsureSuccessStatusCode();
 
-        var tenantDto = await response.Content.ReadFromJsonAsync<TenantDto>();
-        var tenantId = DatabaseSeeder.Tenant1Id.AsRawString();
+        var tenantDto = await response.Content.ReadFromJsonAsync<TenantResponseDto>();
         const string tenantName = DatabaseSeeder.Tenant1Name;
         var createdAt = tenantDto?.CreatedAt.ToString(Iso8601TimeFormat);
 
@@ -167,7 +166,7 @@ public sealed class TenantEndpointsTests : IDisposable
         // Assert
         response.EnsureSuccessStatusCode();
 
-        var tenantDto = await response.Content.ReadFromJsonAsync<TenantDto>();
+        var tenantDto = await response.Content.ReadFromJsonAsync<TenantResponseDto>();
 
         tenantDto!.Name.Should().Be("UpdatedName");
         tenantDto.Email.Should().Be("updated@tenant1.com");
@@ -177,6 +176,7 @@ public sealed class TenantEndpointsTests : IDisposable
     [Fact]
     public async Task UpdateTenant_WhenInValid_ShouldReturnBadRequest()
     {
+        // Arrange
         var httpClient = _webApplicationFactory.CreateClient();
 
         var tenantId = DatabaseSeeder.Tenant1Id.AsRawString();
@@ -221,6 +221,7 @@ public sealed class TenantEndpointsTests : IDisposable
     [Fact]
     public async Task DeleteTenant_WhenTenantExists_ShouldDeleteTenant()
     {
+        // Arrange
         var httpClient = _webApplicationFactory.CreateClient();
         var tenantId = DatabaseSeeder.Tenant1Id.AsRawString();
 

--- a/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
+++ b/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
@@ -4,7 +4,6 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 using PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.AccountManagement.Infrastructure;
@@ -66,7 +65,7 @@ public sealed class TenantEndpointsTests : IDisposable
 
         // Act
         var response = await httpClient.PostAsJsonAsync("/tenants",
-            new CreateTenantCommand("TestTenant", "foo", "foo@tenant1.com", "1234567890")
+            new CreateTenantRequest("TestTenant", "foo", "foo@tenant1.com", "1234567890")
         );
 
         // Assert
@@ -96,7 +95,7 @@ public sealed class TenantEndpointsTests : IDisposable
 
         // Act
         var response = await httpClient.PostAsJsonAsync("/tenants",
-            new CreateTenantCommand("TestTenant", "a", "ab", null)
+            new CreateTenantRequest("TestTenant", "a", "ab", null)
         );
 
         // Assert

--- a/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
+++ b/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
@@ -23,7 +23,6 @@ public sealed class TenantEndpointsTests : IDisposable
     // See https://stackoverflow.com/a/17349663
     private const string Iso8601TimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'FFFFFFFK";
 
-    private readonly IServiceProvider _serviceProvider;
     private readonly SqliteInMemoryDbContextFactory<ApplicationDbContext> _sqliteInMemoryDbContextFactory;
     private readonly WebApplicationFactory<Program> _webApplicationFactory;
 
@@ -49,7 +48,8 @@ public sealed class TenantEndpointsTests : IDisposable
             });
         });
 
-        _serviceProvider = _webApplicationFactory.Services;
+        var serviceScope = _webApplicationFactory.Services.CreateScope();
+        serviceScope.ServiceProvider.GetRequiredService<DatabaseSeeder>();
     }
 
     public void Dispose()
@@ -66,7 +66,7 @@ public sealed class TenantEndpointsTests : IDisposable
 
         // Act
         var response = await httpClient.PostAsJsonAsync("/tenants",
-            new CreateTenantCommand("TestTenant", "tenant1", "foo@tenant1.com", "1234567890")
+            new CreateTenantCommand("TestTenant", "foo", "foo@tenant1.com", "1234567890")
         );
 
         // Assert
@@ -117,12 +117,6 @@ public sealed class TenantEndpointsTests : IDisposable
     public async Task GetTenant_WhenTenantExists_ShouldReturnTenant()
     {
         // Arrange
-        using (var serviceScope = _serviceProvider.CreateScope())
-        {
-            var databaseSeeder = serviceScope.ServiceProvider.GetRequiredService<DatabaseSeeder>();
-            databaseSeeder.Seed();
-        }
-
         var httpClient = _webApplicationFactory.CreateClient();
 
         // Act
@@ -162,12 +156,6 @@ public sealed class TenantEndpointsTests : IDisposable
     public async Task UpdateTenant_WhenValid_ShouldUpdateTenant()
     {
         // Arrange
-        using (var serviceScope = _serviceProvider.CreateScope())
-        {
-            var databaseSeeder = serviceScope.ServiceProvider.GetRequiredService<DatabaseSeeder>();
-            databaseSeeder.Seed();
-        }
-
         var httpClient = _webApplicationFactory.CreateClient();
 
         var tenantId = DatabaseSeeder.Tenant1Id.AsRawString();
@@ -190,13 +178,6 @@ public sealed class TenantEndpointsTests : IDisposable
     [Fact]
     public async Task UpdateTenant_WhenInValid_ShouldReturnBadRequest()
     {
-        // Arrange
-        using (var serviceScope = _serviceProvider.CreateScope())
-        {
-            var databaseSeeder = serviceScope.ServiceProvider.GetRequiredService<DatabaseSeeder>();
-            databaseSeeder.Seed();
-        }
-
         var httpClient = _webApplicationFactory.CreateClient();
 
         var tenantId = DatabaseSeeder.Tenant1Id.AsRawString();
@@ -241,13 +222,6 @@ public sealed class TenantEndpointsTests : IDisposable
     [Fact]
     public async Task DeleteTenant_WhenTenantExists_ShouldDeleteTenant()
     {
-        // Arrange
-        using (var serviceScope = _serviceProvider.CreateScope())
-        {
-            var databaseSeeder = serviceScope.ServiceProvider.GetRequiredService<DatabaseSeeder>();
-            databaseSeeder.Seed();
-        }
-
         var httpClient = _webApplicationFactory.CreateClient();
         var tenantId = DatabaseSeeder.Tenant1Id.AsRawString();
 

--- a/account-management/WebApi/Endpoints/TenantEndpoints.cs
+++ b/account-management/WebApi/Endpoints/TenantEndpoints.cs
@@ -1,7 +1,5 @@
 using MediatR;
-using PlatformPlatform.AccountManagement.Application.Tenants.Commands.CreateTenant;
-using PlatformPlatform.AccountManagement.Application.Tenants.Commands.DeleteTenant;
-using PlatformPlatform.AccountManagement.Application.Tenants.Commands.UpdateTenant;
+using PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 using PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.AspNetCoreUtils.Extensions;
@@ -21,7 +19,7 @@ public static class TenantEndpoints
 
     private static async Task<IResult> GetTenant(string id, ISender sender)
     {
-        var result = await sender.Send(new GetTenantByIdQuery(TenantId.FromString(id)));
+        var result = await sender.Send(new GetTenantQuery(TenantId.FromString(id)));
         return result.IsSuccess
             ? Results.Ok(result.Value)
             : Results.NotFound(result.Error);

--- a/account-management/WebApi/Program.cs
+++ b/account-management/WebApi/Program.cs
@@ -1,7 +1,7 @@
 using PlatformPlatform.AccountManagement.Application;
 using PlatformPlatform.AccountManagement.Infrastructure;
 using PlatformPlatform.AccountManagement.WebApi;
-using PlatformPlatform.AccountManagement.WebApi.Endpoints;
+using PlatformPlatform.AccountManagement.WebApi.Tenants;
 using PlatformPlatform.Foundation.AspNetCoreUtils;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/account-management/WebApi/Tenants/CreateTenantRequest.cs
+++ b/account-management/WebApi/Tenants/CreateTenantRequest.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace PlatformPlatform.AccountManagement.WebApi.Tenants;
 
+[UsedImplicitly]
 public sealed record CreateTenantRequest(string Name, string Subdomain, string Email, string? Phone);

--- a/account-management/WebApi/Tenants/CreateTenantRequest.cs
+++ b/account-management/WebApi/Tenants/CreateTenantRequest.cs
@@ -1,0 +1,3 @@
+namespace PlatformPlatform.AccountManagement.WebApi.Tenants;
+
+public sealed record CreateTenantRequest(string Name, string Subdomain, string Email, string? Phone);

--- a/account-management/WebApi/Tenants/TenantEndpoints.cs
+++ b/account-management/WebApi/Tenants/TenantEndpoints.cs
@@ -20,28 +20,29 @@ public static class TenantEndpoints
 
     private static async Task<IResult> GetTenant(string id, ISender sender)
     {
-        var result = await sender.Send(new GetTenantQuery(TenantId.FromString(id)));
-        return result.IsSuccess
-            ? Results.Ok(result.Value)
-            : Results.NotFound(result.Error);
+        var query = new GetTenantQuery(TenantId.FromString(id));
+        var result = await sender.Send(query);
+        return result.AsHttpResult<Tenant, TenantResponseDto>();
     }
 
     private static async Task<IResult> CreateTenant(CreateTenantRequest request, ISender sender)
     {
         var command = request.Adapt<CreateTenantCommand>();
         var result = await sender.Send(command);
-        return result.AsHttpResult($"/tenants/{result.Value?.Id}");
+        return result.AsHttpResult<Tenant, TenantResponseDto>($"/tenants/{result.Value?.Id.AsRawString()}");
     }
 
     private static async Task<IResult> UpdateTenant(string id, UpdateTenantRequest request, ISender sender)
     {
         var command = new UpdateTenantCommand(TenantId.FromString(id), request.Name, request.Email, request.Phone);
-        return (await sender.Send(command)).AsHttpResult();
+        var result = await sender.Send(command);
+        return result.AsHttpResult<Tenant, TenantResponseDto>();
     }
 
     private static async Task<IResult> DeleteTenant(string id, ISender sender)
     {
         var command = new DeleteTenantCommand(TenantId.FromString(id));
-        return (await sender.Send(command)).AsHttpResult();
+        var result = await sender.Send(command);
+        return result.AsHttpResult<Tenant, TenantResponseDto>();
     }
 }

--- a/account-management/WebApi/Tenants/TenantEndpoints.cs
+++ b/account-management/WebApi/Tenants/TenantEndpoints.cs
@@ -1,3 +1,4 @@
+using Mapster;
 using MediatR;
 using PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 using PlatformPlatform.AccountManagement.Application.Tenants.Queries;
@@ -25,8 +26,9 @@ public static class TenantEndpoints
             : Results.NotFound(result.Error);
     }
 
-    private static async Task<IResult> CreateTenant(CreateTenantCommand command, ISender sender)
+    private static async Task<IResult> CreateTenant(CreateTenantRequest request, ISender sender)
     {
+        var command = request.Adapt<CreateTenantCommand>();
         var result = await sender.Send(command);
         return result.AsHttpResult($"/tenants/{result.Value?.Id}");
     }
@@ -43,5 +45,3 @@ public static class TenantEndpoints
         return (await sender.Send(command)).AsHttpResult();
     }
 }
-
-public sealed record UpdateTenantRequest(string Name, string Email, string? Phone);

--- a/account-management/WebApi/Tenants/TenantEndpoints.cs
+++ b/account-management/WebApi/Tenants/TenantEndpoints.cs
@@ -4,7 +4,7 @@ using PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.AspNetCoreUtils.Extensions;
 
-namespace PlatformPlatform.AccountManagement.WebApi.Endpoints;
+namespace PlatformPlatform.AccountManagement.WebApi.Tenants;
 
 public static class TenantEndpoints
 {

--- a/account-management/WebApi/Tenants/TenantResponseDto.cs
+++ b/account-management/WebApi/Tenants/TenantResponseDto.cs
@@ -1,17 +1,14 @@
 using JetBrains.Annotations;
 using Mapster;
-using PlatformPlatform.AccountManagement.Application.Tenants.Commands;
-using PlatformPlatform.AccountManagement.Application.Tenants.Queries;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 
-namespace PlatformPlatform.AccountManagement.Application.Tenants.Dtos;
+namespace PlatformPlatform.AccountManagement.WebApi.Tenants;
 
 /// <summary>
-///     A shared DTO for used both in <see cref="GetTenantQuery" /> and <see cref="CreateTenantCommand" />.
+///     A shared DTO for used as return value for GET, POST and POST in <see cref="TenantEndpoints" />.
 ///     This class is returned by the WebAPI, making it a public contract, so it should be changed with care.
 /// </summary>
-[UsedImplicitly]
-public sealed record TenantDto
+public sealed record TenantResponseDto
 {
     /// <summary>
     ///     The Id of the Tenant.
@@ -52,7 +49,7 @@ public sealed record TenantDto
 
     internal static void ConfigureTenantDtoMapping()
     {
-        TypeAdapterConfig<Tenant, TenantDto>.NewConfig()
+        TypeAdapterConfig<Tenant, TenantResponseDto>.NewConfig()
             .Map(destination => destination.Id, source => source.Id.AsRawString());
     }
 }

--- a/account-management/WebApi/Tenants/UpdateTenantRequest.cs
+++ b/account-management/WebApi/Tenants/UpdateTenantRequest.cs
@@ -1,0 +1,3 @@
+namespace PlatformPlatform.AccountManagement.WebApi.Tenants;
+
+public sealed record UpdateTenantRequest(string Name, string Email, string? Phone);

--- a/account-management/WebApi/WebApiConfiguration.cs
+++ b/account-management/WebApi/WebApiConfiguration.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using JetBrains.Annotations;
+using PlatformPlatform.AccountManagement.WebApi.Tenants;
 using PlatformPlatform.Foundation.AspNetCoreUtils;
 
 namespace PlatformPlatform.AccountManagement.WebApi;
@@ -17,6 +18,18 @@ public static class WebApiConfiguration
     {
         services.AddCommonServices();
 
+        ConfigureMappings();
+
         return services;
+    }
+
+    /// <summary>
+    ///     Configures the mappings between domain entities and DTOs. This is done using Mapster, which uses
+    ///     convention-based mapping, which means no configuration is needed if properties are named the same in both
+    ///     the DTO and the Entity. However, it can be configured to use explicit mappings.
+    /// </summary>
+    private static void ConfigureMappings()
+    {
+        TenantResponseDto.ConfigureTenantDtoMapping();
     }
 }

--- a/backend-foundation/AspNetCoreUtils/AspNetCoreUtils.csproj
+++ b/backend-foundation/AspNetCoreUtils/AspNetCoreUtils.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1"/>
+        <PackageReference Include="Mapster" Version="7.3.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.4">
             <PrivateAssets>all</PrivateAssets>

--- a/backend-foundation/AspNetCoreUtils/Extensions/CommandResultExtensions.cs
+++ b/backend-foundation/AspNetCoreUtils/Extensions/CommandResultExtensions.cs
@@ -1,3 +1,4 @@
+using Mapster;
 using Microsoft.AspNetCore.Http;
 using PlatformPlatform.Foundation.DomainModeling.Cqrs;
 
@@ -5,15 +6,24 @@ namespace PlatformPlatform.Foundation.AspNetCoreUtils.Extensions;
 
 public static class CommandResultExtensions
 {
-    public static IResult AsHttpResult<T>(this CommandResult<T> result)
-    {
-        return Results.Json(result.IsSuccess ? result.Value : result.Errors, statusCode: (int) result.StatusCode);
-    }
-
-    public static IResult AsHttpResult<T>(this CommandResult<T> result, string uri)
+    public static IResult AsHttpResult<T, TDto>(this QueryResult<T> result)
     {
         return result.IsSuccess
-            ? Results.Created(uri, result.Value)
+            ? Results.Ok(result.Value!.Adapt<TDto>())
+            : Results.NotFound(result.Error);
+    }
+
+    public static IResult AsHttpResult<T, TDto>(this CommandResult<T> result)
+    {
+        return result.IsSuccess
+            ? Results.Ok(result.Value!.Adapt<TDto>())
+            : Results.Json(result.Errors, statusCode: (int) result.StatusCode);
+    }
+
+    public static IResult AsHttpResult<T, TDto>(this CommandResult<T> result, string uri)
+    {
+        return result.IsSuccess
+            ? Results.Created(uri, result.Value!.Adapt<TDto>())
             : Results.Json(result.Errors, statusCode: (int) result.StatusCode);
     }
 }

--- a/backend-foundation/DomainModeling/DomainModelingConfiguration.cs
+++ b/backend-foundation/DomainModeling/DomainModelingConfiguration.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using JetBrains.Annotations;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using PlatformPlatform.Foundation.DomainModeling.Behaviors;
@@ -7,6 +8,7 @@ namespace PlatformPlatform.Foundation.DomainModeling;
 
 public static class DomainModelingConfiguration
 {
+    [UsedImplicitly]
     public static IServiceCollection AddDomainModelingServices(this IServiceCollection services, Assembly assembly)
     {
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(UnitOfWorkPipelineBehavior<,>));


### PR DESCRIPTION
### Summary & Motivation

Relocate TenantDTO to WebApi and modify commands and queries to return domain entities. Enhance CommandResultExtensions to accept domain entity and DTO as generic parameters, streamlining and standardizing the minimal API endpoints.

Flatten the commands and queries namespace in the Application Layer for better organization. Update tests accordingly.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
