### PR TITLE
Correct duplicate reference of environment variable env.DOMAIN_NAME.DOMAIN_NAME

### DIFF
--- a/.github/workflows/cloud-infrastructure.yml
+++ b/.github/workflows/cloud-infrastructure.yml
@@ -104,7 +104,7 @@ jobs:
           ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
           CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
           UNIQUE_CLUSTER_PREFIX: ${{ vars.UNIQUE_CLUSTER_PREFIX }}
-          DOMAIN_NAME: ${{ env.DOMAIN_NAME.DOMAIN_NAME }}
+          DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
         run: bash ./cloud-infrastructure/cluster/config/staging-west-europe.sh --plan
 
   staging-environment-deploy:
@@ -171,7 +171,7 @@ jobs:
           ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
           CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
           UNIQUE_CLUSTER_PREFIX: ${{ vars.UNIQUE_CLUSTER_PREFIX }}
-          DOMAIN_NAME: ${{ env.DOMAIN_NAME.DOMAIN_NAME }}
+          DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
         run: bash ./cloud-infrastructure/cluster/config/staging-west-europe.sh --apply
 
       - name: Refresh Azure tokens ## The previous step may take a while, so we refresh the token to avoid timeouts
@@ -219,7 +219,7 @@ jobs:
           ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
           CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
           UNIQUE_CLUSTER_PREFIX: ${{ vars.UNIQUE_CLUSTER_PREFIX }}
-          DOMAIN_NAME: ${{ env.DOMAIN_NAME.DOMAIN_NAME }}
+          DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
         run: bash ./cloud-infrastructure/cluster/config/production-west-europe.sh --plan
 
   production-environment-deploy:
@@ -286,7 +286,7 @@ jobs:
           ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
           CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
           UNIQUE_CLUSTER_PREFIX: ${{ vars.UNIQUE_CLUSTER_PREFIX }}
-          DOMAIN_NAME: ${{ env.DOMAIN_NAME.DOMAIN_NAME }}
+          DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
         run: bash ./cloud-infrastructure/cluster/config/production-west-europe.sh --apply
 
       - name: Refresh Azure tokens ## The previous step may take a while, so we refresh the token to avoid timeouts


### PR DESCRIPTION
### Summary & Motivation

Fix incorrect reference to the environment variable `DOMAIN_NAME`. It was previously referenced as `env.DOMAIN_NAME.DOMAIN_NAME`, but it should naturally be `env.DOMAIN_NAME`.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary