### PR TITLE
Revert Api build events to DEBUG mode only

### DIFF
--- a/application/account-management/Api/Api.csproj
+++ b/application/account-management/Api/Api.csproj
@@ -31,12 +31,12 @@
         </Content>
     </ItemGroup>
 
-    <Target Name="InstallDependencies" BeforeTargets="Build">
+    <Target Name="InstallDependencies" BeforeTargets="Build" Condition="$(Configuration)=='Debug'">
         <Exec Command="dotnet tool restore"/>
         <Exec Command="bun install" WorkingDirectory="$(ProjectDir)/../WebApp/"/>
     </Target>
     
-    <Target Name="CreateSwaggerJson" AfterTargets="Build">
+    <Target Name="CreateSwaggerJson" AfterTargets="Build" Condition="$(Configuration)=='Debug'">
         <Exec Command="SWAGGER_GENERATOR=true dotnet swagger tofile --output $(OutputPath)swagger.json $(OutputPath)$(AssemblyName).dll v1" WorkingDirectory="$(ProjectDir)"/>
         <Exec Command="bunx openapi-typescript $(OutputPath)swagger.json -o ../WebApp/src/lib/api/api.generated.d.ts" WorkingDirectory="$(ProjectDir)"/>
         <Exec Command="bunx prettier ../WebApp/src/lib/api/api.generated.d.ts --write" WorkingDirectory="$(ProjectDir)"/>


### PR DESCRIPTION
### Summary & Motivation

Recent changes to the Api's pre- and post-build events have been reverted. These events were recently changed to run in all modes, including DEBUG and RELEASE. However, this led to an issue in the Docker build process within GitHub, where `bun` was not installed, causing the release build to fail. To resolve this, the build events in the Api project are now set to execute only in DEBUG mode. 

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
