### PR TITLE
Refactoring CQRS structure for enhanced clarity and accessibility

### DIFF
--- a/application/account-management/Api/Tenants/TenantEndpoints.cs
+++ b/application/account-management/Api/Tenants/TenantEndpoints.cs
@@ -12,15 +12,15 @@ public static class TenantEndpoints
         var group = routes.MapGroup(RoutesPrefix);
 
         group.MapGet("/{id}", async Task<ApiResult<TenantResponseDto>> (TenantId id, ISender mediator)
-            => await mediator.Send(new GetTenant.Query(id)));
+            => await mediator.Send(new GetTenantQuery(id)));
 
-        group.MapPost("/", async Task<ApiResult> (CreateTenant.Command command, ISender mediator)
+        group.MapPost("/", async Task<ApiResult> (CreateTenantCommand command, ISender mediator)
             => (await mediator.Send(command)).AddResourceUri(RoutesPrefix));
 
-        group.MapPut("/{id}", async Task<ApiResult> (TenantId id, UpdateTenant.Command command, ISender mediator)
+        group.MapPut("/{id}", async Task<ApiResult> (TenantId id, UpdateTenantCommand command, ISender mediator)
             => await mediator.Send(command with {Id = id}));
 
         group.MapDelete("/{id}", async Task<ApiResult> (TenantId id, ISender mediator)
-            => await mediator.Send(new DeleteTenant.Command(id)));
+            => await mediator.Send(new DeleteTenantCommand(id)));
     }
 }

--- a/application/account-management/Api/Users/UserEndpoints.cs
+++ b/application/account-management/Api/Users/UserEndpoints.cs
@@ -12,15 +12,15 @@ public static class UserEndpoints
         var group = routes.MapGroup(RoutesPrefix);
 
         group.MapGet("/{id}", async Task<ApiResult<UserResponseDto>> (UserId id, ISender mediator)
-            => await mediator.Send(new GetUser.Query(id)));
+            => await mediator.Send(new GetUserQuery(id)));
 
-        group.MapPost("/", async Task<ApiResult> (CreateUser.Command command, ISender mediator)
+        group.MapPost("/", async Task<ApiResult> (CreateUserCommand command, ISender mediator)
             => (await mediator.Send(command)).AddResourceUri(RoutesPrefix));
 
-        group.MapPut("/{id}", async Task<ApiResult> (UserId id, UpdateUser.Command command, ISender mediator)
-            => await mediator.Send(command with {Id = id}));
+        group.MapPut("/{id}", async Task<ApiResult> (UserId id, UpdateUserCommand command, ISender mediator)
+            => await mediator.Send(command with { Id = id }));
 
         group.MapDelete("/{id}", async Task<ApiResult> (UserId id, ISender mediator)
-            => await mediator.Send(new DeleteUser.Command(id)));
+            => await mediator.Send(new DeleteUserCommand(id)));
     }
 }

--- a/application/account-management/Application/Tenants/CreateTenant.cs
+++ b/application/account-management/Application/Tenants/CreateTenant.cs
@@ -5,56 +5,53 @@ using PlatformPlatform.SharedKernel.ApplicationCore.Validation;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants;
 
