### PR TITLE
Update REST endpoints to use enums as strings and utilize expression-bodied methods

### DIFF
--- a/account-management/Api/Tenants/TenantEndpoints.cs
+++ b/account-management/Api/Tenants/TenantEndpoints.cs
@@ -12,29 +12,17 @@ public static class TenantEndpoints
     public static void MapTenantEndpoints(this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup(RoutesPrefix);
-        group.MapGet("/{id}", GetTenant);
-        group.MapPost("/", CreateTenant);
-        group.MapPut("/{id}", UpdateTenant);
-        group.MapDelete("/{id}", DeleteTenant);
-    }
 
-    private static async Task<ApiResult<TenantResponseDto>> GetTenant(TenantId id, ISender mediator)
-    {
-        return await mediator.Send(new GetTenant.Query(id));
-    }
+        group.MapGet("/{id}", async Task<ApiResult<TenantResponseDto>> (TenantId id, ISender mediator)
+            => await mediator.Send(new GetTenant.Query(id)));
 
-    private static async Task<ApiResult> CreateTenant(CreateTenant.Command command, ISender mediator)
-    {
-        return (await mediator.Send(command)).AddResourceUri(RoutesPrefix);
-    }
+        group.MapPost("/", async Task<ApiResult> (CreateTenant.Command command, ISender mediator)
+            => (await mediator.Send(command)).AddResourceUri(RoutesPrefix));
 
-    private static async Task<ApiResult> UpdateTenant(TenantId id, UpdateTenant.Command command, ISender mediator)
-    {
-        return await mediator.Send(command with {Id = id});
-    }
+        group.MapPut("/{id}", async Task<ApiResult> (TenantId id, UpdateTenant.Command command, ISender mediator)
+            => await mediator.Send(command with {Id = id}));
 
-    private static async Task<ApiResult> DeleteTenant(TenantId id, ISender mediator)
-    {
-        return await mediator.Send(new DeleteTenant.Command(id));
+        group.MapDelete("/{id}", async Task<ApiResult> (TenantId id, ISender mediator)
+            => await mediator.Send(new DeleteTenant.Command(id)));
     }
 }

--- a/account-management/Api/Users/UserEndpoints.cs
+++ b/account-management/Api/Users/UserEndpoints.cs
@@ -12,29 +12,17 @@ public static class UserEndpoints
     public static void MapUserEndpoints(this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup(RoutesPrefix);
-        group.MapGet("/{id}", GetUser);
-        group.MapPost("/", CreateUser);
-        group.MapPut("/{id}", UpdateUser);
-        group.MapDelete("/{id}", DeleteUser);
-    }
 
-    private static async Task<ApiResult<UserResponseDto>> GetUser(UserId id, ISender mediator)
-    {
-        return await mediator.Send(new GetUser.Query(id));
-    }
+        group.MapGet("/{id}", async Task<ApiResult<UserResponseDto>> (UserId id, ISender mediator)
+            => await mediator.Send(new GetUser.Query(id)));
 
-    private static async Task<ApiResult> CreateUser(CreateUser.Command command, ISender mediator)
-    {
-        return (await mediator.Send(command)).AddResourceUri(RoutesPrefix);
-    }
+        group.MapPost("/", async Task<ApiResult> (CreateUser.Command command, ISender mediator)
+            => (await mediator.Send(command)).AddResourceUri(RoutesPrefix));
 
-    private static async Task<ApiResult> UpdateUser(UserId id, UpdateUser.Command command, ISender mediator)
-    {
-        return await mediator.Send(command with {Id = id});
-    }
+        group.MapPut("/{id}", async Task<ApiResult> (UserId id, UpdateUser.Command command, ISender mediator)
+            => await mediator.Send(command with {Id = id}));
 
-    private static async Task<ApiResult> DeleteUser(UserId id, ISender mediator)
-    {
-        return await mediator.Send(new DeleteUser.Command(id));
+        group.MapDelete("/{id}", async Task<ApiResult> (UserId id, ISender mediator)
+            => await mediator.Send(new DeleteUser.Command(id)));
     }
 }

--- a/account-management/Domain/Tenants/TenantTypes.cs
+++ b/account-management/Domain/Tenants/TenantTypes.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 using PlatformPlatform.SharedKernel.DomainCore.Identity;
 
