### PR TITLE
Change User to be associated with a Tenant and block deletion of tenants with users

### DIFF
--- a/account-management/Api/Api.csproj
+++ b/account-management/Api/Api.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.4">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/account-management/Api/ApiConfiguration.cs
+++ b/account-management/Api/ApiConfiguration.cs
@@ -9,7 +9,7 @@ public static class WebApiConfiguration
     public static readonly Assembly Assembly = Assembly.GetExecutingAssembly();
 
     [UsedImplicitly]
-    public static IServiceCollection AddWebApiServices(this IServiceCollection services)
+    public static IServiceCollection AddApiServices(this IServiceCollection services)
     {
         services.AddCommonServices();
 

--- a/account-management/Api/Program.cs
+++ b/account-management/Api/Program.cs
@@ -12,7 +12,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services
     .AddApplicationServices()
     .AddInfrastructureServices(builder.Configuration)
-    .AddWebApiServices();
+    .AddApiServices();
 
 var app = builder.Build();
 

--- a/account-management/Api/Tenants/TenantContractsV1.cs
+++ b/account-management/Api/Tenants/TenantContractsV1.cs
@@ -8,20 +8,6 @@ public sealed record CreateTenantRequest(string Name, string Subdomain, string E
 
 public sealed record UpdateTenantRequest(string Name, string Email, string? Phone);
 
-[UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed record TenantResponseDto
-{
-    public required string Id { get; init; }
-
-    public required DateTime CreatedAt { get; init; }
-
-    public required DateTime? ModifiedAt { get; init; }
-
-    public required string Name { get; init; }
-
-    public TenantState State { get; init; }
-
-    public required string Email { get; init; }
-
-    public string? Phone { get; init; }
-}
+[UsedImplicitly]
+public sealed record TenantResponseDto(string Id, DateTime CreatedAt, DateTime? ModifiedAt, string Name,
+    TenantState State, string Email, string? Phone);

--- a/account-management/Api/Users/UserContractsV1.cs
+++ b/account-management/Api/Users/UserContractsV1.cs
@@ -8,16 +8,6 @@ public sealed record CreateUserRequest(string Email, UserRole UserRole);
 
 public sealed record UpdateUserRequest(string Email, UserRole UserRole);
 
-[UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed record UserResponseDto
-{
-    public required string Id { get; init; }
-
-    public required DateTime CreatedAt { get; init; }
-
-    public required DateTime? ModifiedAt { get; init; }
-
-    public required string Email { get; init; }
-
-    public UserRole UserRole { get; init; }
-}
+[UsedImplicitly]
+public sealed record UserResponseDto(string Id, DateTime CreatedAt, DateTime? ModifiedAt, string Email,
+    UserRole UserRole);

--- a/account-management/Api/Users/UserContractsV1.cs
+++ b/account-management/Api/Users/UserContractsV1.cs
@@ -4,7 +4,7 @@ using PlatformPlatform.AccountManagement.Domain.Users;
 namespace PlatformPlatform.AccountManagement.Api.Users;
 
 [UsedImplicitly]
-public sealed record CreateUserRequest(string Email, UserRole UserRole);
+public sealed record CreateUserRequest(string TenantId, string Email, UserRole UserRole);
 
 public sealed record UpdateUserRequest(string Email, UserRole UserRole);
 

--- a/account-management/Application/Tenants/CreateTenant.cs
+++ b/account-management/Application/Tenants/CreateTenant.cs
@@ -57,7 +57,8 @@ public static class CreateTenant
             RuleFor(x => x.Subdomain)
                 .Length(3, 30).Matches(@"^[a-z0-9]+$")
                 .WithMessage("Subdomain must be between 3-30 alphanumeric and lowercase characters.")
-                .MustAsync(async (subdomain, token) => await repository.IsSubdomainFreeAsync(subdomain, token))
+                .MustAsync(async (subdomain, cancellationToken) =>
+                    await repository.IsSubdomainFreeAsync(subdomain, cancellationToken))
                 .WithMessage("The subdomain is not available.")
                 .When(x => !string.IsNullOrEmpty(x.Subdomain));
         }

--- a/account-management/Application/Tenants/CreateTenant.cs
+++ b/account-management/Application/Tenants/CreateTenant.cs
@@ -30,11 +30,11 @@ public static class CreateTenant
             var tenant = Tenant.Create(command.Name, command.Subdomain, command.Email, command.Phone);
             await _tenantRepository.AddAsync(tenant, cancellationToken);
 
-            await CreateTenantOwner(tenant.Id, command.Email, cancellationToken);
+            await CreateTenantOwnerAsync(tenant.Id, command.Email, cancellationToken);
             return tenant;
         }
 
-        private async Task CreateTenantOwner(TenantId tenantId, string tenantOwnerEmail,
+        private async Task CreateTenantOwnerAsync(TenantId tenantId, string tenantOwnerEmail,
             CancellationToken cancellationToken)
         {
             var createTenantOwnerUserCommand = new CreateUser.Command(tenantId, tenantOwnerEmail, UserRole.TenantOwner);
@@ -43,7 +43,7 @@ public static class CreateTenant
             if (!result.IsSuccess)
             {
                 throw new InvalidOperationException(
-                    $"Failed to create a TenantOwner user for tenant. Reason: {result.ErrorMessage}");
+                    $"Failed to create a TenantOwner user for tenant. Reason: {result.GetErrorSummary()}");
             }
         }
     }

--- a/account-management/Application/Tenants/DeleteTenant.cs
+++ b/account-management/Application/Tenants/DeleteTenant.cs
@@ -1,5 +1,8 @@
+using FluentValidation;
+using JetBrains.Annotations;
 using MediatR;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
+using PlatformPlatform.AccountManagement.Domain.Users;
 using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants;
@@ -27,6 +30,17 @@ public static class DeleteTenant
 
             _tenantRepository.Remove(tenant);
             return Result<Tenant>.NoContent();
+        }
+    }
+
+    [UsedImplicitly]
+    public sealed class Validator : AbstractValidator<Command>
+    {
+        public Validator(IUserRepository userRepository)
+        {
+            RuleFor(x => x.Id)
+                .MustAsync(async (tenantId, token) => await userRepository.CountTenantUsersAsync(tenantId, token) == 0)
+                .WithMessage("All users must be deleted before the tenant can be deleted.");
         }
     }
 }

