### PR TITLE
Eliminate SonarCloud Java warnings on Pull Requests, remove Bun warnings in clean .NET build

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -68,6 +68,12 @@ jobs:
       - name: Install dotCover
         run: dotnet tool install --global JetBrains.dotCover.GlobalTool
 
+      - name: Setup-java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "microsoft"
+          java-version: "17"
+
       - name: Install SonarScanner
         run: dotnet tool install --global dotnet-sonarscanner
 

--- a/application/account-management/Api/Api.csproj
+++ b/application/account-management/Api/Api.csproj
@@ -31,9 +31,12 @@
         </Content>
     </ItemGroup>
 
-    <Target Name="CreateSwaggerJson" AfterTargets="Build" Condition="$(Configuration)=='Debug'">
+    <Target Name="InstallDependencies" BeforeTargets="Build">
         <Exec Command="dotnet tool restore"/>
         <Exec Command="bun install" WorkingDirectory="$(ProjectDir)/../WebApp/"/>
+    </Target>
+    
+    <Target Name="CreateSwaggerJson" AfterTargets="Build">
         <Exec Command="SWAGGER_GENERATOR=true dotnet swagger tofile --output $(OutputPath)swagger.json $(OutputPath)$(AssemblyName).dll v1" WorkingDirectory="$(ProjectDir)"/>
         <Exec Command="bunx openapi-typescript $(OutputPath)swagger.json -o ../WebApp/src/lib/api/api.generated.d.ts" WorkingDirectory="$(ProjectDir)"/>
         <Exec Command="bunx prettier ../WebApp/src/lib/api/api.generated.d.ts --write" WorkingDirectory="$(ProjectDir)"/>

--- a/application/account-management/WebApp/WebApp.esproj
+++ b/application/account-management/WebApp/WebApp.esproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/0.5.88868-alpha">
 
-    <Target Name="EnsureApiBuildsFirst" BeforeTargets="Build">
-        <MSBuild Projects="../Api/Api.csproj" Targets="Build"/>
-    </Target>
-
     <PropertyGroup>
-        <StartupCommand>set BROWSER=none&amp;&amp;bun dev</StartupCommand>
+        <StartupCommand>set BROWSER=none;bun dev</StartupCommand>
         <JavaScriptTestRoot>src\</JavaScriptTestRoot>
         <JavaScriptTestFramework>Jest</JavaScriptTestFramework>
         <!-- Command to run on project build -->
-        <BuildCommand>bun run build</BuildCommand>
+        <BuildCommand>bun install;bun run build</BuildCommand>
         <!-- Command to create an optimized build of the project that's ready for publishing -->
         <ProductionBuildCommand>bun run build</ProductionBuildCommand>
         <!-- Folder where production build objects will be placed -->
@@ -17,11 +13,14 @@
 
         <NpmInstallCheck>$(MSBuildProjectDirectory)\bun.lockb</NpmInstallCheck>
         <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
-
     </PropertyGroup>
 
     <ItemGroup>
         <Script Include="tsconfig.json"/>
     </ItemGroup>
+
+    <Target Name="EnsureApiBuildsFirst" BeforeTargets="Build">
+        <MSBuild Projects="../Api/Api.csproj" Targets="Build"/>
+    </Target>
 
 </Project>


### PR DESCRIPTION
### Summary & Motivation
The GitHub workflow has been updated to utilize Java 17, ensuring compatibility with SonarCloud. This update is in response to a warning from SonarCloud stating: "The version of Java (11.0.21) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17." By upgrading to Java 17, we align with SonarCloud's requirements, ensuring continued support and avoiding potential disruptions in our analysis processes.

The .NET solution now includes WebApp as a dependency, necessitating the installation of node modules for a successful `dotnet build`. To address this, the `WebApp.csproj` file has been updated to execute `bun install`. Additionally, updates have been made to the API to run `dotnet tool restore` and `bun install` as a pre-build step. These modifications guarantee that the .NET build process will complete successfully without errors upon the initial build of the solution. As a bonus, this also ensures that Rider does not prompt to `Run 'npm' install` when a clean solution is opened.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
