### PR TITLE
Add NUlid NuGet package and Implement generic strongly typed ID base class using Ulid

### DIFF
--- a/account-management/Api/Api.csproj
+++ b/account-management/Api/Api.csproj
@@ -18,4 +18,11 @@
         <ProjectReference Include="..\Infrastructure\Infrastructure.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/account-management/Domain/Domain.csproj
+++ b/account-management/Domain/Domain.csproj
@@ -9,10 +9,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="PlatformPlatform.AccountManagement.Tests"/>
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\..\shared-kernel\DomainCore\DomainCore.csproj"/>
     </ItemGroup>
 

--- a/account-management/Domain/Users/UserTypes.cs
+++ b/account-management/Domain/Users/UserTypes.cs
@@ -6,15 +6,15 @@ namespace PlatformPlatform.AccountManagement.Domain.Users;
 
 [TypeConverter(typeof(UserIdTypeConverter))]
 [UsedImplicitly]
-public sealed record UserId(long Value) : StronglyTypedLongId<UserId>(Value)
+public sealed record UserId(string Value) : StronglyTypedUlid<UserId>(Value)
 {
     public override string ToString()
     {
-        return Value.ToString();
+        return Value;
     }
 }
 
-public sealed class UserIdTypeConverter : StronglyTypedIdTypeConverter<long, UserId>
+public sealed class UserIdTypeConverter : StronglyTypedIdTypeConverter<string, UserId>
 {
 }
 

--- a/account-management/Infrastructure/AccountManagementDbContext.cs
+++ b/account-management/Infrastructure/AccountManagementDbContext.cs
@@ -23,7 +23,7 @@ public sealed class AccountManagementDbContext : SharedKernelDbContext<AccountMa
         modelBuilder.MapStronglyTypedId<Tenant, TenantId, string>(t => t.Id);
 
         // User
-        modelBuilder.MapStronglyTypedId<User, UserId>(u => u.Id);
+        modelBuilder.MapStronglyTypedUuid<User, UserId>(u => u.Id);
         modelBuilder.MapStronglyTypedId<User, TenantId, string>(u => u.TenantId);
         modelBuilder.Entity<User>().HasOne<Tenant>().WithMany().HasForeignKey(u => u.TenantId)
             .HasPrincipalKey(t => t.Id);

