### PR TITLE
Separate step for Database Permissions and changes in GitHub workflow and tooling

### DIFF
--- a/.github/workflows/azure-infrastructure.yml
+++ b/.github/workflows/azure-infrastructure.yml
@@ -132,6 +132,13 @@ jobs:
         CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
         UNIQUE_CLUSTER_PREFIX: ${{ vars.UNIQUE_CLUSTER_PREFIX }}
       run: bash ./cloud-infrastructure/cluster/config/staging-west-europe.sh --apply
+    - name: Grant permissions to Managed Identities in SQL Server
+      env:
+        ENVIRONMENT: 'staging'
+        LOCATION_PREFIX: 'west-europe'
+        SQL_SERVER_NAME: '${{ vars.UNIQUE_CLUSTER_PREFIX }}stageweu'
+      run: |
+        bash ./cloud-infrastructure/cluster/grant-database-permissions.sh 'account-management'
 
   production-plan:
     runs-on: ubuntu-latest

--- a/.github/workflows/azure-infrastructure.yml
+++ b/.github/workflows/azure-infrastructure.yml
@@ -115,6 +115,13 @@ jobs:
         chmod +x ./bicep &&
         sudo mv ./bicep /usr/local/bin/bicep &&
         bicep --version
+    - name: Replace classic sqlcmd (ODBC) with sqlcmd (GO)
+      run: |
+        sudo apt-get remove -y mssql-tools &&
+        curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc &&
+        sudo add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/22.04/prod.list)" &&
+        sudo apt-get update &&
+        sudo apt-get install -y sqlcmd
     - name: Login to the Staging subscription
       uses: azure/login@v1
       with:
@@ -184,6 +191,13 @@ jobs:
         chmod +x ./bicep &&
         sudo mv ./bicep /usr/local/bin/bicep &&
         bicep --version
+    - name: Replace classic sqlcmd (ODBC) with sqlcmd (GO)
+      run: |
+        sudo apt-get remove -y mssql-tools &&
+        curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc &&
+        sudo add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/22.04/prod.list)" &&
+        sudo apt-get update &&
+        sudo apt-get install -y sqlcmd
     - name: Login to the Production subscription
       uses: azure/login@v1
       with:

--- a/.github/workflows/azure-infrastructure.yml
+++ b/.github/workflows/azure-infrastructure.yml
@@ -10,7 +10,7 @@ on:
     branches:
     - main
     paths:
-    - 'cloud-infrastructure/**'      
+    - 'cloud-infrastructure/**'
   workflow_dispatch:
 
 jobs:
@@ -35,8 +35,8 @@ jobs:
       run: bash ./cloud-infrastructure/shared/config/shared.sh --plan
 
   shared-deploy:
-    if: github.ref == 'refs/heads/main' && needs.shared-plan.result == 'success'
-    needs: shared-plan
+    if: github.ref == 'refs/heads/main' && needs.shared-plan.result == 'success' && needs.staging-plan.result == 'success' && needs.production-plan.result == 'success'
+    needs: [shared-plan, staging-plan, production-plan]
     runs-on: ubuntu-latest
     environment: 'shared' ## Force a manual approval
     steps:
@@ -82,8 +82,8 @@ jobs:
       run: bash ./cloud-infrastructure/cluster/config/staging-west-europe.sh --plan
 
   staging-environment-deploy:
-    if: github.ref == 'refs/heads/main' && needs.staging-plan.result == 'success'
-    needs: [shared-deploy, staging-plan]
+    if: github.ref == 'refs/heads/main' && needs.shared-deploy.result == 'success'
+    needs: shared-deploy
     runs-on: ubuntu-latest
     environment: 'staging' ## Force a manual approval
     steps:
@@ -159,7 +159,7 @@ jobs:
 
   production-environment-deploy:
     if: github.ref == 'refs/heads/main' && needs.staging-west-europe-deploy.result == 'success'
-    needs: [staging-west-europe-deploy, production-plan]
+    needs: staging-west-europe-deploy
     runs-on: ubuntu-latest
     environment: 'production' ## Force a manual approval
     steps:

--- a/cloud-infrastructure/cluster/deploy-cluster.sh
+++ b/cloud-infrastructure/cluster/deploy-cluster.sh
@@ -29,10 +29,3 @@ DEPLOYMENT_PARAMETERS="-l $LOCATION -n $CURRENT_DATE-$RESOURCE_GROUP_NAME --outp
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 . ../deploy.sh
-
-if [[ "$*" != *"--plan"* ]]
-then
-  . ./firewall.sh open
-  . ./grant-database-permissions.sh 'account-management'
-  . ./firewall.sh close
-fi

