### PR TITLE
Add federated credentials for shared, staging, and production environments

### DIFF
--- a/cloud-infrastructure/initialize-azure.sh
+++ b/cloud-infrastructure/initialize-azure.sh
@@ -97,12 +97,32 @@ pullRequestCredential=$(echo -n "{
   \"subject\": \"repo:$gitHubRepositoryPath:pull_request\",
   \"audiences\": [\"api://AzureADTokenExchange\"]
 }")
-
+sharedEnvironmentCredentials=$(echo -n "{
+  \"name\": \"SharedEnvironment\",
+  \"issuer\": \"https://token.actions.githubusercontent.com\",
+  \"subject\": \"repo:$gitHubRepositoryPath:environment:shared\",
+  \"audiences\": [\"api://AzureADTokenExchange\"]
+}")
+stagingEnvironmentCredentials=$(echo -n "{
+  \"name\": \"StagingEnvironment\",
+  \"issuer\": \"https://token.actions.githubusercontent.com\",
+  \"subject\": \"repo:$gitHubRepositoryPath:environment:staging\",
+  \"audiences\": [\"api://AzureADTokenExchange\"]
+}")
+productionEnvironmentCredentials=$(echo -n "{
+  \"name\": \"ProductionEnvironment\",
+  \"issuer\": \"https://token.actions.githubusercontent.com\",
+  \"subject\": \"repo:$gitHubRepositoryPath:environment:production\",
+  \"audiences\": [\"api://AzureADTokenExchange\"]
+}")
 if [ "$userChoiceForReuseServicePrincipalfrastructure" == "y" ]; then
-   echo -e "${YELLOW}You are reusing the Service Principal. Please ignore the error: 'FederatedIdentityCredential with name MainBranch/PullRequests already exists'${NC}"
+   echo -e "${YELLOW}You are reusing the Service Principal. Please ignore the error: 'FederatedIdentityCredential with name xxxx already exists'${NC}"
 fi
 echo $mainCredential | az ad app federated-credential create --id $servicePrincipalAppIdInfrastructure --parameters @-
 echo $pullRequestCredential | az ad app federated-credential create --id $servicePrincipalAppIdInfrastructure --parameters @-
+echo $sharedEnvironmentCredentials | az ad app federated-credential create --id $servicePrincipalAppIdInfrastructure --parameters @-
+echo $stagingEnvironmentCredentials | az ad app federated-credential create --id $servicePrincipalAppIdInfrastructure --parameters @-
+echo $productionEnvironmentCredentials | az ad app federated-credential create --id $servicePrincipalAppIdInfrastructure --parameters @-
 
 echo -e "${GREEN}Successfully configured Service Principal with Federated Credentials${NC}"
 


### PR DESCRIPTION
### Summary & Motivation

Introduce federated credentials for shared, staging, and production environments. For Azure authentications in GitHub Actions with an environment constraint, the federated credentials are now explicitly constrained to that specific environment. The same Service Principal from the Main branch is utilized.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