--- a/account-management/Infrastructure/Migrations/20230618152042_Initial.Designer.cs
+++ b/account-management/Infrastructure/Migrations/20230618152042_Initial.Designer.cs
@@ -12,7 +12,7 @@ using PlatformPlatform.AccountManagement.Infrastructure;
 namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
 {
     [DbContext(typeof(AccountManagementDbContext))]
-    [Migration("20230611095743_Initial")]
+    [Migration("20230618152042_Initial")]
     partial class Initial
     {
         /// <inheritdoc />
@@ -60,7 +60,7 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
                         .HasColumnType("varchar(30)");
 
                     b.Property<long>("Id")
-                        .HasColumnType("bigint");
+                        .HasColumnType("char(26)");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");

--- a/account-management/Infrastructure/Migrations/20230618152042_Initial.cs
+++ b/account-management/Infrastructure/Migrations/20230618152042_Initial.cs
@@ -34,7 +34,7 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
                 columns: table => new
                 {
                     TenantId = table.Column<string>(type: "varchar(30)", nullable: false),
-                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    Id = table.Column<long>(type: "char(26)", nullable: false),
                     CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
                     ModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     Email = table.Column<string>(type: "nvarchar(100)", nullable: false),

--- a/account-management/Infrastructure/Migrations/AccountManagementDbContextModelSnapshot.cs
+++ b/account-management/Infrastructure/Migrations/AccountManagementDbContextModelSnapshot.cs
@@ -59,7 +59,7 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
                         .HasColumnType("varchar(30)");
 
                     b.Property<long>("Id")
-                        .HasColumnType("bigint");
+                        .HasColumnType("char(26)");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");

--- a/account-management/Tests/Api/Users/UserEndpointsTests.cs
+++ b/account-management/Tests/Api/Users/UserEndpointsTests.cs
@@ -49,7 +49,7 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
     public async Task GetUser_WhenUserDoesNotExist_ShouldReturnNotFound()
     {
         // Arrange
-        var unknownUserId = Faker.RandomId();
+        var unknownUserId = Faker.RandomUlid();
 
         // Act
         var response = await TestHttpClient.GetAsync($"/api/users/{unknownUserId}");
@@ -182,7 +182,7 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
     public async Task UpdateUser_WhenUserDoesNotExists_ShouldReturnNotFound()
     {
         // Arrange
-        var unknownUserId = Faker.RandomId();
+        var unknownUserId = Faker.RandomUlid();
         var command = new UpdateUser.Command {Email = Faker.Internet.Email(), UserRole = UserRole.TenantAdmin};
 
         // Act
@@ -196,7 +196,7 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
     public async Task DeleteUser_WhenUserDoesNotExists_ShouldReturnNotFound()
     {
         // Arrange
-        var unknownUserId = Faker.RandomId();
+        var unknownUserId = Faker.RandomUlid();
 
         // Act
         var response = await TestHttpClient.DeleteAsync($"/api/users/{unknownUserId}");

--- a/account-management/Tests/DatabaseSeeder.cs
+++ b/account-management/Tests/DatabaseSeeder.cs
@@ -11,10 +11,10 @@ public class DatabaseSeeder
 
     public DatabaseSeeder(AccountManagementDbContext accountManagementDbContext)
     {
-        Tenant1 = new Tenant(new TenantId("tenant1"), "Tenant 1", "1234567890");
+        Tenant1 = Tenant.Create("tenant1", "Tenant 1", "1234567890");
         accountManagementDbContext.Tenants.AddRange(Tenant1);
 
-        User1 = new User(Tenant1.Id, "user1@test.com", UserRole.TenantUser);
+        User1 = User.Create(Tenant1.Id, "user1@test.com", UserRole.TenantUser);
         accountManagementDbContext.Users.AddRange(User1);
 
         accountManagementDbContext.SaveChanges();

--- a/account-management/Tests/FakerExtensions.cs
+++ b/account-management/Tests/FakerExtensions.cs
@@ -1,5 +1,6 @@
 using Bogus;
 using JetBrains.Annotations;
+using NUlid;
 using PlatformPlatform.SharedKernel.DomainCore.Identity;
 
 namespace PlatformPlatform.AccountManagement.Tests;
@@ -31,5 +32,11 @@ public static class FakerExtensions
     public static long RandomId(this Faker faker)
     {
         return IdGenerator.NewId();
+    }
+
+    [UsedImplicitly]
+    public static string RandomUlid(this Faker faker)
+    {
+        return Ulid.NewUlid().ToString();
     }
 }

--- a/shared-kernel/ApiCore/ApiCore.csproj
+++ b/shared-kernel/ApiCore/ApiCore.csproj
@@ -19,10 +19,6 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
     </ItemGroup>
 

--- a/shared-kernel/DomainCore/DomainCore.csproj
+++ b/shared-kernel/DomainCore/DomainCore.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1"/>
         <PackageReference Include="MediatR" Version="12.0.1"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="NUlid" Version="1.7.1"/>
     </ItemGroup>
 
 </Project>

--- a/shared-kernel/DomainCore/Identity/StronglyTypedLongId.cs
+++ b/shared-kernel/DomainCore/Identity/StronglyTypedLongId.cs
@@ -17,12 +17,6 @@ public abstract record StronglyTypedLongId<T>(long Value) : StronglyTypedId<long
     }
 
     [UsedImplicitly]
-    public static T Parse(string value)
-    {
-        return FormLong(long.Parse(value));
-    }
-
-    [UsedImplicitly]
     public static bool TryParse(string? value, out T? result)
     {
         var success = long.TryParse(value, out var parsedValue);

--- a/shared-kernel/DomainCore/Identity/StronglyTypedUlid.cs
+++ b/shared-kernel/DomainCore/Identity/StronglyTypedUlid.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using JetBrains.Annotations;
+using NUlid;
+
+namespace PlatformPlatform.SharedKernel.DomainCore.Identity;
+
+/// <summary>
+///     This is a special version of <see cref="StronglyTypedLongId{T}" /> for longs which is the recommended type to use.
+///     It uses the <see cref="IdGenerator" />  to create IDs that are chronological and guaranteed to be unique.
+/// </summary>
+public abstract record StronglyTypedUlid<T>(string Value) : StronglyTypedId<string, T>(Value)
+    where T : StronglyTypedUlid<T>
+{
+    public static T NewId()
+    {
+        var newValue = Ulid.NewUlid();
+        return FormUlid(newValue);
+    }
+
+    [UsedImplicitly]
+    public static bool TryParse(string? value, out T? result)
+    {
+        var success = Ulid.TryParse(value ?? "", out var parsedValue);
+        result = success ? FormUlid(parsedValue) : null;
+        return success;
+    }
+
+    private static T FormUlid(Ulid newValue)
+    {
+        return (T) Activator.CreateInstance(typeof(T),
+            BindingFlags.Instance | BindingFlags.Public, null, new object[] {newValue.ToString()}, null)!;
+    }
+}

--- a/shared-kernel/InfrastructureCore/EntityFramework/ModelBuilderExtensions.cs
+++ b/shared-kernel/InfrastructureCore/EntityFramework/ModelBuilderExtensions.cs
@@ -12,8 +12,19 @@ public static class ModelBuilderExtensions
     ///     This method is used to tell Entity Framework how to map a strongly typed ID to a SQL column using the
     ///     underlying type of the strongly-typed ID.
     /// </summary>
-    public static void MapStronglyTypedId<T, TId>(this ModelBuilder modelBuilder, Expression<Func<T, TId>> expression)
+    [UsedImplicitly]
+    public static void MapStronglyTypedLongId<T, TId>(this ModelBuilder modelBuilder,
+        Expression<Func<T, TId>> expression)
         where T : class where TId : StronglyTypedLongId<TId>
+    {
+        modelBuilder
+            .Entity<T>()
+            .Property(expression)
+            .HasConversion(v => v.Value, v => (Activator.CreateInstance(typeof(TId), v) as TId)!);
+    }
+
+    public static void MapStronglyTypedUuid<T, TId>(this ModelBuilder modelBuilder, Expression<Func<T, TId>> expression)
+        where T : class where TId : StronglyTypedUlid<TId>
     {
         modelBuilder
             .Entity<T>()


### PR DESCRIPTION
### Summary & Motivation

Add the NUlid NuGet package to the shared kernel to enable the use of [Ulid-based IDs](https://github.com/ulid/spec/). This allows for globally unique IDs that are roughly sorted, eliminating the need for sorting when querying and enabling better page splitting in SQL Server.

Create a generic strongly typed ID base class that utilizes Ulid. Update the UserId strongly typed ID to use this new class instead of Snowflake IDs.

Reset the database schema by changing UserId from a bigint to CHAR(26) column type to accommodate the Ulid-based IDs. Create the MapStronglyTypedUuid mapper to allow Entity Framework to read and write Ulid values.

Ensure that the Microsoft.EntityFrameworkCore.Design NuGet package is added to the AccountManagement.Api project, as it is required by the EF Database Migrations tool.

Enhance the DatabaseSeeder by introducing factory methods for creating Tenant and User entities. This modification removes the need for the InternalsVisibleTo attribute, improving encapsulation and maintainability.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