-public static class CreateTenant
+public sealed record CreateTenantCommand(string Subdomain, string Name, string? Phone, string Email)
+    : ICommand, ITenantValidation, IRequest<Result<TenantId>>;
+
+[UsedImplicitly]
+public sealed class CreateTenantHandler : IRequestHandler<CreateTenantCommand, Result<TenantId>>
 {
-    public sealed record Command(string Subdomain, string Name, string? Phone, string Email)
-        : ICommand, ITenantValidation, IRequest<Result<TenantId>>;
+    private readonly ISender _mediator;
+    private readonly ITenantRepository _tenantRepository;
 
-    [UsedImplicitly]
-    public sealed class Handler : IRequestHandler<Command, Result<TenantId>>
+    public CreateTenantHandler(ITenantRepository tenantRepository, ISender mediator)
     {
-        private readonly ISender _mediator;
-        private readonly ITenantRepository _tenantRepository;
-
-        public Handler(ITenantRepository tenantRepository, ISender mediator)
-        {
-            _tenantRepository = tenantRepository;
-            _mediator = mediator;
-        }
-
-        public async Task<Result<TenantId>> Handle(Command command, CancellationToken cancellationToken)
-        {
-            var tenant = Tenant.Create(command.Subdomain, command.Name, command.Phone);
-            await _tenantRepository.AddAsync(tenant, cancellationToken);
-
-            await CreateTenantOwnerAsync(tenant.Id, command.Email, cancellationToken);
-            return tenant.Id;
-        }
-
-        private async Task CreateTenantOwnerAsync(TenantId tenantId, string tenantOwnerEmail,
-            CancellationToken cancellationToken)
-        {
-            var createTenantOwnerUserCommand = new CreateUser.Command(tenantId, tenantOwnerEmail, UserRole.TenantOwner);
-            var result = await _mediator.Send(createTenantOwnerUserCommand, cancellationToken);
-
-            if (!result.IsSuccess) throw new UnreachableException($"Create Tenant Owner: {result.GetErrorSummary()}");
-        }
+        _tenantRepository = tenantRepository;
+        _mediator = mediator;
     }
 
-    [UsedImplicitly]
-    public sealed class Validator : TenantValidator<Command>
+    public async Task<Result<TenantId>> Handle(CreateTenantCommand command, CancellationToken cancellationToken)
     {
-        public Validator(ITenantRepository tenantRepository)
-        {
-            RuleFor(x => x.Email).NotEmpty().SetValidator(new SharedValidations.Email());
-            RuleFor(x => x.Subdomain).NotEmpty();
-            RuleFor(x => x.Subdomain)
-                .Matches("^[a-z0-9]{3,30}$")
-                .WithMessage("Subdomain must be between 3-30 alphanumeric and lowercase characters.")
-                .MustAsync(async (subdomain, cancellationToken) =>
-                    await tenantRepository.IsSubdomainFreeAsync(subdomain, cancellationToken))
-                .WithMessage("The subdomain is not available.")
-                .When(x => !string.IsNullOrEmpty(x.Subdomain));
-        }
+        var tenant = Tenant.Create(command.Subdomain, command.Name, command.Phone);
+        await _tenantRepository.AddAsync(tenant, cancellationToken);
+
+        await CreateTenantOwnerAsync(tenant.Id, command.Email, cancellationToken);
+        return tenant.Id;
+    }
+
+    private async Task CreateTenantOwnerAsync(TenantId tenantId, string tenantOwnerEmail,
+        CancellationToken cancellationToken)
+    {
+        var createTenantOwnerUserCommand = new CreateUserCommand(tenantId, tenantOwnerEmail, UserRole.TenantOwner);
+        var result = await _mediator.Send(createTenantOwnerUserCommand, cancellationToken);
+
+        if (!result.IsSuccess) throw new UnreachableException($"Create Tenant Owner: {result.GetErrorSummary()}");
+    }
+}
+
+[UsedImplicitly]
+public sealed class CreateTenantValidator : TenantValidator<CreateTenantCommand>
+{
+    public CreateTenantValidator(ITenantRepository tenantRepository)
+    {
+        RuleFor(x => x.Email).NotEmpty().SetValidator(new SharedValidations.Email());
+        RuleFor(x => x.Subdomain).NotEmpty();
+        RuleFor(x => x.Subdomain)
+            .Matches("^[a-z0-9]{3,30}$")
+            .WithMessage("Subdomain must be between 3-30 alphanumeric and lowercase characters.")
+            .MustAsync(async (subdomain, cancellationToken) =>
+                await tenantRepository.IsSubdomainFreeAsync(subdomain, cancellationToken))
+            .WithMessage("The subdomain is not available.")
+            .When(x => !string.IsNullOrEmpty(x.Subdomain));
     }
 }