@@ -31,6 +32,7 @@ public sealed class TenantIdTypeConverter : StronglyTypedIdTypeConverter<string,
 }
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TenantState
 {
     Trial,

--- a/account-management/Domain/Users/UserTypes.cs
+++ b/account-management/Domain/Users/UserTypes.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 using PlatformPlatform.SharedKernel.DomainCore.Identity;
 
@@ -19,6 +20,7 @@ public sealed class UserIdTypeConverter : StronglyTypedIdTypeConverter<string, U
 }
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum UserRole
 {
     TenantUser = 0,

--- a/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
+++ b/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
@@ -32,7 +32,7 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
                     'createdAt': {'type': 'string', 'format': 'date-time'},
                     'modifiedAt': {'type': ['null', 'string'], 'format': 'date-time'},
                     'name': {'type': 'string', 'minLength': 1, 'maxLength': 30},
-                    'state': {'type': 'integer', 'minimum': 0},
+                    'state': {'type': 'string', 'minLength': 1, 'maxLength':20},
                     'phone': {'type': ['null', 'string'], 'maxLength': 20}
                 },
                 'required': ['id', 'createdAt', 'modifiedAt', 'name', 'state', 'phone'],

--- a/account-management/Tests/Api/Users/UserEndpointsTests.cs
+++ b/account-management/Tests/Api/Users/UserEndpointsTests.cs
@@ -34,7 +34,7 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
                     'createdAt': {'type': 'string', 'format': 'date-time'},
                     'modifiedAt': {'type': ['null', 'string'], 'format': 'date-time'},
                     'email': {'type': 'string', 'maxLength': 100},
-                    'userRole': {'type': 'integer', 'minimum': 0}
+                    'userRole': {'type': 'string', 'minLength': 1, 'maxLength':20}
                 },
                 'required': ['id', 'createdAt', 'modifiedAt', 'email', 'userRole'],
                 'additionalProperties': false

--- a/shared-kernel/ApiCore/AspNetCoreUtilsConfiguration.cs
+++ b/shared-kernel/ApiCore/AspNetCoreUtilsConfiguration.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using PlatformPlatform.SharedKernel.ApiCore.Endpoints;
+using PlatformPlatform.SharedKernel.ApiCore.Filters;
 using PlatformPlatform.SharedKernel.ApiCore.Middleware;
 
 namespace PlatformPlatform.SharedKernel.ApiCore;
@@ -23,8 +24,12 @@ public static class AspNetCoreUtilsConfiguration
         services.AddSwaggerGen(c =>
         {
             c.SwaggerDoc("v1", new OpenApiInfo {Title = "PlatformPlatform API", Version = "v1"});
+
             // This is needed because commands are nested so CreateTenant.Command becomes CreateTenant+Command 
             c.CustomSchemaIds(type => type.FullName?.Split(".").Last().Replace("+", ""));
+
+            // Ensure that enums are shown as strings in the Swagger UI
+            c.SchemaFilter<XEnumNamesSchemaFilter>();
         });
 
         // Ensure that enums are serialized as strings

--- a/shared-kernel/ApiCore/AspNetCoreUtilsConfiguration.cs
+++ b/shared-kernel/ApiCore/AspNetCoreUtilsConfiguration.cs
@@ -1,5 +1,7 @@
+using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
@@ -23,6 +25,12 @@ public static class AspNetCoreUtilsConfiguration
             c.SwaggerDoc("v1", new OpenApiInfo {Title = "PlatformPlatform API", Version = "v1"});
             // This is needed because commands are nested so CreateTenant.Command becomes CreateTenant+Command 
             c.CustomSchemaIds(type => type.FullName?.Split(".").Last().Replace("+", ""));
+        });
+
+        // Ensure that enums are serialized as strings
+        services.Configure<JsonOptions>(options =>
+        {
+            options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
         });
 
         return services;

--- a/shared-kernel/ApiCore/Filters/XEnumNamesSchemaFilter.cs
+++ b/shared-kernel/ApiCore/Filters/XEnumNamesSchemaFilter.cs
@@ -1,0 +1,27 @@
+using JetBrains.Annotations;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace PlatformPlatform.SharedKernel.ApiCore.Filters;
+
+/// <summary>
+///     This class is used to allow Swagger contracts to show the names of the enum values instead of their numeric
+///     values.
+/// </summary>
+[UsedImplicitly]
+public class XEnumNamesSchemaFilter : ISchemaFilter
+{
+    private const string Name = "x-enumNames";
+
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (!context.Type.IsEnum) return;
+        if (schema.Extensions.ContainsKey(Name)) return;
+
+        var openApiArray = new OpenApiArray();
+        var openApiStrings = Enum.GetNames(context.Type).Select(name => new OpenApiString(name));
+        openApiArray.AddRange(openApiStrings);
+        schema.Extensions.Add(Name, openApiArray);
+    }
+}


### PR DESCRIPTION
### Summary & Motivation

Modify the default Json serialization of REST endpoints to use enums as strings instead of their integer values. This change enhances the clarity when working with the API. Also, update the Swagger configuration to accurately display the correct contract, reflecting the usage of enum strings.

Refactor all REST endpoints to use online expression-bodied methods instead of dedicated endpoint methods. This approach simplifies the code and improves maintainability by reducing redundancy and promoting a more concise coding style.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
