### PR TITLE
Consolidate infrastructure deployment jobs for streamlined process and quicker execution

### DIFF
--- a/.github/workflows/cloud-infrastructure.yml
+++ b/.github/workflows/cloud-infrastructure.yml
@@ -20,11 +20,11 @@ permissions:
   contents: read
 
 jobs:
-  shared-plan:
-    name: Plan Shared
+  plan:
+    name: Plan Changes
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v3
 
       - name: Install Bicep CLI
@@ -41,65 +41,15 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Plan changes to Shared resources
+      - name: Plan Changes to Shared Resources
         env:
           CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
         run: bash ./cloud-infrastructure/shared/config/shared.sh --plan
 
-  shared-deploy:
-    name: Deploy Shared
-    if: github.ref == 'refs/heads/main'
-    needs: [shared-plan, staging-plan, production-plan]
-    runs-on: ubuntu-latest
-    environment: "shared" ## Force a manual approval
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Install Bicep CLI
-        run: |
-          curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64 &&
-          chmod +x ./bicep &&
-          sudo mv ./bicep /usr/local/bin/bicep &&
-          bicep --version
-
-      - name: Login to Azure subscription
-        uses: azure/login@v1
-        with:
-          client-id: ${{ secrets.AZURE_SERVICE_PRINCIPAL_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Deploy Shared resources
-        env:
-          CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
-        run: bash ./cloud-infrastructure/shared/config/shared.sh --apply
-
-  staging-plan:
-    name: Plan Staging
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Install Bicep CLI
-        run: |
-          curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64 &&
-          chmod +x ./bicep &&
-          sudo mv ./bicep /usr/local/bin/bicep &&
-          bicep --version
-
-      - name: Login to Azure subscription
-        uses: azure/login@v1
-        with:
-          client-id: ${{ secrets.AZURE_SERVICE_PRINCIPAL_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Plan changes to shared Staging environment resources
+      - name: Plan Changes to Shared Staging Environment Resources
         run: bash ./cloud-infrastructure/environment/config/staging.sh --plan
 
-      - name: Plan changes to Staging West Europe cluster
+      - name: Plan Changes to Staging West Europe Cluster
         env:
           ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
           CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
@@ -107,14 +57,25 @@ jobs:
           DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
         run: bash ./cloud-infrastructure/cluster/config/staging-west-europe.sh --plan
 
-  staging-environment-deploy:
-    name: Staging Environment
+      - name: Plan Changes to Shared Production Environment Resources
+        run: bash ./cloud-infrastructure/environment/config/production.sh --plan
+
+      - name: Plan Changes to Production West Europe Cluster
+        env:
+          ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
+          CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
+          UNIQUE_CLUSTER_PREFIX: ${{ vars.UNIQUE_CLUSTER_PREFIX }}
+          DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
+        run: bash ./cloud-infrastructure/cluster/config/production-west-europe.sh --plan
+
+  shared:
+    name: Shared
     if: github.ref == 'refs/heads/main'
-    needs: shared-deploy
+    needs: plan
     runs-on: ubuntu-latest
-    environment: "staging" ## Force a manual approval
+    environment: "shared" ## Force a manual approval
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v3
 
       - name: Install Bicep CLI
@@ -124,23 +85,26 @@ jobs:
           sudo mv ./bicep /usr/local/bin/bicep &&
           bicep --version
 
-      - name: Login to Azure subscription
+      - name: Login to Azure Subscription
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_SERVICE_PRINCIPAL_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Deploy shared Staging environment resources
-        run: bash ./cloud-infrastructure/environment/config/staging.sh --apply
+      - name: Deploy Shared Resources
+        env:
+          CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
+        run: bash ./cloud-infrastructure/shared/config/shared.sh --apply
 
-  staging-west-europe-deploy:
-    name: Staging Cluster
+  staging:
+    name: Staging
     if: github.ref == 'refs/heads/main'
-    needs: staging-environment-deploy
+    needs: shared
     runs-on: ubuntu-latest
+    environment: "staging" ## Force a manual approval
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v3
 
       - name: Install Bicep CLI
@@ -150,7 +114,7 @@ jobs:
           sudo mv ./bicep /usr/local/bin/bicep &&
           bicep --version
 
-      - name: Replace classic sqlcmd (ODBC) with sqlcmd (GO)
+      - name: Replace Classic sqlcmd (ODBC) with sqlcmd (GO)
         run: |
           sudo apt-get remove -y mssql-tools &&
           curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc &&
@@ -158,14 +122,17 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install -y sqlcmd
 
-      - name: Login to Azure subscription
+      - name: Login to Azure Subscription
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_SERVICE_PRINCIPAL_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Deploy Staging West Europe cluster
+      - name: Deploy Shared Staging Environment Resources
+        run: bash ./cloud-infrastructure/environment/config/staging.sh --apply
+
+      - name: Deploy Staging West Europe Cluster
         id: deploy_cluster
         env:
           ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
@@ -174,14 +141,14 @@ jobs:
           DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
         run: bash ./cloud-infrastructure/cluster/config/staging-west-europe.sh --apply
 
-      - name: Refresh Azure tokens ## The previous step may take a while, so we refresh the token to avoid timeouts
+      - name: Refresh Azure Tokens ## The previous step may take a while, so we refresh the token to avoid timeouts
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_SERVICE_PRINCIPAL_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Grant Database permissions
+      - name: Grant Database Permissions
         env:
           ENVIRONMENT: "staging"
           LOCATION_PREFIX: "west-europe"
@@ -190,46 +157,14 @@ jobs:
           ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID=${{ steps.deploy_cluster.outputs.ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID }}
           bash ./cloud-infrastructure/cluster/grant-database-permissions.sh 'account-management' $ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID
 
-  production-plan:
-    name: Plan Production
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Install Bicep CLI
-        run: |
-          curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64 &&
-          chmod +x ./bicep &&
-          sudo mv ./bicep /usr/local/bin/bicep &&
-          bicep --version
-
-      - name: Login to Azure subscription
-        uses: azure/login@v1
-        with:
-          client-id: ${{ secrets.AZURE_SERVICE_PRINCIPAL_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Plan changes to shared Production environment resources
-        run: bash ./cloud-infrastructure/environment/config/production.sh --plan
-
-      - name: Plan changes to Production West Europe cluster
-        env:
-          ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
-          CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
-          UNIQUE_CLUSTER_PREFIX: ${{ vars.UNIQUE_CLUSTER_PREFIX }}
-          DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
-        run: bash ./cloud-infrastructure/cluster/config/production-west-europe.sh --plan
-
-  production-environment-deploy:
-    name: Production Environment
+  production:
+    name: Production
     if: github.ref == 'refs/heads/main'
-    needs: staging-west-europe-deploy
+    needs: staging
     runs-on: ubuntu-latest
     environment: "production" ## Force a manual approval
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v3
 
       - name: Install Bicep CLI
@@ -239,33 +174,7 @@ jobs:
           sudo mv ./bicep /usr/local/bin/bicep &&
           bicep --version
 
-      - name: Login to Azure subscription
-        uses: azure/login@v1
-        with:
-          client-id: ${{ secrets.AZURE_SERVICE_PRINCIPAL_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Deploy shared Production environment resources
-        run: bash ./cloud-infrastructure/environment/config/production.sh --apply
-
-  production-west-europe-deploy:
-    name: Production Cluster
-    if: github.ref == 'refs/heads/main'
-    needs: production-environment-deploy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Install Bicep CLI
-        run: |
-          curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64 &&
-          chmod +x ./bicep &&
-          sudo mv ./bicep /usr/local/bin/bicep &&
-          bicep --version
-
-      - name: Replace classic sqlcmd (ODBC) with sqlcmd (GO)
+      - name: Replace Classic sqlcmd (ODBC) with sqlcmd (GO)
         run: |
           sudo apt-get remove -y mssql-tools &&
           curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc &&
@@ -273,14 +182,17 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install -y sqlcmd
 
-      - name: Login to Azure subscription
+      - name: Login to Azure Subscription
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_SERVICE_PRINCIPAL_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Deploy Production West Europe cluster
+      - name: Deploy Shared Production Environment Resources
+        run: bash ./cloud-infrastructure/environment/config/production.sh --apply
+
+      - name: Deploy Production West Europe Cluster
         id: deploy_cluster
         env:
           ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
@@ -289,14 +201,14 @@ jobs:
           DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
         run: bash ./cloud-infrastructure/cluster/config/production-west-europe.sh --apply
 
-      - name: Refresh Azure tokens ## The previous step may take a while, so we refresh the token to avoid timeouts
+      - name: Refresh Azure Tokens ## The previous step may take a while, so we refresh the token to avoid timeouts
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_SERVICE_PRINCIPAL_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Grant Database permissions
+      - name: Grant Database Permissions
         env:
           ENVIRONMENT: "production"
           LOCATION_PREFIX: "west-europe"

--- a/.github/workflows/cloud-infrastructure.yml
+++ b/.github/workflows/cloud-infrastructure.yml
@@ -54,7 +54,7 @@ jobs:
           ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
           CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
           UNIQUE_CLUSTER_PREFIX: ${{ vars.UNIQUE_CLUSTER_PREFIX }}
-          DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
+          DOMAIN_NAME: ${{ vars.DOMAIN_NAME_STAGING }}
         run: bash ./cloud-infrastructure/cluster/config/staging-west-europe.sh --plan
 
       - name: Plan Changes to Shared Production Environment Resources
@@ -65,7 +65,7 @@ jobs:
           ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
           CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
           UNIQUE_CLUSTER_PREFIX: ${{ vars.UNIQUE_CLUSTER_PREFIX }}
-          DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
+          DOMAIN_NAME: ${{ vars.DOMAIN_NAME_PRODUCTION }}
         run: bash ./cloud-infrastructure/cluster/config/production-west-europe.sh --plan
 
   shared:
@@ -138,7 +138,7 @@ jobs:
           ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
           CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
           UNIQUE_CLUSTER_PREFIX: ${{ vars.UNIQUE_CLUSTER_PREFIX }}
-          DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
+          DOMAIN_NAME: ${{ vars.DOMAIN_NAME_STAGING }}
         run: bash ./cloud-infrastructure/cluster/config/staging-west-europe.sh --apply
 
       - name: Refresh Azure Tokens ## The previous step may take a while, so we refresh the token to avoid timeouts
@@ -198,7 +198,7 @@ jobs:
           ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
           CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
           UNIQUE_CLUSTER_PREFIX: ${{ vars.UNIQUE_CLUSTER_PREFIX }}
-          DOMAIN_NAME: ${{ env.DOMAIN_NAME }}
+          DOMAIN_NAME: ${{ vars.DOMAIN_NAME_PRODUCTION }}
         run: bash ./cloud-infrastructure/cluster/config/production-west-europe.sh --apply
 
       - name: Refresh Azure Tokens ## The previous step may take a while, so we refresh the token to avoid timeouts

--- a/cloud-infrastructure/initialize-azure.sh
+++ b/cloud-infrastructure/initialize-azure.sh
@@ -188,6 +188,8 @@ echo -e "\n"
 echo -e "The following GitHub repository ${BOLD}variables${NO_BOLD} must be created:"
 echo -e "- CONTAINER_REGISTRY_NAME: <unique name for your Azure Container Registry (ACR)>"
 echo -e "- UNIQUE_CLUSTER_PREFIX: <your unique perfix for azure resources. Max 8 alphanumeric characters."
+echo -e "- DOMAIN_NAME_STAGING: Optional domain name for your staging environment. If provided domain and SSL cerficate will be created."
+echo -e "- DOMAIN_NAME_PRODUCTION: Optional domain name for your production environment. If provided domain and SSL cerficate will be created."
 
 isGitHubCLIInstalled=$(command -v gh > /dev/null 2>&1 && echo "true" || echo "false")
 if [[ "$isGitHubCLIInstalled" == "true" ]]; then
@@ -213,7 +215,7 @@ if [[ "$isGitHubCLIInstalled" == "true" ]]; then
     if [[ -n "$clusterPrefix" ]]; then
       gh variable set UNIQUE_CLUSTER_PREFIX -b"$clusterPrefix" --repo=$gitHubRepositoryPath || exit 1
     fi
-     
+
     echo -e "${GREEN}Successfully created secrets in GitHub.${RESET}"
   fi
 fi
@@ -232,7 +234,6 @@ fi
 echo -e "\n${YELLOW}To finalize setting configuration of GitHub, please follow these instructions to setup environments:${RESET}"
 echo -e "- Navigate to: $gitHubRepositoryUrl/settings/environments"
 echo -e "- Create three environments named: ${BOLD}production${NO_BOLD}, ${BOLD}staging${NO_BOLD}, and ${BOLD}shared${NO_BOLD}."
-echo -e "- For the ${BOLD}production${NO_BOLD} and ${BOLD}staging${NO_BOLD} environments, optionally create an environment variable named ${BOLD}DOMAIN_NAME${NO_BOLD} to set up a Custom Domain name and SSL Certificate."
 echo -e "- It's also recommended to set up 'Required reviewers' and 'Branch protection rules' for each environment to ensure only code from the main branch are deployed."
 
 


### PR DESCRIPTION
### Summary & Motivation

Streamline the deployment process by merging the Plan jobs for Shared, Staging, and Production into a singular Plan job. In a similar fashion, unify the jobs for Shared Environment Resources and Cluster deployment into one consolidated job per environment. This refinement reduces the deployment steps to a Plan, Shared, Staging, and Production jobs.

This reorganization not only eliminates redundant tasks such as code checkout, Azure login, and Bicep installation but also introduces a trade-off by potentially making the multi-cluster deployment process less transparent.

Furthermore, transition the DOMAIN_NAME environment variable to utilize DOMAIN_NAME_STAGING and DOMAIN_NAME_PRODUCTION. This adaptation allows for the effective reuse of these variables in the Plan job, circumventing its lack of access to environment-specific variables.


### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
