### PR TITLE
Improve Bash Deployment Scripts for Robust Error Handling

### DIFF
--- a/cloud-infrastructure/cluster/config/development-west-europe.sh
+++ b/cloud-infrastructure/cluster/config/development-west-europe.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ENVIRONMENT="development"
 LOCATION="WestEurope"
 LOCATION_PREFIX="west-europe"

--- a/cloud-infrastructure/cluster/config/production-west-europe.sh
+++ b/cloud-infrastructure/cluster/config/production-west-europe.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ENVIRONMENT="production"
 LOCATION="WestEurope"
 LOCATION_PREFIX="west-europe"

--- a/cloud-infrastructure/cluster/config/staging-west-europe.sh
+++ b/cloud-infrastructure/cluster/config/staging-west-europe.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ENVIRONMENT="staging"
 LOCATION="WestEurope"
 LOCATION_PREFIX="west-europe"

--- a/cloud-infrastructure/deploy.sh
+++ b/cloud-infrastructure/deploy.sh
@@ -19,5 +19,5 @@ fi
 if [[ "$*" == *"--apply"* ]]
 then
     echo "$(date +"%Y-%m-%dT%H:%M:%S") Applying changes..."
-    export output=$($DEPLOYMENT_COMMAND $DEPLOYMENT_PARAMETERS | tee /dev/tty)
+    export output=$($DEPLOYMENT_COMMAND $DEPLOYMENT_PARAMETERS 2>&1)
 fi

--- a/cloud-infrastructure/environment/config/development.sh
+++ b/cloud-infrastructure/environment/config/development.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ENVIRONMENT="development"
 LOCATION="WestEurope"
 

--- a/cloud-infrastructure/environment/config/production.sh
+++ b/cloud-infrastructure/environment/config/production.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ENVIRONMENT="production"
 LOCATION="WestEurope"
 

--- a/cloud-infrastructure/environment/config/staging.sh
+++ b/cloud-infrastructure/environment/config/staging.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ENVIRONMENT="staging"
 LOCATION="WestEurope"
 

--- a/cloud-infrastructure/shared/config/shared-development.sh
+++ b/cloud-infrastructure/shared/config/shared-development.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 ENVIRONMENT="development"
 LOCATION="WestEurope"

--- a/cloud-infrastructure/shared/config/shared.sh
+++ b/cloud-infrastructure/shared/config/shared.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ENVIRONMENT="production"
 LOCATION="WestEurope"
 


### PR DESCRIPTION
### Summary & Motivation

Address error handling in infrastructure Bash deployment scripts to correct the issue where the output of Bicep commands piped to `tee /dev/tty` fails in non-interactive environments. Modify the piping to `2>&1` to capture both `stdout` and `stderr` reliably across different contexts.

Introduce `#!/bin/bash` shebang to all infrastructure scripts to standardize execution behavior and formatting, aligning the local terminal experience with that of GitHub Actions.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
