### PR TITLE
Introduce Docker Compose for local setup to run SQL Server and Account Management API

### DIFF
--- a/.github/workflows/platformplatform-build-and-test.yml
+++ b/.github/workflows/platformplatform-build-and-test.yml
@@ -116,7 +116,7 @@ jobs:
       run: |
         docker buildx create --use
         docker buildx build \
-          --platform linux/amd64,linux/arm64 \
+          --platform linux/amd64 \
           --build-arg VERSION=${{ needs.build.outputs.version }} \
           -t ${{ vars.CONTAINER_REGISTRY_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.version }} \
           -t ${{ vars.CONTAINER_REGISTRY_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:latest \

--- a/.github/workflows/platformplatform-build-and-test.yml
+++ b/.github/workflows/platformplatform-build-and-test.yml
@@ -95,11 +95,9 @@ jobs:
     needs: [build, test-with-code-coverage, jetbrains-code-inspection]
     runs-on: ubuntu-latest
     steps:
-    - name: Download build artifacts
-      uses: actions/download-artifact@v3
+    - uses: actions/checkout@v3
       with:
-        name: publish
-        path: ./publish
+        fetch-depth: 0    
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Login to Azure subscription
@@ -112,15 +110,16 @@ jobs:
       run: |
         az acr login --name ${{ vars.CONTAINER_REGISTRY_NAME }}
     - name: Build and push Docker image
+      working-directory: application
       env:
         IMAGE_NAME: account-management-api
       run: |
         docker buildx create --use
         docker buildx build \
           --platform linux/amd64,linux/arm64 \
+          --build-arg VERSION=${{ needs.build.outputs.version }} \
           -t ${{ vars.CONTAINER_REGISTRY_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.version }} \
           -t ${{ vars.CONTAINER_REGISTRY_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:latest \
-          -f ./publish/Dockerfile \
+          -f ./account-management/Api/Dockerfile \
           --push .
         docker buildx rm
-

--- a/application/account-management/Api/Dockerfile
+++ b/application/account-management/Api/Dockerfile
@@ -1,25 +1,31 @@
-# Use the ASP.NET 7.0 Alpine image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+WORKDIR /src
 
-# Create a group and user 'nonroot'
-RUN addgroup -S nonroot \
-    && adduser -S nonroot -G nonroot
+# Copy all source code to /src
+COPY ./ ./
 
-# Install ICU libraries
+# Set the working directory to the API project
+WORKDIR /src/account-management/Api
+RUN dotnet restore
+RUN dotnet publish -c Release -o /publish
+
+
+# Runtime stage (start with a clean image and copy only published binairies)
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS runtime
+WORKDIR /app
+COPY --from=build /publish ./
+
+# Install ICU libraries and other essentials
 RUN apk add --no-cache icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
-# Set the working directory in the container
-WORKDIR /app
-
-# Expose ports (non-root user can't use ports below 1024)
-EXPOSE 8443
-
-# Switch to 'nonroot' user
+# Create non-root user
+RUN addgroup -S nonroot && adduser -S nonroot -G nonroot
 USER nonroot
 
-# Copy the build app to the container
-COPY ./publish .
+# Expose port 8443 (non-root user can't use ports below 1024)
+EXPOSE 8443
 
-# Configure the entry point
+# Entry point
 ENTRYPOINT ["dotnet", "PlatformPlatform.AccountManagement.Api.dll"]

--- a/application/account-management/Api/Dockerfile
+++ b/application/account-management/Api/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+ARG VERSION=1.0.0.0  # Use version 1.0.0.0 as default
 WORKDIR /src
 
 # Copy all source code to /src
@@ -8,7 +9,7 @@ COPY ./ ./
 # Set the working directory to the API project
 WORKDIR /src/account-management/Api
 RUN dotnet restore
-RUN dotnet publish -c Release -o /publish
+RUN dotnet publish -c Release -o /publish /p:Version="$VERSION"
 
 
 # Runtime stage (start with a clean image and copy only published binairies)

--- a/application/account-management/Api/Properties/launchSettings.json
+++ b/application/account-management/Api/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "development"
       },
       "applicationUrl": "https://localhost:8443"
     }

--- a/application/account-management/Api/appsettings.development.json
+++ b/application/account-management/Api/appsettings.development.json
@@ -1,5 +1,5 @@
 {
   "ConnectionStrings": {
-    "Default": "Server=localhost;Database=account-management;User Id=sa;Encrypt=True;TrustServerCertificate=True"
+    "Default": "Server=${SQL_SERVER_NAME};Database=account-management;User Id=sa;Password=${SQL_SERVER_PASSWORD};Encrypt=True;TrustServerCertificate=True"
   }
 }

--- a/application/docker-compose.yml
+++ b/application/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  sql-server:
+    container_name: sql-server
+    image: mcr.microsoft.com/azure-sql-edge
+    ports:
+      - "1433:1433"
+    environment:
+      SA_PASSWORD: $SQL_SERVER_PASSWORD
+      ACCEPT_EULA: "Y"
+    volumes:
+      - sql-server-data:/var/opt/mssql
+
+  account-management-api:
+    container_name: account-management-api
+    build:
+      context: .
+      dockerfile: ./account-management/Api/Dockerfile
+    image: account-management-api
+    depends_on:
+      - sql-server
+    ports:
+      - "8443:443"
+    environment:
+      ASPNETCORE_ENVIRONMENT: "development"
+      SQL_SERVER_NAME: "sql-server"
+      SQL_SERVER_PASSWORD: $SQL_SERVER_PASSWORD
+      ASPNETCORE_Kestrel__Certificates__Default__Path: "/https/localhost.pfx"
+      ASPNETCORE_Kestrel__Certificates__Default__Password: $CERTIFICATE_PASSWORD
+      ASPNETCORE_URLS: "https://+"
+    volumes:
+      - ${HOME}/.aspnet/https:/https
+
+volumes:
+  sql-server-data:


### PR DESCRIPTION
### Summary & Motivation

Introduce Docker Compose to simplify the local setup of PlatformPlatform, including the initialization of SQL Server and the Account Management API. Store the SQL password in an environment variable, facilitating the seamless setup and configuration of SQL Server and the connection string, whether running the API in Docker or debugging via Rider or Visual Studio.

Transform the Account Management API's Dockerfile into a multi-stage build, streamlining the build process and including only the necessary binaries and runtime for production deployment.

Revise the GetConnectionString method to dynamically construct the SQL Server connection string based on the running environment (Azure, Docker, or debugging). Cache the connection string at startup.

Update the README to guide users in setting up passwords for SQL Server and SSL Certificate and store in environment variable for reuse (use random.org for generating random passwords). Include step-by-step instructions for running SQL Server in Docker and the API in either Docker or development environments, like Rider or Visual Studio.

### Checklist
- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
