### PR TITLE
Restrict container image pushes to main branch and streamline deployment workflows

### DIFF
--- a/.github/workflows/_deploy-container.yml
+++ b/.github/workflows/_deploy-container.yml
@@ -30,7 +30,7 @@ jobs:
 
   production-west-europe-deploy:
     name: Production
-    if: github.ref == 'refs/heads/main' && needs.staging-west-europe-deploy.result == 'success'
+    if: github.ref == 'refs/heads/main'
     needs: staging-west-europe-deploy
     runs-on: ubuntu-latest
     environment: "production" ## Force a manual approval

--- a/.github/workflows/_publish-container.yml
+++ b/.github/workflows/_publish-container.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   publish-container-image:
     name: Publish Container
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -88,6 +88,7 @@ jobs:
 
   account-management-api-publish:
     name: Account Management API Publish
+    if: github.ref == 'refs/heads/main'
     needs: [build]
     uses: ./.github/workflows/_publish-container.yml
     secrets: inherit

--- a/application/account-management/Api/Dockerfile
+++ b/application/account-management/Api/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --no-cache icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
 # Create non-root user
-RUN addgroup -S nonroot && adduser -S nonroot -G nonroot
+RUN adduser -S nonroot
 USER nonroot
 
 # Expose port 8443 (non-root user can't use ports below 1024)


### PR DESCRIPTION
### Summary & Motivation


Implement guards in both `application.yml` and `_publish-container.yml` to ensure container images are pushed exclusively from the main branch.

Remove the redundant success check for the staging job in production deployment, streamlining the workflow.

Simplify the creation of a non-root user in the Dockerfile by omitting the creation of a nonroot group.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