--- a/account-management/Application/Tenants/DeleteTenant.cs
+++ b/account-management/Application/Tenants/DeleteTenant.cs
@@ -39,7 +39,8 @@ public static class DeleteTenant
         public Validator(IUserRepository userRepository)
         {
             RuleFor(x => x.Id)
-                .MustAsync(async (tenantId, token) => await userRepository.CountTenantUsersAsync(tenantId, token) == 0)
+                .MustAsync(async (tenantId, cancellationToken) =>
+                    await userRepository.CountTenantUsersAsync(tenantId, cancellationToken) == 0)
                 .WithMessage("All users must be deleted before the tenant can be deleted.");
         }
     }

--- a/account-management/Application/Users/CreateUser.cs
+++ b/account-management/Application/Users/CreateUser.cs
@@ -36,7 +36,8 @@ public static class CreateUser
         public Validator(IUserRepository repository)
         {
             RuleFor(x => x)
-                .MustAsync(async (x, token) => await repository.IsEmailFreeAsync(x.TenantId, x.Email, token))
+                .MustAsync(async (x, cancellationToken)
+                    => await repository.IsEmailFreeAsync(x.TenantId, x.Email, cancellationToken))
                 .WithMessage(x => $"The email '{x.Email}' is already in use by another user on this tenant.")
                 .When(x => !string.IsNullOrEmpty(x.Email));
         }

