### PR TITLE
Streamline Azure Container App deployments and update Bicep resource versions

### DIFF
--- a/cloud-infrastructure/cluster/deploy-cluster.sh
+++ b/cloud-infrastructure/cluster/deploy-cluster.sh
@@ -23,9 +23,16 @@ else
   echo "$(date +"%Y-%m-%dT%H:%M:%S") All environment variables are set."
 fi
 
-get_active_version() {
-  local image=$(az containerapp revision list --name $1 --resource-group $RESOURCE_GROUP_NAME --query "[0].properties.template.containers[0].image" --output tsv 2>/dev/null)
-  [ -z "$image" ] && echo "latest" || echo ${image##*:}
+get_active_version()
+{
+   local image=$(az containerapp revision list --name $1 --resource-group $RESOURCE_GROUP_NAME --query "[0].properties.template.containers[0].image" --output tsv 2>/dev/null)
+   local version=${image##*:}
+   
+   if [[ -z "$image" ]]; then
+      echo ""
+   else
+      echo $version
+   fi
 }
 
 function is_domain_configured() {

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -30,7 +30,7 @@ resource existingLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces
   name: '${environment}-log-analytics-workspace'
 }
 
-resource clusterResourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+resource clusterResourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
   name: resourceGroupName
   location: location
   tags: tags

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -181,7 +181,7 @@ module accountManagementApi '../modules/container-app.bicep' = {
     sqlDatabaseName: 'account-management'
     userAssignedIdentityName: 'account-management-${resourceGroupName}'
     domainName: domainName == '' ? '' : 'account-management-api.${domainName}'
-    accountManagementDomainConfigured: domainName != '' && accountManagementDomainConfigured
+    domainConfigured: domainName != '' && accountManagementDomainConfigured
   }
   dependsOn: [accountManagementDatabase]
 }

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -175,6 +175,8 @@ module accountManagementApi '../modules/container-app.bicep' = {
     containerImageTag: accountManagementApiVersion
     cpu: '0.25'
     memory: '0.5Gi'
+    minReplicas: 1
+    maxReplicas: 3
     sqlServerName: clusterUniqueName
     sqlDatabaseName: 'account-management'
     userAssignedIdentityName: 'account-management-${resourceGroupName}'

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -9,7 +9,7 @@ param containerRegistryName string
 param location string = deployment().location
 param sqlAdminObjectId string
 param domainName string
-param accountManagementApiVersion string
+param accountManagementApiVersion string = ''
 param accountManagementDomainConfigured bool
 
 var tags = { environment: environment, 'managed-by': 'bicep' }

--- a/cloud-infrastructure/deploy.sh
+++ b/cloud-infrastructure/deploy.sh
@@ -1,4 +1,6 @@
 set -eo pipefail
+CYAN='\033[0;36m'
+RESET='\033[0m' # Reset formatting
 
 if [[ "$1" == "" ]]
 then
@@ -9,6 +11,7 @@ fi
 if [[ "$*" == *"--plan"* ]]
 then
     echo "$(date +"%Y-%m-%dT%H:%M:%S") Preparing plan..."
+    echo -e "$CYAN$DEPLOYMENT_COMMAND -w $DEPLOYMENT_PARAMETERS$RESET"
     $DEPLOYMENT_COMMAND -w $DEPLOYMENT_PARAMETERS
     if [[ $? -ne 0 ]]; then
         echo "::error::Plan preparation failed."
@@ -19,5 +22,6 @@ fi
 if [[ "$*" == *"--apply"* ]]
 then
     echo "$(date +"%Y-%m-%dT%H:%M:%S") Applying changes..."
+    echo -e "$CYAN$DEPLOYMENT_COMMAND $DEPLOYMENT_PARAMETERS$RESET"
     export output=$($DEPLOYMENT_COMMAND $DEPLOYMENT_PARAMETERS 2>&1)
 fi

--- a/cloud-infrastructure/environment/main-environment.bicep
+++ b/cloud-infrastructure/environment/main-environment.bicep
@@ -6,7 +6,7 @@ param location string = deployment().location
 
 var tags = { environment: environment, 'managed-by': 'bicep' }
 
-resource monitorResourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+resource monitorResourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
   name: resourceGroupName
   location: location
   tags: tags

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -15,7 +15,7 @@ param sqlServerName string
 param sqlDatabaseName string
 param userAssignedIdentityName string
 param domainName string
-param accountManagementDomainConfigured bool
+param domainConfigured bool
 
 resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
   scope: resourceGroup(resourceGroupName)
@@ -63,9 +63,9 @@ resource existingManagedCertificate 'Microsoft.App/managedEnvironments/managedCe
 var customDomainConfiguration = isCustomDomainSet
   ? [
       {
-        bindingType: accountManagementDomainConfigured ? 'SniEnabled' : 'Disabled'
+        bindingType: domainConfigured ? 'SniEnabled' : 'Disabled'
         name: domainName
-        certificateId: accountManagementDomainConfigured ? existingManagedCertificate.id : null
+        certificateId: domainConfigured ? existingManagedCertificate.id : null
       }
     ]
   : []

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -47,12 +47,12 @@ module newManagedCertificate './managed-certificate.bicep' =
     }
   }
 
-resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' existing =
+resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-02-preview' existing =
   if (isCustomDomainSet) {
     name: environmentName
   }
 
-resource existingManagedCertificate 'Microsoft.App/managedEnvironments/managedCertificates@2023-05-01' existing =
+resource existingManagedCertificate 'Microsoft.App/managedEnvironments/managedCertificates@2023-05-02-preview' existing =
   if (isCustomDomainSet) {
     name: certificateName
     parent: containerAppsEnvironment
@@ -69,7 +69,7 @@ var customDomainConfiguration = isCustomDomainSet
   : []
 
 var containerRegistryServerUrl = '${containerRegistryName}.azurecr.io'
-resource containerApp 'Microsoft.App/containerApps@2023-04-01-preview' = {
+resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
   name: name
   location: location
   tags: tags

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -9,6 +9,8 @@ param containerImageName string
 param containerImageTag string
 param cpu string = '0.25'
 param memory string = '0.5Gi'
+param minReplicas int = 1
+param maxReplicas int = 3
 param sqlServerName string
 param sqlDatabaseName string
 param userAssignedIdentityName string
@@ -108,7 +110,8 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
       ]
       revisionSuffix: replace(containerImageTag, '.', '-')
       scale: {
-        minReplicas: 0
+        minReplicas: minReplicas
+        maxReplicas: maxReplicas
       }
     }
     configuration: {

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -70,6 +70,8 @@ var customDomainConfiguration = isCustomDomainSet
     ]
   : []
 
+var imageTag = containerImageTag != '' ? containerImageTag : 'latest'
+
 var containerRegistryServerUrl = '${containerRegistryName}.azurecr.io'
 resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
   name: name
@@ -87,7 +89,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
       containers: [
         {
           name: name
-          image: '${containerRegistryServerUrl}/${containerImageName}:${containerImageTag}'
+          image: '${containerRegistryServerUrl}/${containerImageName}:${imageTag}'
           resources: {
             cpu: json(cpu)
             memory: memory
@@ -108,7 +110,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
           ]
         }
       ]
-      revisionSuffix: replace(containerImageTag, '.', '-')
+      revisionSuffix: containerImageTag == '' ? 'initial' : null
       scale: {
         minReplicas: minReplicas
         maxReplicas: maxReplicas

--- a/cloud-infrastructure/modules/container-apps-environment.bicep
+++ b/cloud-infrastructure/modules/container-apps-environment.bicep
@@ -3,7 +3,7 @@ param location string
 param tags object
 param subnetId string
 
-resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' = {
+resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-02-preview' = {
   name: name
   location: location
   tags: tags

--- a/cloud-infrastructure/modules/container-registry-permission.bicep
+++ b/cloud-infrastructure/modules/container-registry-permission.bicep
@@ -1,7 +1,7 @@
 param containerRegistryName string
 param identityPrincipalId string
 
-resource containerRegistryResource 'Microsoft.ContainerRegistry/registries@2023-06-01-preview' existing = {
+resource containerRegistryResource 'Microsoft.ContainerRegistry/registries@2023-08-01-preview' existing = {
   name: containerRegistryName
 }
 

--- a/cloud-infrastructure/modules/container-registry.bicep
+++ b/cloud-infrastructure/modules/container-registry.bicep
@@ -2,7 +2,7 @@ param name string
 param location string
 param tags object
 
-resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-06-01-preview' = {
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-08-01-preview' = {
   name: name
   location: location
   tags: tags

--- a/cloud-infrastructure/modules/key-vault.bicep
+++ b/cloud-infrastructure/modules/key-vault.bicep
@@ -6,7 +6,7 @@ param subnetId string
 param storageAccountId string
 param workspaceId string
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-02-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: name
   location: location
   tags: tags

--- a/cloud-infrastructure/modules/managed-certificate.bicep
+++ b/cloud-infrastructure/modules/managed-certificate.bicep
@@ -4,11 +4,11 @@ param tags object
 param environmentName string
 param domainName string
 
-resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' existing = {
+resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-02-preview' existing = {
   name: environmentName
 }
 
-resource managedCertificate 'Microsoft.App/managedEnvironments/managedCertificates@2023-05-01' = {
+resource managedCertificate 'Microsoft.App/managedEnvironments/managedCertificates@2023-05-02-preview' = {
   name: name
   parent: containerAppsEnvironment
   location: location

--- a/cloud-infrastructure/modules/microsoft-sql-database.bicep
+++ b/cloud-infrastructure/modules/microsoft-sql-database.bicep
@@ -3,7 +3,7 @@ param databaseName string
 param location string
 param tags object
 
-resource sqlDatabase 'Microsoft.Sql/servers/databases@2022-11-01-preview' = {
+resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-05-01-preview' = {
   name: '${sqlServerName}/${databaseName}'
   location: location
   tags: tags

--- a/cloud-infrastructure/modules/microsoft-sql-server-diagnostic.bicep
+++ b/cloud-infrastructure/modules/microsoft-sql-server-diagnostic.bicep
@@ -9,7 +9,7 @@ resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' e
   name: diagnosticStorageAccountName
 }
 
-resource existingMicrosoftSqlServer 'Microsoft.Sql/servers@2022-11-01-preview' existing = {
+resource existingMicrosoftSqlServer 'Microsoft.Sql/servers@2023-05-01-preview' existing = {
   name: microsoftSqlServerName
 }
 
@@ -31,13 +31,13 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
 }
 
-resource microsoftSqlServerOutboundFirewallRules 'Microsoft.Sql/servers/outboundFirewallRules@2022-11-01-preview' = {
+resource microsoftSqlServerOutboundFirewallRules 'Microsoft.Sql/servers/outboundFirewallRules@2023-05-01-preview' = {
   parent: existingMicrosoftSqlServer
   name: replace(replace(dianosticStorageAccountBlobEndpoint, 'https:', ''), '/', '')
   dependsOn: [roleAssignment]
 }
 
-resource microsoftSqlServerAuditingSettings 'Microsoft.Sql/servers/auditingSettings@2022-11-01-preview' = {
+resource microsoftSqlServerAuditingSettings 'Microsoft.Sql/servers/auditingSettings@2023-05-01-preview' = {
   parent: existingMicrosoftSqlServer
   name: 'default'
   properties: {
@@ -56,7 +56,7 @@ resource microsoftSqlServerAuditingSettings 'Microsoft.Sql/servers/auditingSetti
   dependsOn: [microsoftSqlServerOutboundFirewallRules]
 }
 
-resource microsoftSqlServerVulnerabilityAssessment 'Microsoft.Sql/servers/vulnerabilityAssessments@2022-11-01-preview' = {
+resource microsoftSqlServerVulnerabilityAssessment 'Microsoft.Sql/servers/vulnerabilityAssessments@2023-05-01-preview' = {
   name: 'default'
   parent: existingMicrosoftSqlServer
   properties: {

--- a/cloud-infrastructure/modules/microsoft-sql-server-elastic-pool.bicep
+++ b/cloud-infrastructure/modules/microsoft-sql-server-elastic-pool.bicep
@@ -7,7 +7,7 @@ param skuTier string
 param skuCapacity int
 param maxDatabaseCapacity int
 
-resource microsoftSqlServerElasticPool 'Microsoft.Sql/servers/elasticPools@2022-11-01-preview' = {
+resource microsoftSqlServerElasticPool 'Microsoft.Sql/servers/elasticPools@2023-05-01-preview' = {
   name: '${sqlServerName}/${name}'
   tags: tags
   location: location

--- a/cloud-infrastructure/modules/microsoft-sql-server.bicep
+++ b/cloud-infrastructure/modules/microsoft-sql-server.bicep
@@ -5,7 +5,7 @@ param subnetId string
 param tenantId string
 param sqlAdminObjectId string
 
-resource microsoftSqlServer 'Microsoft.Sql/servers@2022-11-01-preview' = {
+resource microsoftSqlServer 'Microsoft.Sql/servers@2023-05-01-preview' = {
   name: name
   location: location
   tags: tags
@@ -27,7 +27,7 @@ resource microsoftSqlServer 'Microsoft.Sql/servers@2022-11-01-preview' = {
   }
 }
 
-resource sqlServerVirtualNetworkRule 'Microsoft.Sql/servers/virtualNetworkRules@2022-11-01-preview' = {
+resource sqlServerVirtualNetworkRule 'Microsoft.Sql/servers/virtualNetworkRules@2023-05-01-preview' = {
   name: 'sql-server-virtual-network-rule'
   parent: microsoftSqlServer
   properties: {
@@ -36,7 +36,7 @@ resource sqlServerVirtualNetworkRule 'Microsoft.Sql/servers/virtualNetworkRules@
   }
 }
 
-resource microsoftSqlServerSecurityAlertPolicies 'Microsoft.Sql/servers/securityAlertPolicies@2022-11-01-preview' = {
+resource microsoftSqlServerSecurityAlertPolicies 'Microsoft.Sql/servers/securityAlertPolicies@2023-05-01-preview' = {
   parent: microsoftSqlServer
   name: 'Default'
   properties: {

--- a/cloud-infrastructure/modules/private-endpoint-sql-server.bicep
+++ b/cloud-infrastructure/modules/private-endpoint-sql-server.bicep
@@ -4,7 +4,7 @@ param tags object
 param subnetId string
 param sqlServerId string
 
-resource privatelink 'Microsoft.Network/privateEndpoints@2023-04-01' = {
+resource privatelink 'Microsoft.Network/privateEndpoints@2023-05-01' = {
   name: name
   location: location
   tags: tags

--- a/cloud-infrastructure/modules/virtual-network.bicep
+++ b/cloud-infrastructure/modules/virtual-network.bicep
@@ -2,7 +2,7 @@ param name string
 param location string
 param tags object
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
   name: name
   location: location
   tags: tags

--- a/cloud-infrastructure/shared/main-shared.bicep
+++ b/cloud-infrastructure/shared/main-shared.bicep
@@ -7,7 +7,7 @@ param location string = deployment().location
 
 var tags = { environment: environment, 'managed-by': 'bicep' }
 
-resource sharedResourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+resource sharedResourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
   name: resourceGroupName
   location: location
   tags: tags


### PR DESCRIPTION
### Summary & Motivation

Address deployment errors when making revision-based changes to the Azure Container App, which requires a new revision suffix. The revision suffix is now exclusively managed through the `az container app update` command when deploying new container images. The only exception to this rule is the assignment of the suffix `initial` during the creation of a new container. Note that Bicep will make a random suffix in the rare case where revision-based changes are done (like changing CPU, Memory, and scaling rules).

Furthermore, the `account-management-api` configuration is adjusted to run 1 replica by default, rather than 0. The Container App Bicep module has been enhanced with `minReplicas` and `maxReplicas` parameters, with default values set to 1 and 3, respectively.

Additionally, a minor naming inconsistency in the Container App module is addressed, changing `accountManagementDomainConfigured` to the more concise `domainConfigured`.

Lastly, all Bicep resources have been updated to the latest versions to ensure up-to-date functionality and alignment with current standards.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
