### PR TITLE
Update create endpoints to return ApiResult instead of ApiResult<TenantId>

### DIFF
--- a/account-management/Api/Tenants/TenantEndpoints.cs
+++ b/account-management/Api/Tenants/TenantEndpoints.cs
@@ -23,7 +23,7 @@ public static class TenantEndpoints
         return await mediatr.Send(new GetTenant.Query(id));
     }
 
-    private static async Task<ApiResult<TenantId>> CreateTenant(CreateTenant.Command command, ISender mediatr)
+    private static async Task<ApiResult> CreateTenant(CreateTenant.Command command, ISender mediatr)
     {
         return (await mediatr.Send(command)).AddResourceUri(RoutesPrefix);
     }

--- a/account-management/Api/Tenants/TenantEndpoints.cs
+++ b/account-management/Api/Tenants/TenantEndpoints.cs
@@ -1,7 +1,7 @@
 using MediatR;
 using PlatformPlatform.AccountManagement.Application.Tenants;
 using PlatformPlatform.AccountManagement.Domain.Tenants;
-using PlatformPlatform.SharedKernel.ApiCore.HttpResults;
+using PlatformPlatform.SharedKernel.ApiCore.ApiResults;
 
 namespace PlatformPlatform.AccountManagement.Api.Tenants;
 

--- a/account-management/Api/Users/UserEndpoints.cs
+++ b/account-management/Api/Users/UserEndpoints.cs
@@ -23,7 +23,7 @@ public static class UserEndpoints
         return await mediatr.Send(new GetUser.Query(id));
     }
 
-    private static async Task<ApiResult<UserId>> CreateUser(CreateUser.Command command, ISender mediatr)
+    private static async Task<ApiResult> CreateUser(CreateUser.Command command, ISender mediatr)
     {
         return (await mediatr.Send(command)).AddResourceUri(RoutesPrefix);
     }

--- a/account-management/Api/Users/UserEndpoints.cs
+++ b/account-management/Api/Users/UserEndpoints.cs
@@ -1,7 +1,7 @@
 using MediatR;
 using PlatformPlatform.AccountManagement.Application.Users;
 using PlatformPlatform.AccountManagement.Domain.Users;
-using PlatformPlatform.SharedKernel.ApiCore.HttpResults;
+using PlatformPlatform.SharedKernel.ApiCore.ApiResults;
 
 namespace PlatformPlatform.AccountManagement.Api.Users;
 

--- a/shared-kernel/ApiCore/ApiResults/ApiResult.cs
+++ b/shared-kernel/ApiCore/ApiResults/ApiResult.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
-namespace PlatformPlatform.SharedKernel.ApiCore.HttpResults;
+namespace PlatformPlatform.SharedKernel.ApiCore.ApiResults;
 
 public partial class ApiResult : IResult
 {

--- a/shared-kernel/ApiCore/ApiResults/ApiResultExtensions.cs
+++ b/shared-kernel/ApiCore/ApiResults/ApiResultExtensions.cs
@@ -1,6 +1,6 @@
 using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
-namespace PlatformPlatform.SharedKernel.ApiCore.HttpResults;
+namespace PlatformPlatform.SharedKernel.ApiCore.ApiResults;
 
 public static class ApiResultExtensions
 {

--- a/shared-kernel/ApiCore/HttpResults/ApiResultExtensions.cs
+++ b/shared-kernel/ApiCore/HttpResults/ApiResultExtensions.cs
@@ -4,7 +4,7 @@ namespace PlatformPlatform.SharedKernel.ApiCore.HttpResults;
 
 public static class ApiResultExtensions
 {
-    public static ApiResult<T> AddResourceUri<T>(this Result<T> result, string routePrefix)
+    public static ApiResult AddResourceUri<T>(this Result<T> result, string routePrefix)
     {
         return new ApiResult<T>(result, routePrefix);
     }


### PR DESCRIPTION
### Summary & Motivation

Update the create endpoints to return ApiResult instead of ApiResult<TenantId> since the Id is already returned as part of the location header and not in the response body.

Refactor the Tenant and UserEndpointsTest to further enhance their consistency.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