--- a/account-management/Application/Users/CreateUser.cs
+++ b/account-management/Application/Users/CreateUser.cs
@@ -33,8 +33,14 @@ public static class CreateUser
     [UsedImplicitly]
     public sealed class Validator : UserValidator<Command>
     {
-        public Validator(IUserRepository repository)
+        public Validator(IUserRepository repository, ITenantRepository tenantRepository)
         {
+            RuleFor(x => x.TenantId)
+                .MustAsync(async (tenantId, cancellationToken) =>
+                    await tenantRepository.ExistsAsync(tenantId, cancellationToken))
+                .WithMessage(x => $"The tenant '{x.TenantId}' does not exist.")
+                .When(x => !string.IsNullOrEmpty(x.Email));
+
             RuleFor(x => x)
                 .MustAsync(async (x, cancellationToken)
                     => await repository.IsEmailFreeAsync(x.TenantId, x.Email, cancellationToken))

--- a/account-management/Application/Users/CreateUser.cs
+++ b/account-management/Application/Users/CreateUser.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using JetBrains.Annotations;
 using MediatR;
+using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.AccountManagement.Domain.Users;
 using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
@@ -8,7 +9,7 @@ namespace PlatformPlatform.AccountManagement.Application.Users;
 
 public static class CreateUser
 {
-    public sealed record Command(string Email, UserRole UserRole)
+    public sealed record Command(TenantId TenantId, string Email, UserRole UserRole)
         : ICommand, IUserValidation, IRequest<Result<User>>;
 
     [UsedImplicitly]
@@ -23,7 +24,7 @@ public static class CreateUser
 
         public async Task<Result<User>> Handle(Command command, CancellationToken cancellationToken)
         {
-            var user = User.Create(command.Email, command.UserRole);
+            var user = User.Create(command.TenantId, command.Email, command.UserRole);
             await _userRepository.AddAsync(user, cancellationToken);
             return user;
         }
@@ -34,9 +35,9 @@ public static class CreateUser
     {
         public Validator(IUserRepository repository)
         {
-            RuleFor(x => x.Email)
-                .MustAsync(async (email, token) => await repository.IsEmailFreeAsync(email, token))
-                .WithMessage(x => $"The email '{x.Email}' is already in use by another user.")
+            RuleFor(x => x)
+                .MustAsync(async (x, token) => await repository.IsEmailFreeAsync(x.TenantId, x.Email, token))
+                .WithMessage(x => $"The email '{x.Email}' is already in use by another user on this tenant.")
                 .When(x => !string.IsNullOrEmpty(x.Email));
         }
     }

--- a/account-management/Domain/Users/IUserRepository.cs
+++ b/account-management/Domain/Users/IUserRepository.cs
@@ -6,4 +6,6 @@ namespace PlatformPlatform.AccountManagement.Domain.Users;
 public interface IUserRepository : IRepository<User, UserId>
 {
     Task<bool> IsEmailFreeAsync(TenantId tenantId, string email, CancellationToken cancellationToken);
+
+    Task<int> CountTenantUsersAsync(TenantId tenantId, CancellationToken cancellationToken);
 }

--- a/account-management/Domain/Users/IUserRepository.cs
+++ b/account-management/Domain/Users/IUserRepository.cs
@@ -1,8 +1,9 @@
+using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.SharedKernel.DomainCore.Persistence;
 
 namespace PlatformPlatform.AccountManagement.Domain.Users;
 
 public interface IUserRepository : IRepository<User, UserId>
 {
-    Task<bool> IsEmailFreeAsync(string email, CancellationToken cancellationToken);
+    Task<bool> IsEmailFreeAsync(TenantId tenantId, string email, CancellationToken cancellationToken);
 }

--- a/account-management/Domain/Users/User.cs
+++ b/account-management/Domain/Users/User.cs
@@ -1,22 +1,26 @@
+using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.SharedKernel.DomainCore.Entities;
 
 namespace PlatformPlatform.AccountManagement.Domain.Users;
 
 public sealed class User : AggregateRoot<UserId>
 {
-    internal User(string email, UserRole userRole) : base(UserId.NewId())
+    internal User(TenantId tenantId, string email, UserRole userRole) : base(UserId.NewId())
     {
+        TenantId = tenantId;
         Email = email;
         UserRole = userRole;
     }
+
+    public TenantId TenantId { get; }
 
     public string Email { get; private set; }
 
     public UserRole UserRole { get; private set; }
 
-    public static User Create(string email, UserRole userRole)
+    public static User Create(TenantId tenantId, string email, UserRole userRole)
     {
-        return new User(email, userRole);
+        return new User(tenantId, email, userRole);
     }
 
     public void Update(string email, UserRole userRole)

--- a/account-management/Infrastructure/AccountManagementDbContext.cs
+++ b/account-management/Infrastructure/AccountManagementDbContext.cs
@@ -20,7 +20,7 @@ public sealed class AccountManagementDbContext : SharedKernelDbContext<AccountMa
         base.OnModelCreating(modelBuilder);
 
         // Ensures the strongly typed IDs can be saved and read by entity framework as the underlying type.
-        modelBuilder.Entity<Tenant>().ConfigureStronglyTypedId<Tenant, TenantId>();
-        modelBuilder.Entity<User>().ConfigureStronglyTypedId<User, UserId>();
+        modelBuilder.MapStronglyTypedId<Tenant, TenantId>(t => t.Id);
+        modelBuilder.MapStronglyTypedId<User, UserId>(u => u.Id);
     }
 }

--- a/account-management/Infrastructure/AccountManagementDbContext.cs
+++ b/account-management/Infrastructure/AccountManagementDbContext.cs
@@ -19,9 +19,13 @@ public sealed class AccountManagementDbContext : SharedKernelDbContext<AccountMa
     {
         base.OnModelCreating(modelBuilder);
 
-        // Ensures the strongly typed IDs can be saved and read by entity framework as the underlying type.
+        // Tenant
         modelBuilder.MapStronglyTypedId<Tenant, TenantId>(t => t.Id);
+
+        // User
         modelBuilder.MapStronglyTypedId<User, UserId>(u => u.Id);
         modelBuilder.MapStronglyTypedId<User, TenantId>(u => u.TenantId);
+        modelBuilder.Entity<User>().HasOne<Tenant>().WithMany().HasForeignKey(u => u.TenantId)
+            .HasPrincipalKey(t => t.Id);
     }
 }

--- a/account-management/Infrastructure/AccountManagementDbContext.cs
+++ b/account-management/Infrastructure/AccountManagementDbContext.cs
@@ -22,5 +22,6 @@ public sealed class AccountManagementDbContext : SharedKernelDbContext<AccountMa
         // Ensures the strongly typed IDs can be saved and read by entity framework as the underlying type.
         modelBuilder.MapStronglyTypedId<Tenant, TenantId>(t => t.Id);
         modelBuilder.MapStronglyTypedId<User, UserId>(u => u.Id);
+        modelBuilder.MapStronglyTypedId<User, TenantId>(u => u.TenantId);
     }
 }

