### PR TITLE
Remove audit log retention configuration for Azure services

### DIFF
--- a/cloud-infrastructure/modules/key-vault.bicep
+++ b/cloud-infrastructure/modules/key-vault.bicep
@@ -46,28 +46,16 @@ resource keyVaultAuditDiagnosticSetting 'Microsoft.Insights/diagnosticSettings@2
       {
         categoryGroup: 'audit'
         enabled: true
-        retentionPolicy: {
-          enabled: true
-          days: 90
-        }
       }
       {
         categoryGroup: 'allLogs'
         enabled: false
-        retentionPolicy: {
-          enabled: false
-          days: 0
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: false
-        retentionPolicy: {
-          enabled: false
-          days: 0
-        }
       }
     ]
   }
@@ -82,28 +70,16 @@ resource keyVaultMetricDiagnosticSetting 'Microsoft.Insights/diagnosticSettings@
       {
         category: 'AuditEvent'
         enabled: false
-        retentionPolicy: {
-          enabled: false
-          days: 0
-        }
       }
       {
         category: 'AzurePolicyEvaluationDetails'
         enabled: false
-        retentionPolicy: {
-          enabled: false
-          days: 0
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          enabled: true
-          days: 90
-        }
       }
     ]
   }

--- a/cloud-infrastructure/modules/service-bus.bicep
+++ b/cloud-infrastructure/modules/service-bus.bicep
@@ -32,28 +32,16 @@ resource serviceBusAuditDiagnosticSetting 'Microsoft.Insights/diagnosticSettings
       {
         categoryGroup: 'audit'
         enabled: true
-        retentionPolicy: {
-          enabled: true
-          days: 90
-        }
       }
       {
         categoryGroup: 'allLogs'
         enabled: false
-        retentionPolicy: {
-          enabled: false
-          days: 0
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: false
-        retentionPolicy: {
-          enabled: false
-          days: 0
-        }
       }
     ]
   }
@@ -69,44 +57,24 @@ resource serviceBusMetricDiagnosticSetting 'Microsoft.Insights/diagnosticSetting
       {
         category: 'OperationalLogs'
         enabled: false
-        retentionPolicy: {
-          enabled: false
-          days: 0
-        }
       }
       {
         category: 'VNetAndIPFilteringLogs'
         enabled: false
-        retentionPolicy: {
-          enabled: false
-          days: 0
-        }
       }
       {
         category: 'RuntimeAuditLogs'
         enabled: false
-        retentionPolicy: {
-          enabled: false
-          days: 0
-        }
       }
       {
         category: 'ApplicationMetricsLogs'
         enabled: false
-        retentionPolicy: {
-          enabled: false
-          days: 0
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          enabled: true
-          days: 90
-        }
       }
     ]
   }


### PR DESCRIPTION
### Summary & Motivation

Azure Key Vault and Service Bus no longer offer the option to configure the duration for retaining audit logs. Consequently, this pull request removes the settings for audit log retention periods.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