--- a/application/account-management/Application/Tenants/DeleteTenant.cs
+++ b/application/account-management/Application/Tenants/DeleteTenant.cs
@@ -3,42 +3,36 @@ using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants;
 
-public static class DeleteTenant
+public sealed record DeleteTenantCommand(TenantId Id) : ICommand, IRequest<Result>;
+
+[UsedImplicitly]
+public sealed class DeleteTenantHandler : IRequestHandler<DeleteTenantCommand, Result>
 {
-    public sealed record Command(TenantId Id) : ICommand, IRequest<Result>;
+    private readonly ITenantRepository _tenantRepository;
 
-    [UsedImplicitly]
-    public sealed class Handler : IRequestHandler<Command, Result>
+    public DeleteTenantHandler(ITenantRepository tenantRepository)
     {
-        private readonly ITenantRepository _tenantRepository;
-
-        public Handler(ITenantRepository tenantRepository)
-        {
-            _tenantRepository = tenantRepository;
-        }
-
-        public async Task<Result> Handle(Command command, CancellationToken cancellationToken)
-        {
-            var tenant = await _tenantRepository.GetByIdAsync(command.Id, cancellationToken);
-            if (tenant is null)
-            {
-                return Result.NotFound($"Tenant with id '{command.Id}' not found.");
-            }
-
-            _tenantRepository.Remove(tenant);
-            return Result.Success();
-        }
+        _tenantRepository = tenantRepository;
     }
 
-    [UsedImplicitly]
-    public sealed class Validator : AbstractValidator<Command>
+    public async Task<Result> Handle(DeleteTenantCommand command, CancellationToken cancellationToken)
     {
-        public Validator(IUserRepository userRepository)
-        {
-            RuleFor(x => x.Id)
-                .MustAsync(async (tenantId, cancellationToken) =>
-                    await userRepository.CountTenantUsersAsync(tenantId, cancellationToken) == 0)
-                .WithMessage("All users must be deleted before the tenant can be deleted.");
-        }
+        var tenant = await _tenantRepository.GetByIdAsync(command.Id, cancellationToken);
+        if (tenant is null) return Result.NotFound($"Tenant with id '{command.Id}' not found.");
+
+        _tenantRepository.Remove(tenant);
+        return Result.Success();
+    }
+}
+
+[UsedImplicitly]
+public sealed class DeleteTenantValidator : AbstractValidator<DeleteTenantCommand>
+{
+    public DeleteTenantValidator(IUserRepository userRepository)
+    {
+        RuleFor(x => x.Id)
+            .MustAsync(async (tenantId, cancellationToken) =>
+                await userRepository.CountTenantUsersAsync(tenantId, cancellationToken) == 0)
+            .WithMessage("All users must be deleted before the tenant can be deleted.");
     }
 }

--- a/application/account-management/Application/Tenants/GetTenant.cs
+++ b/application/account-management/Application/Tenants/GetTenant.cs
@@ -3,25 +3,22 @@ using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants;
 
-public static class GetTenant
+public sealed record GetTenantQuery(TenantId Id) : IRequest<Result<TenantResponseDto>>;
+
+[UsedImplicitly]
+public sealed class GetTenantHandler : IRequestHandler<GetTenantQuery, Result<TenantResponseDto>>
 {
-    public sealed record Query(TenantId Id) : IRequest<Result<TenantResponseDto>>;
+    private readonly ITenantRepository _tenantRepository;
 
-    [UsedImplicitly]
-    public sealed class Handler : IRequestHandler<Query, Result<TenantResponseDto>>
+    public GetTenantHandler(ITenantRepository tenantRepository)
     {
-        private readonly ITenantRepository _tenantRepository;
+        _tenantRepository = tenantRepository;
+    }
 
-        public Handler(ITenantRepository tenantRepository)
-        {
-            _tenantRepository = tenantRepository;
-        }
-
-        public async Task<Result<TenantResponseDto>> Handle(Query request, CancellationToken cancellationToken)
-        {
-            var tenant = await _tenantRepository.GetByIdAsync(request.Id, cancellationToken);
-            return tenant?.Adapt<TenantResponseDto>()
-                   ?? Result<TenantResponseDto>.NotFound($"Tenant with id '{request.Id}' not found.");
-        }
+    public async Task<Result<TenantResponseDto>> Handle(GetTenantQuery request, CancellationToken cancellationToken)
+    {
+        var tenant = await _tenantRepository.GetByIdAsync(request.Id, cancellationToken);
+        return tenant?.Adapt<TenantResponseDto>()
+               ?? Result<TenantResponseDto>.NotFound($"Tenant with id '{request.Id}' not found.");
     }
 }