--- a/account-management/Infrastructure/Migrations/20230529195123_Add_Users.Designer.cs
+++ b/account-management/Infrastructure/Migrations/20230529195123_Add_Users.Designer.cs
@@ -27,6 +27,9 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
 
             modelBuilder.Entity("PlatformPlatform.AccountManagement.Domain.Users.User", b =>
                 {
+                    b.Property<long>("TenantId")
+                        .HasColumnType("bigint");
+
                     b.Property<long>("Id")
                         .HasColumnType("bigint");
 
@@ -48,6 +51,14 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("Users");
+                });
+
+            modelBuilder.Entity("PlatformPlatform.AccountManagement.Domain.Users.User", b =>
+                {
+                    b.HasOne("PlatformPlatform.AccountManagement.Domain.Tenants.Tenant", null)
+                        .WithMany()
+                        .HasForeignKey("TenantId")
+                        .IsRequired();
                 });
 #pragma warning restore 612, 618
         }

--- a/account-management/Infrastructure/Migrations/20230529195123_Add_Users.cs
+++ b/account-management/Infrastructure/Migrations/20230529195123_Add_Users.cs
@@ -15,6 +15,7 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
                 name: "Users",
                 columns: table => new
                 {
+                    TenantId = table.Column<long>(type: "bigint", nullable: false),
                     Id = table.Column<long>(type: "bigint", nullable: false),
                     CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
                     ModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
@@ -25,6 +26,18 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
                 {
                     table.PrimaryKey("PK_Users", x => x.Id);
                 });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_TenantId",
