### PR TITLE
Grant managed identity permissions to database using security identifier (SID) 

### DIFF
--- a/.github/workflows/azure-infrastructure.yml
+++ b/.github/workflows/azure-infrastructure.yml
@@ -132,13 +132,6 @@ jobs:
         CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
         UNIQUE_CLUSTER_PREFIX: ${{ vars.UNIQUE_CLUSTER_PREFIX }}
       run: bash ./cloud-infrastructure/cluster/config/staging-west-europe.sh --apply
-    - name: Grant permissions to Managed Identities in SQL Server
-      env:
-        ENVIRONMENT: 'staging'
-        LOCATION_PREFIX: 'west-europe'
-        SQL_SERVER_NAME: '${{ vars.UNIQUE_CLUSTER_PREFIX }}stageweu'
-      run: |
-        bash ./cloud-infrastructure/cluster/grant-database-permissions.sh 'account-management'
 
   production-plan:
     runs-on: ubuntu-latest

--- a/cloud-infrastructure/cluster/grant-database-permissions.sh
+++ b/cloud-infrastructure/cluster/grant-database-permissions.sh
@@ -3,28 +3,27 @@ MANAGED_IDENTITY="$1-$RESOURCE_GROUP_NAME"
 SQL_DATABASE=$1
 SQL_SERVER="$SQL_SERVER_NAME.database.windows.net"
 
-cd "$(dirname "${BASH_SOURCE[0]}")"
-. ./firewall.sh open
-# Ensure that the firewall is closed no matter if other commands fail
-trap '. ./firewall.sh close' EXIT
+# Convert the ClientId of the Managed Identity to the binary version. The following bash script is equivalent to this PowerShell:
+#   $SID = "0x" + [System.BitConverter]::ToString(([guid]$SID).ToByteArray()).Replace("-", "")
+SID=$(echo $2 | tr 'a-f' 'A-F' | tr -d '-') # Convert to uppercase and remove hyphens
+SID=$(awk -v id="$SID" 'BEGIN {
+  printf "0x%s%s%s%s\n",
+    substr(id,7,2) substr(id,5,2) substr(id,3,2) substr(id,1,2),
+    substr(id,11,2) substr(id,9,2),
+    substr(id,15,2) substr(id,13,2),
+    substr(id,17)
+}') # Reverse the byte order for the first three sections of the GUID and concatenate
 
-echo Granting $MANAGED_IDENTITY in Recource group $RESOURCE_GROUP_NAME permissions on $SQL_SERVER/$SQL_DATABASE database
+echo "Granting $MANAGED_IDENTITY (ID: $SID) in Recource group $RESOURCE_GROUP_NAME permissions on $SQL_SERVER/$SQL_DATABASE database"
 
 # Execute the SQL script using mssql-scripter. Pass the script as a heredoc to sqlcmd to allow for complex SQL.
 sqlcmd -S $SQL_SERVER -d $SQL_DATABASE --authentication-method=ActiveDirectoryDefault --exit-on-error << EOF
 IF NOT EXISTS (SELECT [name] FROM [sys].[database_principals] WHERE [name] = '$MANAGED_IDENTITY' AND [type] = 'E')
 BEGIN
-    CREATE USER [$MANAGED_IDENTITY] FROM EXTERNAL PROVIDER;
+    CREATE USER [$MANAGED_IDENTITY] WITH SID = $SID, TYPE = E;
     ALTER ROLE db_datareader ADD MEMBER [$MANAGED_IDENTITY];
     ALTER ROLE db_datawriter ADD MEMBER [$MANAGED_IDENTITY];
     ALTER ROLE db_ddladmin ADD MEMBER [$MANAGED_IDENTITY];
 END
 GO
 EOF
-
-if [ $? -eq 0 ]; then
-  echo "Permissions granted successfully"
-else
-  echo "::error::Please manually add the $SQL_SERVER_NAME to the Azure AD built-in \"Directory Readers\" group and try again. This is a one-time operation, which cannot be automated. See https://stackoverflow.com/q/76995900/8547"
-  exit 1 
-fi

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -178,14 +178,4 @@ module accountManagementApi '../modules/container-app.bicep' = {
   dependsOn: [accountManagementDatabase]
 }
 
-// module sqlPrivateLink '../modules/private-endpoint-sql-server.bicep' = {
-//   name: 'sql-private-link'
-//   scope: clusterResourceGroup
-//   params: {
-//     name: 'sql-server-private-link'
-//     location: location
-//     tags: tags
-//     subnetId: subnetId
-//     sqlServerId: microsoftSqlServer.outputs.sqlServerId
-//   }
-// }
+output accountManagementIdentityClientId string = accountManagementIdentity.outputs.clientId

--- a/cloud-infrastructure/deploy.sh
+++ b/cloud-infrastructure/deploy.sh
@@ -1,5 +1,11 @@
 set -eo pipefail
 
+if [[ "$1" == "" ]]
+then
+    echo "::error::Please specify either the --plan or the--apply parameter."
+    exit 1
+fi
+
 if [[ "$*" == *"--plan"* ]]
 then
     echo "Preparing plan..."
@@ -9,11 +15,5 @@ fi
 if [[ "$*" == *"--apply"* ]]
 then
     echo "Applying changes..."
-    $DEPLOYMENT_COMMAND $DEPLOYMENT_PARAMETERS
-fi
-
-if [[ "$1" == "" ]]
-then
-    echo "Detecting changes..."
-   $DEPLOYMENT_COMMAND -c $DEPLOYMENT_PARAMETERS
+    export output=$($DEPLOYMENT_COMMAND $DEPLOYMENT_PARAMETERS)
 fi


### PR DESCRIPTION
### Summary & Motivation

Grant access to databases for managed identities by directly providing the internal Azure AD security identifier (SID). Instead of relying on the standard SQL command `CREATE USER [$MANAGED_IDENTITY] FROM EXTERNAL PROVIDER`, which necessitates the SQL Server to have permissions to read the Active Directory, this pull request employs a more direct approach using `CREATE USER [$MANAGED_IDENTITY] WITH SID = $SID, TYPE = E`. This effectively bypasses the need for the SQL Server to have Active Directory permissions.

The SID is obtained by fetching the Client ID of the Managed Identity from the Bicep output and converting converting it to its binary form.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
