### PR TITLE
Add required SKU properties to SQL database Bicep configuration

### DIFF
--- a/cloud-infrastructure/modules/microsoft-sql-database.bicep
+++ b/cloud-infrastructure/modules/microsoft-sql-database.bicep
@@ -9,7 +9,9 @@ resource sqlDatabase 'Microsoft.Sql/servers/databases@2022-11-01-preview' = {
   tags: tags
   sku: {
     name: 'GP_S_Gen5'
+    tier: 'GeneralPurpose'
     family: 'Gen5'
+    capacity: 1
   }
   properties: {
     collation: 'SQL_Latin1_General_CP1_CI_AS'


### PR DESCRIPTION
### Summary & Motivation

Add required GeneralPurpose and Capacity SKU properties to the SQL Database Bicep configuration. Despite their recurrent appearance as deleted items in every Bicep what-if execution, these properties remain essential.


### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
