### PR TITLE
Optimize http response error messages

### DIFF
--- a/account-management/Application/Tenants/Commands/DeleteTenantCommand.cs
+++ b/account-management/Application/Tenants/Commands/DeleteTenantCommand.cs
@@ -2,7 +2,6 @@ using System.Net;
 using MediatR;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.DomainModeling.Cqrs;
-using PlatformPlatform.Foundation.DomainModeling.Validation;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 
@@ -22,8 +21,7 @@ public sealed class DeleteTenantCommandHandler : IRequestHandler<DeleteTenantCom
         var tenant = await _tenantRepository.GetByIdAsync(command.Id, cancellationToken);
         if (tenant is null)
         {
-            return CommandResult<Tenant>.Failure(new[] {new PropertyError("TenantId", "Tenant not found.")},
-                HttpStatusCode.NotFound);
+            return CommandResult<Tenant>.Failure($"Tenant with id '{command.Id}' not found.", HttpStatusCode.NotFound);
         }
 
         _tenantRepository.Remove(tenant);

--- a/account-management/Application/Tenants/Commands/UpdateTenantCommand.cs
+++ b/account-management/Application/Tenants/Commands/UpdateTenantCommand.cs
@@ -2,11 +2,10 @@ using System.Net;
 using MediatR;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.Foundation.DomainModeling.Cqrs;
-using PlatformPlatform.Foundation.DomainModeling.Validation;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants.Commands;
 
-public sealed record UpdateTenantCommand(TenantId TenantId, string Name, string Email, string? Phone)
+public sealed record UpdateTenantCommand(TenantId Id, string Name, string Email, string? Phone)
     : IRequest<CommandResult<Tenant>>;
 
 public sealed class UpdateTenantCommandHandler : IRequestHandler<UpdateTenantCommand, CommandResult<Tenant>>
