### PR TITLE
Upgrade NuGet packages

### DIFF
--- a/account-management/Api/Api.csproj
+++ b/account-management/Api/Api.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.7">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/account-management/Tests/Tests.csproj
+++ b/account-management/Tests/Tests.csproj
@@ -27,7 +27,7 @@
         <PackageReference Include="FluentAssertions" Version="6.11.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.7"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.7"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2"/>
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
         <PackageReference Include="NJsonSchema" Version="10.9.0"/>
         <PackageReference Include="NSubstitute" Version="5.0.0"/>

--- a/account-management/Tests/Tests.csproj
+++ b/account-management/Tests/Tests.csproj
@@ -26,7 +26,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="6.11.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.7"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1"/>
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
         <PackageReference Include="NJsonSchema" Version="10.9.0"/>

--- a/account-management/Tests/Tests.csproj
+++ b/account-management/Tests/Tests.csproj
@@ -25,7 +25,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="6.11.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.7"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.7"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1"/>
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>

--- a/shared-kernel/DomainCore/DomainCore.csproj
+++ b/shared-kernel/DomainCore/DomainCore.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="IdGen" Version="3.0.3"/>
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1"/>
         <PackageReference Include="MediatR" Version="12.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1"/>
         <PackageReference Include="NUlid" Version="1.7.1"/>
     </ItemGroup>
 

--- a/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
+++ b/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
@@ -14,9 +14,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.7"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.7"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.7">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/shared-kernel/Tests/Tests.csproj
+++ b/shared-kernel/Tests/Tests.csproj
@@ -20,7 +20,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.11.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.7"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1"/>
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
         <PackageReference Include="NSubstitute" Version="5.0.0"/>

--- a/shared-kernel/Tests/Tests.csproj
+++ b/shared-kernel/Tests/Tests.csproj
@@ -19,7 +19,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.11.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.7"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.7"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1"/>
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>

--- a/shared-kernel/Tests/Tests.csproj
+++ b/shared-kernel/Tests/Tests.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="FluentAssertions" Version="6.11.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.7"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.7"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2"/>
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
         <PackageReference Include="NSubstitute" Version="5.0.0"/>
         <PackageReference Include="xunit" Version="2.4.2"/>


### PR DESCRIPTION
### Summary & Motivation

Update all NuGet packages to the latest version to incorporate the latest improvements and bug fixes:

- Upgrade EntityFrameworkCore NuGet packages from 7.0.5 to 7.0.7
- Upgrade AspNetCore.Mvc.Testing NuGet packages from 7.0.5 to 7.0.7
- Upgrade Microsoft.Extensions.Logging NuGet packages from 7.0.0 to 7.0.1
- Upgrade Microsoft.NET.Test.Sdk NuGet packages from 17.6.1 to 17.6.2
- 

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
