### PR TITLE
Disable Azure SQL Server elastic pool and allow manual triggering of infrastructure workflows

### DIFF
--- a/.github/workflows/azure-infrastructure-change-preview.yml
+++ b/.github/workflows/azure-infrastructure-change-preview.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'cloud-infrastructure/**'
+  workflow_dispatch:
 
 jobs:
   shared:

--- a/.github/workflows/azure-infrastructure-deployment.yml
+++ b/.github/workflows/azure-infrastructure-deployment.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'cloud-infrastructure/**'
+  workflow_dispatch:
 
 jobs:
   shared-plan:

--- a/cloud-infrastructure/cluster/config/production-west-europe.sh
+++ b/cloud-infrastructure/cluster/config/production-west-europe.sh
@@ -2,7 +2,7 @@ environment="production"
 location="WestEurope"
 locationPrefix="west-europe"
 clusterUniqueName="p14mprodweu"
-useMssqlElasticPool=true
+useMssqlElasticPool=false
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 . ../deploy.sh


### PR DESCRIPTION
### Summary & Motivation

Disable the Azure SQL Server elastic pool on the Production West Europe cluster.

Enable manual triggering of the azure-infrastructure-change-preview.yml and azure-infrastructure-deployment.yml GitHub workflows.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