--- a/application/account-management/Application/Tenants/UpdateTenant.cs
+++ b/application/account-management/Application/Tenants/UpdateTenant.cs
@@ -2,44 +2,38 @@ using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants;
 
-public static class UpdateTenant
+public sealed record UpdateTenantCommand : ICommand, ITenantValidation, IRequest<Result>
 {
-    public sealed record Command : ICommand, ITenantValidation, IRequest<Result>
+    [JsonIgnore] // Removes the Id from the API contract
+    public TenantId Id { get; init; } = null!;
+
+    public required string Name { get; init; }
+
+    public string? Phone { get; init; }
+}
+
+[UsedImplicitly]
+public sealed class UpdateTenantHandler : IRequestHandler<UpdateTenantCommand, Result>
+{
+    private readonly ITenantRepository _tenantRepository;
+
+    public UpdateTenantHandler(ITenantRepository tenantRepository)
     {
-        [JsonIgnore] // Removes the Id from the API contract
-        public TenantId Id { get; init; } = null!;
-
-        public required string Name { get; init; }
-
-        public string? Phone { get; init; }
+        _tenantRepository = tenantRepository;
     }
 
-    [UsedImplicitly]
-    public sealed class Handler : IRequestHandler<Command, Result>
+    public async Task<Result> Handle(UpdateTenantCommand command, CancellationToken cancellationToken)
     {
-        private readonly ITenantRepository _tenantRepository;
+        var tenant = await _tenantRepository.GetByIdAsync(command.Id, cancellationToken);
+        if (tenant is null) return Result.NotFound($"Tenant with id '{command.Id}' not found.");
 
-        public Handler(ITenantRepository tenantRepository)
-        {
-            _tenantRepository = tenantRepository;
-        }
-
-        public async Task<Result> Handle(Command command, CancellationToken cancellationToken)
-        {
-            var tenant = await _tenantRepository.GetByIdAsync(command.Id, cancellationToken);
-            if (tenant is null)
-            {
-                return Result.NotFound($"Tenant with id '{command.Id}' not found.");
-            }
-
-            tenant.Update(command.Name, command.Phone);
-            _tenantRepository.Update(tenant);
-            return Result.Success();
-        }
+        tenant.Update(command.Name, command.Phone);
+        _tenantRepository.Update(tenant);
+        return Result.Success();
     }
+}
 
-    [UsedImplicitly]
-    public sealed class Validator : TenantValidator<Command>
-    {
-    }
+[UsedImplicitly]
+public sealed class UpdateTenantValidator : TenantValidator<UpdateTenantCommand>
+{
 }

--- a/application/account-management/Application/Users/CreateUser.cs
+++ b/application/account-management/Application/Users/CreateUser.cs
@@ -3,46 +3,43 @@ using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Application.Users;
 