+                table: "Users",
+                column: "TenantId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Users_Tenants_TenantId",
+                table: "Users",
+                column: "TenantId",
+                principalTable: "Tenants",
+                principalColumn: "Id");
         }
     }
 }

--- a/account-management/Infrastructure/Migrations/AccountManagementDbContextModelSnapshot.cs
+++ b/account-management/Infrastructure/Migrations/AccountManagementDbContextModelSnapshot.cs
@@ -87,6 +87,14 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
 
                     b.ToTable("Users");
                 });
+
+            modelBuilder.Entity("PlatformPlatform.AccountManagement.Domain.Users.User", b =>
+                {
+                    b.HasOne("PlatformPlatform.AccountManagement.Domain.Tenants.Tenant", null)
+                        .WithMany()
+                        .HasForeignKey("TenantId")
+                        .IsRequired();
+                });
 #pragma warning restore 612, 618
         }
     }

--- a/account-management/Infrastructure/Users/UserRepository.cs
+++ b/account-management/Infrastructure/Users/UserRepository.cs
@@ -1,5 +1,6 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using PlatformPlatform.AccountManagement.Domain.Tenants;
 using PlatformPlatform.AccountManagement.Domain.Users;
 using PlatformPlatform.SharedKernel.InfrastructureCore.Persistence;
 
@@ -12,8 +13,8 @@ internal sealed class UserRepository : RepositoryBase<User, UserId>, IUserReposi
     {
     }
 
-    public Task<bool> IsEmailFreeAsync(string email, CancellationToken cancellationToken)
+    public async Task<bool> IsEmailFreeAsync(TenantId tenantId, string email, CancellationToken cancellationToken)
     {
-        return DbSet.AllAsync(user => user.Email != email, cancellationToken);
+        return await DbSet.AnyAsync(u => u.TenantId == tenantId && u.Email == email, cancellationToken);
     }
 }

--- a/account-management/Infrastructure/Users/UserRepository.cs
+++ b/account-management/Infrastructure/Users/UserRepository.cs
@@ -15,6 +15,11 @@ internal sealed class UserRepository : RepositoryBase<User, UserId>, IUserReposi
 
     public async Task<bool> IsEmailFreeAsync(TenantId tenantId, string email, CancellationToken cancellationToken)
     {
-        return await DbSet.AnyAsync(u => u.TenantId == tenantId && u.Email == email, cancellationToken);
+        return !await DbSet.AnyAsync(u => u.TenantId == tenantId && u.Email == email, cancellationToken);
+    }
+
+    public Task<int> CountTenantUsersAsync(TenantId tenantId, CancellationToken cancellationToken)
+    {
+        return DbSet.CountAsync(u => u.TenantId == tenantId, cancellationToken);
     }
 }

--- a/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
+++ b/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
@@ -86,7 +86,7 @@ public sealed class TenantEndpointsTests : IDisposable
     }
 
     [Fact]