@@ -20,12 +19,11 @@ public sealed class UpdateTenantCommandHandler : IRequestHandler<UpdateTenantCom
 
     public async Task<CommandResult<Tenant>> Handle(UpdateTenantCommand command, CancellationToken cancellationToken)
     {
-        var tenant = await _tenantRepository.GetByIdAsync(command.TenantId, cancellationToken);
+        var tenant = await _tenantRepository.GetByIdAsync(command.Id, cancellationToken);
 
         if (tenant is null)
         {
-            return CommandResult<Tenant>.Failure(new[] {new PropertyError("TenantId", "Tenant not found.")},
-                HttpStatusCode.NotFound);
+            return CommandResult<Tenant>.Failure($"Tenant with id '{command.Id}' not found.", HttpStatusCode.NotFound);
         }
 
         var propertyErrors = TenantValidation.ValidateName(command.Name).Errors

--- a/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
+++ b/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
@@ -100,11 +100,11 @@ public sealed class TenantEndpointsTests : IDisposable
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var errors = await response.Content.ReadFromJsonAsync<PropertyError[]>();
+        var errors = await response.Content.ReadFromJsonAsync<AttributeError[]>();
         errors!.Length.Should().BeGreaterThan(0);
-        errors.Should().Contain(new PropertyError("Subdomain",
+        errors.Should().Contain(new AttributeError("Subdomain",
             "Subdomains should be 3 to 30 lowercase alphanumeric characters."));
-        errors.Should().Contain(new PropertyError("Email",
+        errors.Should().Contain(new AttributeError("Email",
             "Email must be a valid email address and not exceed 100 characters."));
 
         response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
@@ -130,7 +130,6 @@ public sealed class TenantEndpointsTests : IDisposable
 
         var expectedBody =
             $@"{{""id"":""{tenantId}"",""createdAt"":""{createdAt}"",""modifiedAt"":null,""name"":""{tenantName}"",""state"":0,""email"":""foo@tenant1.com"",""phone"":""1234567890""}}";
-
         var responseBody = await response.Content.ReadAsStringAsync();
         responseBody.Should().Be(expectedBody);
     }
@@ -171,7 +170,6 @@ public sealed class TenantEndpointsTests : IDisposable
         response.EnsureSuccessStatusCode();
 
         var tenantDto = await response.Content.ReadFromJsonAsync<TenantResponseDto>();
-
         tenantDto!.Name.Should().Be("UpdatedName");
         tenantDto.Email.Should().Be("updated@tenant1.com");
         tenantDto.Phone.Should().Be("0987654321");
@@ -208,6 +206,7 @@ public sealed class TenantEndpointsTests : IDisposable
 
         //Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
         const string expectedBody = $@"{{""message"":""Tenant with id '{nonExistingTenantId}' not found.""}}";
         var responseBody = await response.Content.ReadAsStringAsync();
         responseBody.Should().Be(expectedBody);
@@ -223,6 +222,7 @@ public sealed class TenantEndpointsTests : IDisposable
         // Act
         var response = await httpClient.DeleteAsync($"/tenants/{nonExistingTenantId}");
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
         const string expectedBody = $@"{{""message"":""Tenant with id '{nonExistingTenantId}' not found.""}}";
         var responseBody = await response.Content.ReadAsStringAsync();
         responseBody.Should().Be(expectedBody);

--- a/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
+++ b/account-management/Tests/WebApi/Endpoints/TenantEndpointsTests.cs
@@ -148,6 +148,10 @@ public sealed class TenantEndpointsTests : IDisposable
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var expectedBody = $@"{{""message"":""Tenant with id '{nonExistingTenantId}' not found.""}}";
+        var responseBody = await response.Content.ReadAsStringAsync();
+        responseBody.Should().Be(expectedBody);
     }
 
     [Fact]
@@ -204,6 +208,9 @@ public sealed class TenantEndpointsTests : IDisposable
 
         //Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        const string expectedBody = $@"{{""message"":""Tenant with id '{nonExistingTenantId}' not found.""}}";
+        var responseBody = await response.Content.ReadAsStringAsync();
+        responseBody.Should().Be(expectedBody);
     }
 
     [Fact]
@@ -216,6 +223,9 @@ public sealed class TenantEndpointsTests : IDisposable
         // Act
         var response = await httpClient.DeleteAsync($"/tenants/{nonExistingTenantId}");
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        const string expectedBody = $@"{{""message"":""Tenant with id '{nonExistingTenantId}' not found.""}}";
+        var responseBody = await response.Content.ReadAsStringAsync();
+        responseBody.Should().Be(expectedBody);
     }
 
     [Fact]

--- a/backend-foundation/AspNetCoreUtils/Extensions/CommandResultExtensions.cs
+++ b/backend-foundation/AspNetCoreUtils/Extensions/CommandResultExtensions.cs
@@ -15,9 +15,14 @@ public static class CommandResultExtensions
 
     public static IResult AsHttpResult<T, TDto>(this CommandResult<T> result)
     {
-        return result.IsSuccess
-            ? Results.Ok(result.Value!.Adapt<TDto>())
-            : Results.Json(result.Errors, statusCode: (int) result.StatusCode);
+        if (result.IsSuccess)
+        {
+            return Results.Ok(result.Value!.Adapt<TDto>());
+        }
+
+        return result.Errors.Length > 0
+            ? Results.Json(result.Errors, statusCode: (int) result.StatusCode)
+            : Results.Json(result.Error, statusCode: (int) result.StatusCode);
     }
 
     public static IResult AsHttpResult<T, TDto>(this CommandResult<T> result, string uri)

--- a/backend-foundation/AspNetCoreUtils/Extensions/CommandResultExtensions.cs
+++ b/backend-foundation/AspNetCoreUtils/Extensions/CommandResultExtensions.cs
@@ -10,7 +10,7 @@ public static class CommandResultExtensions
     {
         return result.IsSuccess
             ? Results.Ok(result.Value!.Adapt<TDto>())
-            : Results.NotFound(result.Error);
+            : Results.NotFound(result.ErrorMessage);
     }
 
     public static IResult AsHttpResult<T, TDto>(this CommandResult<T> result)
@@ -22,7 +22,7 @@ public static class CommandResultExtensions
 
         return result.Errors.Length > 0
             ? Results.Json(result.Errors, statusCode: (int) result.StatusCode)
-            : Results.Json(result.Error, statusCode: (int) result.StatusCode);
+            : Results.Json(result.ErrorMessage, statusCode: (int) result.StatusCode);
     }
 
     public static IResult AsHttpResult<T, TDto>(this CommandResult<T> result, string uri)