--- a/cloud-infrastructure/cluster/firewall.sh
+++ b/cloud-infrastructure/cluster/firewall.sh
@@ -1,12 +1,11 @@
-SQL_SERVER=$CLUSTER_UNIQUE_NAME
 IP_ADDRESS=$(curl -s https://api.ipify.org)
 FIREWALL_RULE_NAME="Short lived deployment Script"
 
 if [[ "$1" == "open" ]]
 then
-    echo "Add the IP $IP_ADDRESS to the SQL Server firewall on server $SQL_SERVER"
-    az sql server firewall-rule create --resource-group $RESOURCE_GROUP_NAME --server $SQL_SERVER --name "$FIREWALL_RULE_NAME" --start-ip-address $IP_ADDRESS --end-ip-address $IP_ADDRESS
+    echo "Add the IP $IP_ADDRESS to the SQL Server firewall on server $SQL_SERVER_NAME"
+    az sql server firewall-rule create --resource-group $RESOURCE_GROUP_NAME --server $SQL_SERVER_NAME --name "$FIREWALL_RULE_NAME" --start-ip-address $IP_ADDRESS --end-ip-address $IP_ADDRESS
 else
-    echo "Delete the IP $IP_ADDRESS from the SQL Server firewall on server $SQL_SERVER"
-    az sql server firewall-rule delete --resource-group $RESOURCE_GROUP_NAME --server $SQL_SERVER --name "$FIREWALL_RULE_NAME"
+    echo "Delete the IP $IP_ADDRESS from the SQL Server firewall on server $SQL_SERVER_NAME"
+    az sql server firewall-rule delete --resource-group $RESOURCE_GROUP_NAME --server $SQL_SERVER_NAME --name "$FIREWALL_RULE_NAME"
 fi

--- a/cloud-infrastructure/cluster/grant-database-permissions.sh
+++ b/cloud-infrastructure/cluster/grant-database-permissions.sh
@@ -6,10 +6,10 @@ SQL_SERVER="$SQL_SERVER_NAME.database.windows.net"
 cd "$(dirname "${BASH_SOURCE[0]}")"
 . ./firewall.sh open
 
-echo Granting $MANAGED_IDENTITY permissions on $SQL_SERVER/$SQL_DATABASE database
+echo Granting $MANAGED_IDENTITY in Recource group $RESOURCE_GROUP_NAME permissions on $SQL_SERVER/$SQL_DATABASE database
 
 # Execute the SQL script using mssql-scripter. Pass the script as a heredoc to sqlcmd to allow for complex SQL.
-sqlcmd -S $SQL_SERVER -d $SQL_DATABASE --authentication-method=ActiveDirectoryDefault << EOF
+sqlcmd -S $SQL_SERVER -d $SQL_DATABASE --authentication-method=ActiveDirectoryDefault --exit-on-error << EOF
 IF NOT EXISTS (SELECT [name] FROM [sys].[database_principals] WHERE [name] = '$MANAGED_IDENTITY' AND [type] = 'E')
 BEGIN
     CREATE USER [$MANAGED_IDENTITY] FROM EXTERNAL PROVIDER;
@@ -19,5 +19,12 @@ BEGIN
 END
 GO
 EOF
+
+# Check the exit status of the sqlcmd command
+if [ $? -eq 0 ]; then
+  echo "Permissions granted successfully"
+else
+  echo "Please add the $SQL_SERVER_NAME to the Azure AD built-in \"Directory Readers\" group and try again."
+fi
 
 . ./firewall.sh close

--- a/cloud-infrastructure/cluster/grant-database-permissions.sh
+++ b/cloud-infrastructure/cluster/grant-database-permissions.sh
@@ -5,6 +5,8 @@ SQL_SERVER="$SQL_SERVER_NAME.database.windows.net"
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 . ./firewall.sh open
+# Ensure that the firewall is closed no matter if other commands fail
+trap '. ./firewall.sh close' EXIT
 
 echo Granting $MANAGED_IDENTITY in Recource group $RESOURCE_GROUP_NAME permissions on $SQL_SERVER/$SQL_DATABASE database
 
@@ -20,11 +22,9 @@ END
 GO
 EOF
 
-# Check the exit status of the sqlcmd command
 if [ $? -eq 0 ]; then
   echo "Permissions granted successfully"
 else
-  echo "Please add the $SQL_SERVER_NAME to the Azure AD built-in \"Directory Readers\" group and try again."
+  echo "::error::Please manually add the $SQL_SERVER_NAME to the Azure AD built-in \"Directory Readers\" group and try again. This is a one-time operation, which cannot be automated. See https://stackoverflow.com/q/76995900/8547"
+  exit 1 
 fi
-
-. ./firewall.sh close

--- a/cloud-infrastructure/cluster/grant-database-permissions.sh
+++ b/cloud-infrastructure/cluster/grant-database-permissions.sh
@@ -1,8 +1,12 @@
+RESOURCE_GROUP_NAME="$ENVIRONMENT-$LOCATION_PREFIX"
 MANAGED_IDENTITY="$1-$RESOURCE_GROUP_NAME"
 SQL_DATABASE=$1
-SQL_SERVER="$CLUSTER_UNIQUE_NAME.database.windows.net"
+SQL_SERVER="$SQL_SERVER_NAME.database.windows.net"
 
-echo Granting database permissions to $MANAGED_IDENTITY on $SQL_SERVER/$SQL_DATABASE
+cd "$(dirname "${BASH_SOURCE[0]}")"
+. ./firewall.sh open
+
+echo Granting $MANAGED_IDENTITY permissions on $SQL_SERVER/$SQL_DATABASE database
 
 # Execute the SQL script using mssql-scripter. Pass the script as a heredoc to sqlcmd to allow for complex SQL.
 sqlcmd -S $SQL_SERVER -d $SQL_DATABASE --authentication-method=ActiveDirectoryDefault << EOF
@@ -15,3 +19,5 @@ BEGIN
 END
 GO
 EOF
+
+. ./firewall.sh close


### PR DESCRIPTION
### Summary & Motivation

Modify the GitHub Workflow to grant database permissions in a separate step. Unfortunately a manual step is required to grant SQL Server access to read the Managed Identity from Active Directory. Currently, there it seems there is no way to automate this action. For more details, refer to this [Stack Overflow question](https://stackoverflow.com/q/76995900/8547).

Install the new version of SQLCMD, specifically the [go-sqlcmd](https://learn.microsoft.com/en-us/sql/tools/sqlcmd/go-sqlcmd-utility) utility. This version adds support for the -authentication-method=ActiveDirectoryDefault option, facilitating the use of GitHub service principals for Azure access.

Ensure the firewall is closed, even if the script execution fails, to maintain security.

Alter the GitHub workflow jobs to execute all planning steps after merging to the main branch. This approach allows for reviewing changes before deploying them to the staging and production environments.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