-public static class CreateUser
+public sealed record CreateUserCommand(TenantId TenantId, string Email, UserRole UserRole)
+    : ICommand, IUserValidation, IRequest<Result<UserId>>;
+
+[UsedImplicitly]
+public sealed class CreateUserHandler : IRequestHandler<CreateUserCommand, Result<UserId>>
 {
-    public sealed record Command(TenantId TenantId, string Email, UserRole UserRole)
-        : ICommand, IUserValidation, IRequest<Result<UserId>>;
+    private readonly IUserRepository _userRepository;
 
-    [UsedImplicitly]
-    public sealed class Handler : IRequestHandler<Command, Result<UserId>>
+    public CreateUserHandler(IUserRepository userRepository)
     {
-        private readonly IUserRepository _userRepository;
-
-        public Handler(IUserRepository userRepository)
-        {
-            _userRepository = userRepository;
-        }
-
-        public async Task<Result<UserId>> Handle(Command command, CancellationToken cancellationToken)
-        {
-            var user = User.Create(command.TenantId, command.Email, command.UserRole);
-            await _userRepository.AddAsync(user, cancellationToken);
-            return user.Id;
-        }
+        _userRepository = userRepository;
     }
 
-    [UsedImplicitly]
-    public sealed class Validator : UserValidator<Command>
+    public async Task<Result<UserId>> Handle(CreateUserCommand command, CancellationToken cancellationToken)
     {
-        public Validator(IUserRepository userRepository, ITenantRepository tenantRepository)
-        {
-            RuleFor(x => x.TenantId)
-                .MustAsync(async (tenantId, cancellationToken) =>
-                    await tenantRepository.ExistsAsync(tenantId, cancellationToken))
-                .WithMessage(x => $"The tenant '{x.TenantId}' does not exist.")
-                .When(x => !string.IsNullOrEmpty(x.Email));
+        var user = User.Create(command.TenantId, command.Email, command.UserRole);
+        await _userRepository.AddAsync(user, cancellationToken);
+        return user.Id;
+    }
+}
 
-            RuleFor(x => x)
-                .MustAsync(async (x, cancellationToken)
-                    => await userRepository.IsEmailFreeAsync(x.TenantId, x.Email, cancellationToken))
-                .WithName("Email")
-                .WithMessage(x => $"The email '{x.Email}' is already in use by another user on this tenant.")
-                .When(x => !string.IsNullOrEmpty(x.Email));
-        }
+[UsedImplicitly]
+public sealed class CreateUserValidator : UserValidator<CreateUserCommand>
+{
+    public CreateUserValidator(IUserRepository userRepository, ITenantRepository tenantRepository)
+    {
+        RuleFor(x => x.TenantId)
+            .MustAsync(async (tenantId, cancellationToken) =>
+                await tenantRepository.ExistsAsync(tenantId, cancellationToken))
+            .WithMessage(x => $"The tenant '{x.TenantId}' does not exist.")
+            .When(x => !string.IsNullOrEmpty(x.Email));
+
+        RuleFor(x => x)
+            .MustAsync(async (x, cancellationToken)
+                => await userRepository.IsEmailFreeAsync(x.TenantId, x.Email, cancellationToken))
+            .WithName("Email")
+            .WithMessage(x => $"The email '{x.Email}' is already in use by another user on this tenant.")
+            .When(x => !string.IsNullOrEmpty(x.Email));
     }
 }

--- a/application/account-management/Application/Users/GetUser.cs
+++ b/application/account-management/Application/Users/GetUser.cs
@@ -3,25 +3,22 @@ using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Application.Users;
 
-public static class GetUser
+public sealed record GetUserQuery(UserId Id) : IRequest<Result<UserResponseDto>>;
+
+[UsedImplicitly]
+public sealed class GetUserHandler : IRequestHandler<GetUserQuery, Result<UserResponseDto>>
 {
-    public sealed record Query(UserId Id) : IRequest<Result<UserResponseDto>>;
+    private readonly IUserRepository _userRepository;
 
-    [UsedImplicitly]
-    public sealed class Handler : IRequestHandler<Query, Result<UserResponseDto>>
+    public GetUserHandler(IUserRepository userRepository)
     {
-        private readonly IUserRepository _userRepository;
+        _userRepository = userRepository;
+    }
 
-        public Handler(IUserRepository userRepository)
-        {
-            _userRepository = userRepository;
-        }
-
-        public async Task<Result<UserResponseDto>> Handle(Query request, CancellationToken cancellationToken)
-        {
-            var user = await _userRepository.GetByIdAsync(request.Id, cancellationToken);
-            return user?.Adapt<UserResponseDto>()
-                   ?? Result<UserResponseDto>.NotFound($"User with id '{request.Id}' not found.");
-        }
+    public async Task<Result<UserResponseDto>> Handle(GetUserQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _userRepository.GetByIdAsync(request.Id, cancellationToken);
+        return user?.Adapt<UserResponseDto>()
+               ?? Result<UserResponseDto>.NotFound($"User with id '{request.Id}' not found.");
     }
 }