--- a/backend-foundation/DomainModeling/Cqrs/CommandResult.cs
+++ b/backend-foundation/DomainModeling/Cqrs/CommandResult.cs
@@ -6,11 +6,11 @@ namespace PlatformPlatform.Foundation.DomainModeling.Cqrs;
 /// <summary>
 ///     All commands should return a <see cref="CommandResult{T}" />. This is used to indicate if the command was
 ///     successful or not. If the command was successful, the <see cref="CommandResult{T}" /> will contain the result of
-///     the command. If the command was not successful, it will contain a collection of <see cref="PropertyError" />.
+///     the command. If the command was not successful, it will contain a collection of <see cref="AttributeError" />.
 /// </summary>
 public sealed class CommandResult<T>
 {
-    private CommandResult(bool isSuccess, T? value, PropertyError[] errors, HttpStatusCode statusCode)
+    private CommandResult(bool isSuccess, T? value, AttributeError[] errors, HttpStatusCode statusCode)
     {
         IsSuccess = isSuccess;
         Value = value;
@@ -18,12 +18,12 @@ public sealed class CommandResult<T>
         Errors = errors;
     }
 
-    private CommandResult(bool isSuccess, QueryError error, HttpStatusCode statusCode)
+    private CommandResult(bool isSuccess, ErrorMessage errorMessage, HttpStatusCode statusCode)
     {
         IsSuccess = isSuccess;
         StatusCode = statusCode;
-        Error = error;
-        Errors = Array.Empty<PropertyError>();
+        ErrorMessage = errorMessage;
+        Errors = Array.Empty<AttributeError>();
     }
 
     public bool IsSuccess { get; }
@@ -32,22 +32,22 @@ public sealed class CommandResult<T>
 
     public HttpStatusCode StatusCode { get; private set; }
 
-    public QueryError? Error { get; }
+    public ErrorMessage? ErrorMessage { get; }
 
-    public PropertyError[] Errors { get; }
+    public AttributeError[] Errors { get; }
 
     /// <summary>
     ///     Use this to indicate a error when doing a query.
     /// </summary>
     public static CommandResult<T> Failure(string message, HttpStatusCode statusCode)
     {
-        return new CommandResult<T>(false, new QueryError(message), statusCode);
+        return new CommandResult<T>(false, new ErrorMessage(message), statusCode);
     }
 
     /// <summary>
-    ///     Use this to indicate a failed command, with a collection of <see cref="PropertyError" />.
+    ///     Use this to indicate a failed command, with a collection of <see cref="AttributeError" />.
     /// </summary>
-    public static CommandResult<T> Failure(PropertyError[] errors, HttpStatusCode statusCode)
+    public static CommandResult<T> Failure(AttributeError[] errors, HttpStatusCode statusCode)
     {
         return new CommandResult<T>(false, default!, errors, statusCode);
     }
@@ -58,7 +58,7 @@ public sealed class CommandResult<T>
     /// </summary>
     public static CommandResult<T> Success(T? value, HttpStatusCode statusCode = HttpStatusCode.OK)
     {
-        return new CommandResult<T>(true, value, Array.Empty<PropertyError>(), statusCode);
+        return new CommandResult<T>(true, value, Array.Empty<AttributeError>(), statusCode);
     }
 
     /// <summary>

--- a/backend-foundation/DomainModeling/Cqrs/CommandResult.cs
+++ b/backend-foundation/DomainModeling/Cqrs/CommandResult.cs
@@ -14,8 +14,16 @@ public sealed class CommandResult<T>
     {
         IsSuccess = isSuccess;
         Value = value;
-        Errors = errors;
         StatusCode = statusCode;
+        Errors = errors;
+    }
+
+    private CommandResult(bool isSuccess, QueryError error, HttpStatusCode statusCode)
+    {
+        IsSuccess = isSuccess;
+        StatusCode = statusCode;
+        Error = error;
+        Errors = Array.Empty<PropertyError>();
     }
 
     public bool IsSuccess { get; }
@@ -24,7 +32,17 @@ public sealed class CommandResult<T>
 
     public HttpStatusCode StatusCode { get; private set; }
 
+    public QueryError? Error { get; }
+
     public PropertyError[] Errors { get; }
+
+    /// <summary>
+    ///     Use this to indicate a error when doing a query.
+    /// </summary>
+    public static CommandResult<T> Failure(string message, HttpStatusCode statusCode)
+    {
+        return new CommandResult<T>(false, new QueryError(message), statusCode);
+    }
 
     /// <summary>
     ///     Use this to indicate a failed command, with a collection of <see cref="PropertyError" />.

--- a/backend-foundation/DomainModeling/Cqrs/QueryResult.cs
+++ b/backend-foundation/DomainModeling/Cqrs/QueryResult.cs
@@ -1,36 +1,34 @@
 using JetBrains.Annotations;
+using PlatformPlatform.Foundation.DomainModeling.Validation;
 
 namespace PlatformPlatform.Foundation.DomainModeling.Cqrs;
-
-[UsedImplicitly]
-public sealed record QueryError(string Message);
 
 /// <summary>
 ///     All queries should return a <see cref="QueryResult{T}" />. This is used to indicate if the query was successful
 ///     or not. If the query was successful, the <see cref="QueryResult{T}" /> will contain the result of the query.
-///     If the query was not successful, it will contain a <see cref="QueryError" />
+///     If the query was not successful, it will contain a <see cref="ErrorMessage" />
 /// </summary>
 public sealed class QueryResult<T>
 {
-    private QueryResult(bool isSuccess, T value, QueryError error)
+    private QueryResult(bool isSuccess, T value, ErrorMessage errorMessage)
     {
         IsSuccess = isSuccess;
         Value = value;
-        Error = error;
+        ErrorMessage = errorMessage;
     }
 
     public bool IsSuccess { get; }
 
     public T Value { get; }
 
-    public QueryError Error { get; }
+    public ErrorMessage ErrorMessage { get; }
 
     /// <summary>
     ///     Use this to indicate a error when doing a query.
     /// </summary>
     public static QueryResult<T> Failure(string message)
     {
-        return new QueryResult<T>(false, default!, new QueryError(message));
+        return new QueryResult<T>(false, default!, new ErrorMessage(message));
     }
 
     /// <summary>

--- a/backend-foundation/DomainModeling/Validation/AttributeError.cs
+++ b/backend-foundation/DomainModeling/Validation/AttributeError.cs
@@ -1,0 +1,6 @@
+using JetBrains.Annotations;
+
+namespace PlatformPlatform.Foundation.DomainModeling.Validation;
+
+[UsedImplicitly]
+public sealed record AttributeError(string? PropertyName, string Message);

--- a/backend-foundation/DomainModeling/Validation/ErrorMessage.cs
+++ b/backend-foundation/DomainModeling/Validation/ErrorMessage.cs
@@ -1,0 +1,6 @@
+using JetBrains.Annotations;
+
+namespace PlatformPlatform.Foundation.DomainModeling.Validation;
+
+[UsedImplicitly]
+public sealed record ErrorMessage(string Message);

--- a/backend-foundation/DomainModeling/Validation/ValidationResult.cs
+++ b/backend-foundation/DomainModeling/Validation/ValidationResult.cs
@@ -1,18 +1,13 @@
-using JetBrains.Annotations;
-
 namespace PlatformPlatform.Foundation.DomainModeling.Validation;
-
-[UsedImplicitly]
-public sealed record PropertyError(string? PropertyName, string Message);
 
 public sealed class ValidationResult
 {
-    private ValidationResult(PropertyError[]? errors)
+    private ValidationResult(AttributeError[]? errors)
     {
-        Errors = errors ?? Array.Empty<PropertyError>();
+        Errors = errors ?? Array.Empty<AttributeError>();
     }
 
-    public PropertyError[] Errors { get; }
+    public AttributeError[] Errors { get; }
 
     public static ValidationResult Success()
     {
@@ -21,6 +16,6 @@ public sealed class ValidationResult
 
     public static ValidationResult Failure(string name, string error)
     {
-        return new ValidationResult(new[] {new PropertyError(name, error)});
+        return new ValidationResult(new[] {new AttributeError(name, error)});
     }
 }


### PR DESCRIPTION
### Summary & Motivation

Modify 'NotFound' command endpoints to return an error message, similar to Query endpoints for consistent error handling.

Rename PropertyError to AttributeError and QueryError to ErrorMessage for clearer identification and understanding of the error types.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