-    public async Task CreateTenant_WhenInValid_ShouldNotCreateTenant()
+    public async Task CreateTenant_WhenInvalid_ShouldNotCreateTenant()
     {
         // Arrange
         var httpClient = _webApplicationFactory.CreateClient();

--- a/account-management/Tests/Api/Users/UserEndpointsTests.cs
+++ b/account-management/Tests/Api/Users/UserEndpointsTests.cs
@@ -64,7 +64,7 @@ public sealed class UserEndpointsTests : IDisposable
 
         // Act
         var response = await httpClient.PostAsJsonAsync("/api/users/v1",
-            new CreateUserRequest("test@test.com", UserRole.TenantUser)
+            new CreateUserRequest(DatabaseSeeder.Tenant1Id.ToString(), "test@test.com", UserRole.TenantUser)
         );
 
         // Assert
@@ -93,7 +93,7 @@ public sealed class UserEndpointsTests : IDisposable
 
         // Act
         var response = await httpClient.PostAsJsonAsync("/api/users/v1",
-            new CreateUserRequest("a", UserRole.TenantOwner)
+            new CreateUserRequest(DatabaseSeeder.Tenant1Id.ToString(), "a", UserRole.TenantOwner)
         );
 
         // Assert

--- a/account-management/Tests/DatabaseSeeder.cs
+++ b/account-management/Tests/DatabaseSeeder.cs
@@ -32,7 +32,7 @@ public class DatabaseSeeder
 
     private void SeedUsers()
     {
-        var user1 = new User(User1Email, UserRole.TenantUser)
+        var user1 = new User(Tenant1Id, User1Email, UserRole.TenantUser)
         {
             Id = User1Id
         };

--- a/account-management/Tests/Tests.csproj
+++ b/account-management/Tests/Tests.csproj
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.10.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.4"/>
+        <PackageReference Include="FluentAssertions" Version="6.11.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1"/>
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
         <PackageReference Include="NSubstitute" Version="5.0.0"/>
         <PackageReference Include="xunit" Version="2.4.2"/>

--- a/shared-kernel/ApplicationCore/Behaviors/UnitOfWorkPipelineBehaviorConcurrentCounter.cs
+++ b/shared-kernel/ApplicationCore/Behaviors/UnitOfWorkPipelineBehaviorConcurrentCounter.cs
@@ -2,10 +2,9 @@ namespace PlatformPlatform.SharedKernel.ApplicationCore.Behaviors;
 
 /// <summary>
 ///     The UnitOfWorkPipelineBehaviorConcurrentCounter class is a concurrent counter used to count the number of
-///     concurrent requests that are being handled by the UnitOfWorkPipelineBehavior. It is used by to only commit
-///     changes to the database when all requests have been handled. This is to ensure that all changes to all
-///     aggregates and entities are committed to the database only after all command and domain events are successfully
-///     handled.
+///     concurrent requests that are being handled by the UnitOfWorkPipelineBehavior. It is used by only commit changes
+///     to the database when all requests have been handled. This is to ensure that all changes to all aggregates and
+///     entities are committed to the database only after all command and domain events are successfully handled.
 /// </summary>
 public sealed class UnitOfWorkPipelineBehaviorConcurrentCounter
 {

--- a/shared-kernel/ApplicationCore/Behaviors/ValidationPipelineBehavior.cs
+++ b/shared-kernel/ApplicationCore/Behaviors/ValidationPipelineBehavior.cs
@@ -57,6 +57,6 @@ public sealed class ValidationPipelineBehavior<TRequest, TResponse> : IPipelineB
     private static TResult CreateValidationResult<TResult>(ErrorDetail[] errorDetails)
         where TResult : IResult
     {
-        return (TResult) Activator.CreateInstance(typeof(TResult), null, errorDetails, HttpStatusCode.BadRequest)!;
+        return (TResult) Activator.CreateInstance(typeof(TResult), HttpStatusCode.BadRequest, null, errorDetails)!;
     }
 }

--- a/shared-kernel/ApplicationCore/Cqrs/Result.cs
+++ b/shared-kernel/ApplicationCore/Cqrs/Result.cs
@@ -54,6 +54,12 @@ public class Result<T> : IResult
 
     public HttpStatusCode StatusCode { get; }
 
+    public string GetErrorSummary()
+    {
+        return ErrorMessage?.Message
+               ?? string.Join(Environment.NewLine, Errors!.Select(ed => $"{ed.Code}: {ed.Message}"));
+    }
+
     public static Result<T> NotFound(string message)
     {
         return new Result<T>(new ErrorMessage(message), Array.Empty<ErrorDetail>(), HttpStatusCode.NotFound);

--- a/shared-kernel/ApplicationCore/Cqrs/Result.cs
+++ b/shared-kernel/ApplicationCore/Cqrs/Result.cs
@@ -30,13 +30,13 @@ public class Result<T> : IResult
 {
     private Result(T value, HttpStatusCode httpStatusCode)
     {
-        IsSuccess = true;
         Value = value;
+        IsSuccess = true;
         StatusCode = httpStatusCode;
     }
 
     [UsedImplicitly]
-    public Result(ErrorMessage errorMessage, ErrorDetail[] errors, HttpStatusCode statusCode)
+    public Result(HttpStatusCode statusCode, ErrorMessage errorMessage, ErrorDetail[] errors)
     {
         IsSuccess = false;
         StatusCode = statusCode;
@@ -48,11 +48,11 @@ public class Result<T> : IResult
 
     public bool IsSuccess { get; }
 
+    public HttpStatusCode StatusCode { get; }
+
     public ErrorMessage? ErrorMessage { get; }
 
     public ErrorDetail[]? Errors { get; }
-
-    public HttpStatusCode StatusCode { get; }
 
     public string GetErrorSummary()
     {
@@ -62,17 +62,17 @@ public class Result<T> : IResult
 
     public static Result<T> NotFound(string message)
     {
-        return new Result<T>(new ErrorMessage(message), Array.Empty<ErrorDetail>(), HttpStatusCode.NotFound);
+        return new Result<T>(HttpStatusCode.NotFound, new ErrorMessage(message), Array.Empty<ErrorDetail>());
+    }
+
+    public static Result<T> BadRequest(string message)
+    {
+        return new Result<T>(HttpStatusCode.BadRequest, new ErrorMessage(message), Array.Empty<ErrorDetail>());
     }
 
     public static Result<T> NoContent()
     {
         return new Result<T>(default!, HttpStatusCode.NoContent);
-    }
-
-    public static Result<T> BadRequest(string message)
-    {
-        return new Result<T>(new ErrorMessage(message), Array.Empty<ErrorDetail>(), HttpStatusCode.BadRequest);
     }
 
     /// <summary>

--- a/shared-kernel/DomainCore/Persistence/IRepository.cs
+++ b/shared-kernel/DomainCore/Persistence/IRepository.cs
@@ -17,6 +17,8 @@ public interface IRepository<T, in TId> where T : IAggregateRoot where TId : ICo
 {
     Task<T?> GetByIdAsync(TId id, CancellationToken cancellationToken);
 
+    Task<bool> ExistsAsync(TId id, CancellationToken cancellationToken);
+
     Task AddAsync(T aggregate, CancellationToken cancellationToken);
 
     void Update(T aggregate);

--- a/shared-kernel/InfrastructureCore/EntityFramework/ModelBuilderExtensions.cs
+++ b/shared-kernel/InfrastructureCore/EntityFramework/ModelBuilderExtensions.cs
@@ -1,8 +1,7 @@
+using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using PlatformPlatform.SharedKernel.DomainCore.Entities;
 using PlatformPlatform.SharedKernel.DomainCore.Identity;
 
 namespace PlatformPlatform.SharedKernel.InfrastructureCore.EntityFramework;
@@ -13,13 +12,13 @@ public static class ModelBuilderExtensions
     ///     This method is used to tell Entity Framework how to map a strongly typed ID to a SQL column using the
     ///     underlying type of the strongly-typed ID.
     /// </summary>
-    public static void ConfigureStronglyTypedId<T, TId>(this EntityTypeBuilder<T> entity)
-        where T : Entity<TId>
-        where TId : StronglyTypedId<TId>
+    public static void MapStronglyTypedId<T, TId>(this ModelBuilder modelBuilder, Expression<Func<T, TId>> expression)
+        where T : class where TId : StronglyTypedId<TId>
     {
-        entity
-            .Property(e => e.Id)
-            .HasConversion(v => v.Value, v => (TId) Activator.CreateInstance(typeof(TId), v)!);
+        modelBuilder
+            .Entity<T>()
+            .Property(expression)
+            .HasConversion(v => v.Value, v => (Activator.CreateInstance(typeof(TId), v) as TId)!);
     }
 
     /// <summary>

--- a/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
+++ b/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.4"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.4"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.4">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/shared-kernel/InfrastructureCore/Persistence/RepositoryBase.cs
+++ b/shared-kernel/InfrastructureCore/Persistence/RepositoryBase.cs
@@ -21,6 +21,11 @@ public abstract class RepositoryBase<T, TId> : IRepository<T, TId>
         return await DbSet.FindAsync(keyValues, cancellationToken);
     }
 
+    public async Task<bool> ExistsAsync(TId id, CancellationToken cancellationToken)
+    {
+        return DbSet.Local.Any(e => e.Id.Equals(id)) || await DbSet.AnyAsync(e => e.Id.Equals(id), cancellationToken);
+    }
+
     public async Task AddAsync(T aggregate, CancellationToken cancellationToken)
     {
         if (aggregate is null) throw new ArgumentNullException(nameof(aggregate));

--- a/shared-kernel/Tests/Tests.csproj
+++ b/shared-kernel/Tests/Tests.csproj
@@ -12,10 +12,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.10.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.4"/>
+        <PackageReference Include="FluentAssertions" Version="6.11.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1"/>
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
         <PackageReference Include="NSubstitute" Version="5.0.0"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
@@ -23,7 +23,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
### Summary & Motivation

Add a new property called TenantId to the User entity to ensure that each user is associated with a specific Tenant. Create a database migration that establishes a foreign key relationship between Users.TenantId and Tenants.Id. Update the CreateUser command to require the existence of the specified Tenant. To support this functionality, implement a new generic ExistsAsync method in the RepositoryBase class, which includes entities added to the DbContext but not yet committed to the Database (like when Creating a Tenant and TenantOwner user in the same transaction). Furthermore, implement logic to provide meaningful error messages when attempting to delete a Tenant that has associated users. To enable this, add a new method called CountTenantUsersAsync in the UserRepository class, and invoke it for validating the DeleteTenant command. Update the CreateUser command to enforce unique email addresses within a specific tenant. This modification involves adding the TenantId as a parameter to the UserRepository.IsEmailFreeAsync check.

Modify the mapping of StronglyTypedId in Entity Framework to enable the mapping of non primary key properties, such as User.TenantId.

Reorganize the parameters of the Result class constructor to match the property order and assignment. Implement a Result.GetErrorSummary() method and use it within the CreateTenant.CreateTenantOwnerAsync method.

Simplify the contract for TenantResponseDto and UserResponseDto by using a one-liner record type declaration instead of separate lines for each property.

Update the following NuGet packages to the specified versions: EF Core and Microsoft.AspNetCore.Mvc.Testing to version 7.05, Microsoft.NET.Test.Sdk to version 17.6.1, FluentAssertions to version 6.11.0, and coverlet.collector to version 6.0.0.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