--- a/application/account-management/Application/Users/UpdateUser.cs
+++ b/application/account-management/Application/Users/UpdateUser.cs
@@ -2,44 +2,38 @@ using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Application.Users;
 
-public static class UpdateUser
+public sealed record UpdateUserCommand : ICommand, IUserValidation, IRequest<Result>
 {
-    public sealed record Command : ICommand, IUserValidation, IRequest<Result>
+    [JsonIgnore] // Removes the Id from the API contract
+    public UserId Id { get; init; } = null!;
+
+    public required UserRole UserRole { get; init; }
+
+    public required string Email { get; init; }
+}
+
+[UsedImplicitly]
+public sealed class UpdateUserHandler : IRequestHandler<UpdateUserCommand, Result>
+{
+    private readonly IUserRepository _userRepository;
+
+    public UpdateUserHandler(IUserRepository userRepository)
     {
-        [JsonIgnore] // Removes the Id from the API contract
-        public UserId Id { get; init; } = null!;
-
-        public required UserRole UserRole { get; init; }
-
-        public required string Email { get; init; }
+        _userRepository = userRepository;
     }
 
-    [UsedImplicitly]
-    public sealed class Handler : IRequestHandler<Command, Result>
+    public async Task<Result> Handle(UpdateUserCommand command, CancellationToken cancellationToken)
     {
-        private readonly IUserRepository _userRepository;
+        var user = await _userRepository.GetByIdAsync(command.Id, cancellationToken);
+        if (user is null) return Result.NotFound($"User with id '{command.Id}' not found.");
 
-        public Handler(IUserRepository userRepository)
-        {
-            _userRepository = userRepository;
-        }
-
-        public async Task<Result> Handle(Command command, CancellationToken cancellationToken)
-        {
-            var user = await _userRepository.GetByIdAsync(command.Id, cancellationToken);
-            if (user is null)
-            {
-                return Result.NotFound($"User with id '{command.Id}' not found.");
-            }
-
-            user.Update(command.Email, command.UserRole);
-            _userRepository.Update(user);
-            return Result.Success();
-        }
+        user.Update(command.Email, command.UserRole);
+        _userRepository.Update(user);
+        return Result.Success();
     }
+}
 
-    [UsedImplicitly]
-    public sealed class Validator : UserValidator<Command>
-    {
-    }
+[UsedImplicitly]
+public sealed class UpdateUserValidator : UserValidator<UpdateUserCommand>
+{
 }

--- a/application/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
@@ -78,7 +78,7 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         // Arrange
         var subdomain = Faker.Subdomain();
         var email = Faker.Internet.Email();
-        var command = new CreateTenant.Command(subdomain, Faker.TenantName(), Faker.PhoneNumber(), email);
+        var command = new CreateTenantCommand(subdomain, Faker.TenantName(), Faker.PhoneNumber(), email);
 
         // Act
         var response = await TestHttpClient.PostAsJsonAsync("/api/tenants", command);
@@ -86,7 +86,7 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         // Assert
         await EnsureSuccessPostRequest(response, $"/api/tenants/{subdomain}");
         Connection.RowExists("Tenants", subdomain);
-        Connection.ExecuteScalar("SELECT COUNT(*) FROM Users WHERE Email = @email", new {email}).Should().Be(1);
+        Connection.ExecuteScalar("SELECT COUNT(*) FROM Users WHERE Email = @email", new { email }).Should().Be(1);
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         var invalidPhone = Faker.Phone.PhoneNumber("+1 ### ###-INVALID");
         var invalidEmail = Faker.InvalidEmail();
 
-        var command = new CreateTenant.Command(invalidSubdomain, invalidName, invalidPhone, invalidEmail);
+        var command = new CreateTenantCommand(invalidSubdomain, invalidName, invalidPhone, invalidEmail);
 
         // Act
         var response = await TestHttpClient.PostAsJsonAsync("/api/tenants", command);
@@ -119,7 +119,7 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
     {
         // Arrange
         var unavailableSubdomain = DatabaseSeeder.Tenant1.Id;
-        var command = new CreateTenant.Command(unavailableSubdomain, Faker.TenantName(), null, Faker.Internet.Email());
+        var command = new CreateTenantCommand(unavailableSubdomain, Faker.TenantName(), null, Faker.Internet.Email());
 
         // Act
         var response = await TestHttpClient.PostAsJsonAsync("/api/tenants", command);
@@ -137,7 +137,7 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
     {
         // Arrange
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
-        var command = new UpdateTenant.Command {Name = Faker.TenantName(), Phone = Faker.PhoneNumber()};
+        var command = new UpdateTenantCommand { Name = Faker.TenantName(), Phone = Faker.PhoneNumber() };
 
         // Act
         var response = await TestHttpClient.PutAsJsonAsync($"/api/tenants/{existingTenantId}", command);
@@ -153,7 +153,7 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
         var invalidName = Faker.Random.String2(31);
         var invalidPhone = Faker.Phone.PhoneNumber("+1 ### ###-INVALID");
-        var command = new UpdateTenant.Command {Name = invalidName, Phone = invalidPhone};
+        var command = new UpdateTenantCommand { Name = invalidName, Phone = invalidPhone };
 
         // Act
         var response = await TestHttpClient.PutAsJsonAsync($"/api/tenants/{existingTenantId}", command);
@@ -172,7 +172,7 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
     {
         // Arrange
         var unknownTenantId = Faker.Subdomain();
-        var command = new UpdateTenant.Command {Name = Faker.TenantName(), Phone = Faker.PhoneNumber()};
+        var command = new UpdateTenantCommand { Name = Faker.TenantName(), Phone = Faker.PhoneNumber() };
 
         // Act
         var response = await TestHttpClient.PutAsJsonAsync($"/api/tenants/{unknownTenantId}", command);

--- a/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
@@ -75,7 +75,7 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
     {
         // Arrange
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
-        var command = new CreateUser.Command(existingTenantId, Faker.Internet.Email(), UserRole.TenantUser);
+        var command = new CreateUserCommand(existingTenantId, Faker.Internet.Email(), UserRole.TenantUser);
 
         // Act
         var response = await TestHttpClient.PostAsJsonAsync("/api/users", command);
@@ -91,7 +91,7 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
         // Arrange
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
         var invalidEmail = Faker.InvalidEmail();
-        var command = new CreateUser.Command(existingTenantId, invalidEmail, UserRole.TenantUser);
+        var command = new CreateUserCommand(existingTenantId, invalidEmail, UserRole.TenantUser);
 
         // Act
         var response = await TestHttpClient.PostAsJsonAsync("/api/users", command);
@@ -110,7 +110,7 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
         // Arrange
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
         var existingUserEmail = DatabaseSeeder.User1.Email;
-        var command = new CreateUser.Command(existingTenantId, existingUserEmail, UserRole.TenantUser);
+        var command = new CreateUserCommand(existingTenantId, existingUserEmail, UserRole.TenantUser);
 
         // Act
         var response = await TestHttpClient.PostAsJsonAsync("/api/users", command);
@@ -130,7 +130,7 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
         // Arrange
         var unknownTenantId = Faker.Subdomain();
         var command =
-            new CreateUser.Command(new TenantId(unknownTenantId), Faker.Internet.Email(), UserRole.TenantUser);
+            new CreateUserCommand(new TenantId(unknownTenantId), Faker.Internet.Email(), UserRole.TenantUser);
 
         // Act
         var response = await TestHttpClient.PostAsJsonAsync("/api/users", command);
@@ -148,7 +148,7 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
     {
         // Arrange
         var existingUserId = DatabaseSeeder.User1.Id;
-        var command = new UpdateUser.Command {Email = Faker.Internet.Email(), UserRole = UserRole.TenantOwner};
+        var command = new UpdateUserCommand { Email = Faker.Internet.Email(), UserRole = UserRole.TenantOwner };
 
         // Act
         var response = await TestHttpClient.PutAsJsonAsync($"/api/users/{existingUserId}", command);
@@ -163,7 +163,7 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
         // Arrange
         var existingUserId = DatabaseSeeder.User1.Id;
         var invalidEmail = Faker.InvalidEmail();
-        var command = new UpdateUser.Command {Email = invalidEmail, UserRole = UserRole.TenantAdmin};
+        var command = new UpdateUserCommand { Email = invalidEmail, UserRole = UserRole.TenantAdmin };
 
         // Act
         var response = await TestHttpClient.PutAsJsonAsync($"/api/users/{existingUserId}", command);
@@ -181,7 +181,7 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
     {
         // Arrange
         var unknownUserId = Faker.RandomUlid();
-        var command = new UpdateUser.Command {Email = Faker.Internet.Email(), UserRole = UserRole.TenantAdmin};
+        var command = new UpdateUserCommand { Email = Faker.Internet.Email(), UserRole = UserRole.TenantAdmin };
 
         // Act
         var response = await TestHttpClient.PutAsJsonAsync($"/api/users/{unknownUserId}", command);

--- a/application/account-management/Tests/Application/Tenants/CreateTenantValidationTests.cs
+++ b/application/account-management/Tests/Application/Tenants/CreateTenantValidationTests.cs
@@ -16,7 +16,7 @@ public sealed class CreateTenantValidationTests : BaseTest<AccountManagementDbCo
         string name, string phone, string email)
     {
         // Arrange
-        var command = new CreateTenant.Command(subdomain, name, phone, email);
+        var command = new CreateTenantCommand(subdomain, name, phone, email);
         var mediator = Provider.GetRequiredService<ISender>();
 
         // Act
@@ -44,7 +44,7 @@ public sealed class CreateTenantValidationTests : BaseTest<AccountManagementDbCo
         string subdomain, string name, string phone, string email)
     {
         // Arrange
-        var command = new CreateTenant.Command(subdomain, name, phone, email);
+        var command = new CreateTenantCommand(subdomain, name, phone, email);
         var mediator = Provider.GetRequiredService<ISender>();
 
         // Act

--- a/application/account-management/Tests/Application/Tenants/TenantCreatedEventHandlerTests.cs
+++ b/application/account-management/Tests/Application/Tenants/TenantCreatedEventHandlerTests.cs
@@ -17,7 +17,7 @@ public sealed class TenantCreatedEventHandlerTests : BaseTest<AccountManagementD
         var mediator = Provider.GetRequiredService<ISender>();
 
         // Act
-        var command = new CreateTenant.Command("tenant2", "TestTenant", "1234567890", "test@test.com");
+        var command = new CreateTenantCommand("tenant2", "TestTenant", "1234567890", "test@test.com");
         _ = await mediator.Send(command);
 
         // Assert


### PR DESCRIPTION
### Summary & Motivation

Previously, Commands, Queries, Handlers, and Validators were nested within a static class named after the command or query. For instance, the `CreateTenantCommand` static class included nested `Command`, `Handler`, and `Validator` classes. This approach, while structured, led to references like `CreateTenant.Command` in the API, which received multiple remarks for its complexity and readability.

Addressing these concerns, the nested classes have now been elevated to the top level and renamed accordingly. For example, what was previously `CreateTenant.Command` is now `CreateTenantCommand`.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
