### PR TITLE
Remove multi stage docker builds and reuse GitHub build, fixing container build when running in GitHub workflows

### DIFF
--- a/.github/workflows/_publish-container.yml
+++ b/.github/workflows/_publish-container.yml
@@ -15,6 +15,9 @@ on:
       version:
         required: true
         type: string
+      docker_context:
+        required: true
+        type: string
       docker_file:
         required: true
         type: string
@@ -47,7 +50,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push container image
-        working-directory: application
+        working-directory: ${{ inputs.docker_context }}
         run: |
           docker buildx create --use
           docker buildx build \

--- a/.github/workflows/_publish-container.yml
+++ b/.github/workflows/_publish-container.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   publish-container-image:
     name: Publish Container
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/_publish-container.yml
+++ b/.github/workflows/_publish-container.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           docker buildx create --use
           docker buildx build \
-            --platform linux/amd64 \
+            --platform linux/amd64,linux/arm64 \
             --build-arg VERSION=${{ inputs.version }} \
             -t ${{ vars.CONTAINER_REGISTRY_NAME }}.azurecr.io/${{ inputs.image_name }}:${{ inputs.version }} \
             -t ${{ vars.CONTAINER_REGISTRY_NAME }}.azurecr.io/${{ inputs.image_name }}:latest \

--- a/.github/workflows/_publish-container.yml
+++ b/.github/workflows/_publish-container.yml
@@ -3,6 +3,12 @@ name: "Publish container"
 on:
   workflow_call:
     inputs:
+      artifacts_name:
+        required: true
+        type: string
+      artifacts_path:
+        required: true
+        type: string
       image_name:
         required: true
         type: string
@@ -20,6 +26,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artifacts_name }}
+          path: ${{ inputs.artifacts_path }}
 
       - name: Login to Azure
         uses: azure/login@v1

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -59,10 +59,15 @@ jobs:
         run: dotnet build application/PlatformPlatform.sln --no-restore --configuration Release /p:Version=${{ steps.generate_version.outputs.version }}
 
       - name: Publish Account Management API build
-        working-directory: application/account-management/Api
+        working-directory: application/account-management
         run: |
-          dotnet publish Api.csproj --no-restore --configuration Release --output ./publish --version-suffix ${{ steps.generate_version.outputs.version }}
-          echo "{name}=${{ steps.generate_version.outputs.version }}" >> $GITHUB_OUTPUT
+          dotnet publish ./Api/Api.csproj --no-restore --configuration Release --output ./Api/publish --version-suffix ${{ steps.generate_version.outputs.version }}
+
+      - name: Save Account Management API artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: account-management-api
+          path: application/account-management/Api/publish/**/*
 
   test-with-code-coverage:
     name: Test and Code Coverage
@@ -132,6 +137,8 @@ jobs:
     uses: ./.github/workflows/_publish-container.yml
     secrets: inherit
     with:
+      artifacts_name: account-management-api
+      artifacts_path: application/account-management/Api/publish
       image_name: account-management-api
       version: ${{ needs.build.outputs.version }}
       docker_file: ./account-management/Api/Dockerfile

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -128,7 +128,6 @@ jobs:
 
   account-management-api-publish:
     name: Account Management API Publish
-    if: github.ref == 'refs/heads/main'
     needs: [build]
     uses: ./.github/workflows/_publish-container.yml
     secrets: inherit

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -141,7 +141,8 @@ jobs:
       artifacts_path: application/account-management/Api/publish
       image_name: account-management-api
       version: ${{ needs.build.outputs.version }}
-      docker_file: ./account-management/Api/Dockerfile
+      docker_context: ./application/account-management
+      docker_file: ./Api/Dockerfile
 
   account-management-api-deploy:
     name: Account Management API Deploy

--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ Although some features like authentication and multi-tenancy are not yet impleme
 
 </details>
 
-## React frontend with TypeScript, Bun, and Ant Design
+## React frontend with TypeScript, Bun, and React Aria Components
 
-The Frontend has not yet been created. The plan is to eventually create a frontend with these technologies:
+The frontend is built with these technologies:
 
 - [React](https://react.dev)
 - [TypeScript](https://www.typescriptlang.org)
 - [Bun](https://bun.sh)
-- [Ant Design](https://ant.design)
+- [React Aria Components](https://react-spectrum.adobe.com/react-aria/react-aria-components.html)
 
 ## Azure cloud infrastructure with enterprise-grade security and zero secrets
 
@@ -103,7 +103,7 @@ PlatformPlatform's cloud infrastructure is built using the latest Azure Platform
 
 </details>
 
-## GitHub SDLC for deploying application and infrastructure in minutes
+## GitHub SDLC for passwordless deploying application and infrastructure in minutes
 
 PlatformPlatform is built on a solid foundation for a modern software development lifecycle (SDLC):
 
@@ -118,17 +118,17 @@ PlatformPlatform is built on a solid foundation for a modern software developmen
 
 ## Screenshots
 
-This is how it looks when GitHub workflows have deployed Azure Infrastructure:
+This is how it looks when GitHub workflows has deployed Azure Infrastructure:
 
-![GitHub Environments](https://camo.githubusercontent.com/9b9c33e6c18939d49c3571c610585713707d7b553095270a78c3fe39dc49f811/68747470733a2f2f6d656469612e636c65616e73686f742e636c6f75642f6d656469612f34363533392f7652617130366a374c314b696d4b4a3247434a4e6d724a776c69754572313752577366486f6b78492e6a7065673f457870697265733d31363935353137323638265369676e61747572653d6c6d5171664e59777a735a71634d707a45634b646c51714b636b796b6a706d376b6c62442d5437395a794d537542704b666332794b417832414a6a4a45674a6543575657736671714836624d4c44323974303049317a726848686e59516c4f314f5859665266586b5a6f46304a4c32506d594b5373466a56583763564c4d643774626a48684c6748497e4565573464544f6f564e3434737573436d4452354335383555424b3075626d423161566b763062534e4d466b4435705438394f78656744694f326f4b763061715037464e57764377516978426146314d3830726f36456857514e506d6d4e42345265684e3066784e346676424b3865376573364a34556c5a6b386543687774363953745132395364697635514a756177714a7e413146556e3443796666625737467a725734684d5755554b6f78734d6468596e7667546b78634b48394e663477542d76336c52414c544130515f5f264b65792d506169722d49643d4b3236394a4d4154395a4634475a)
+![GitHub Environments](https://platformplatformgithub.blob.core.windows.net/GitHubInfrastructureDeployments.png)
 
 These are the resource groups created when deploying one staging cluster, and two production clusters:
 
-![PlatformPlatform Resoruce Groups](https://camo.githubusercontent.com/cfe23aa287e301b2cc4d510a510a8ba6f718de1b295ab6e4c2ecc9ea99ac7978/68747470733a2f2f6d656469612e636c65616e73686f742e636c6f75642f6d656469612f34363533392f7137446d537378583330544e614e61636c6d4148456d4769706b6c644d6f7235583139356e5161322e6a7065673f457870697265733d31363935343932393131265369676e61747572653d473461595775634853706655524169776e66456778646874414a7e38413442713656417a6639427469526746496b5238646a754647577a754f4d70714244477675773435527e75452d7a312d786b30613375614271383835475649756a5064622d397e48636c3046367577734f3169644f486c77586431726f47672d6e616e4a6b4461694d43593056763934797675486a5362774a696a4954754161736e77627867444370376372793258584f626f525978706a4178763346616872576c2d306f63555554747a77706f764b454472564843547638567968746b354f44664344666437454530713943434f6e4678575242396e39736e565676503451495975634c4e4d6d6a774d2d6974495277482d336c614b7e355674347132496e6c75427a74745842666c70613570676f755839543776574a5a4c4b7a7a4c466550367a4e68477171456279705547794f6e7033426b46703250415f5f264b65792d506169722d49643d4b3236394a4d4154395a4634475a)
+![PlatformPlatform Resource Groups](https://platformplatformgithub.blob.core.windows.net/PlatformPlatformResourceGroups.png)
 
 This is the security score after deploying PlatformPlatform resources to Azure. Achieving a 100% security score in Azure Defender for Cloud without exemptions is not trivial.
 
-![Azure Security Recommendations](https://camo.githubusercontent.com/7f4217d4f4f96cd2fa83c0047fe162375a8dffe55d616e66bd4fde4baccad4d5/68747470733a2f2f6d656469612e636c65616e73686f742e636c6f75642f6d656469612f34363533392f385a47635a5972723034337a31535846764e716b696c5465544c6f527737726663717755335472392e6a7065673f457870697265733d31363934333935323634265369676e61747572653d4f736b336a447e353879396c466b3271464d4843575a4e39454b374c33456964647e706d59506a6830716f7a7e675243336c6d3938515148646b336b6a61716641526a626d66506f4d485543795767383445634b556433347831525730434f68454637426a787568774e64365268557e444b6165457178515045787251767362766f525a5472453041366b37704b6279566733545638585452544b7e44614d396f5574626571545a6d62705a4a692d5646674f645157724c545733595533556e716a4244373056354d4354444a4e466d656c337347552d7272316c526137567347384b444673443176697543517768762d584676704962506b584c6e374e4c73453833695354676a76324c426d7067754d43764c496d79555a494249617a78534c42354238784c73316f5141746661495a614830487552483462684b672d504b37424f73765a6934304b54567e327137366a506437775f5f264b65792d506169722d49643d4b3236394a4d4154395a4634475a)
+![Azure Security Recommendations](https://platformplatformgithub.blob.core.windows.net/AzureSecurityRecommendations.png)
 
 ## Developer environment for both Mac and Windows
 
@@ -180,26 +180,26 @@ Please run the following scripts once to setup your localhost.
 
   ```bash
   # Generate SQL_SERVER_PASSWORD and add to environment variables
-  SQL_SERVER_PASSWORD=$(curl -s "https://www.random.org/strings/?num=1&len=13&digits=on&upperalpha=on&loweralpha=on&unique=on&format=plain&rnd=new")_
+  SQL_SERVER_PASSWORD="$(LC_ALL=C tr -dc 'a-zA-Z0-9!_#$&%' < /dev/urandom | head -c 16)"
   echo "export SQL_SERVER_PASSWORD='$SQL_SERVER_PASSWORD'" >> ~/.zshrc  # or ~/.bashrc, ~/.bash_profile
 
   # Generate CERTIFICATE_PASSWORD and add to environment variables
-  CERTIFICATE_PASSWORD=$(curl -s "https://www.random.org/strings/?num=1&len=13&digits=on&upperalpha=on&loweralpha=on&unique=on&format=plain&rnd=new")_
+  CERTIFICATE_PASSWORD="$(LC_ALL=C tr -dc 'a-zA-Z0-9!_#$&%' < /dev/urandom | head -c 16)"
   echo "export CERTIFICATE_PASSWORD='$CERTIFICATE_PASSWORD'" >> ~/.zshrc  # or ~/.bashrc, ~/.bash_profile
 
   # Generate dev certificate
   dotnet dev-certs https --trust -ep ${HOME}/.aspnet/https/localhost.pfx -p $CERTIFICATE_PASSWORD
   ```
 
-- **Windows**:
+- **Windows (not tested)**:
 
   ```powershell
-  # Generate SQL_SERVER_PASSWORD and add to environment variables
-  $SQL_SERVER_PASSWORD = Invoke-RestMethod -Uri "https://www.random.org/strings/?num=1&len=13&digits=on&upperalpha=on&loweralpha=on&unique=on&format=plain&rnd=new" + "_"
+  # Add SQL_SERVER_PASSWORD and add to environment variables
+  $SQL_SERVER_PASSWORD = "<YourSecretPassword>"
   [Environment]::SetEnvironmentVariable('SQL_SERVER_PASSWORD', $SQL_SERVER_PASSWORD, [System.EnvironmentVariableTarget]::User)
 
-  # Generate CERTIFICATE_PASSWORD and add to environment variables
-  $CERTIFICATE_PASSWORD = Invoke-RestMethod -Uri "https://www.random.org/strings/?num=1&len=13&digits=on&upperalpha=on&loweralpha=on&unique=on&format=plain&rnd=new" + "_"
+  # Add CERTIFICATE_PASSWORD and add to environment variables
+  $CERTIFICATE_PASSWORD = "<AnotherSecretPassword>"
   [Environment]::SetEnvironmentVariable('CERTIFICATE_PASSWORD', $CERTIFICATE_PASSWORD, [System.EnvironmentVariableTarget]::User)
 
   # Generate dev certificate
@@ -210,14 +210,17 @@ To test the system you can now run this (the first time the API runs it will cre
 
 ```bash
 # Run from the application folder
+cd ./application
+dotnet publish ./account-management/Api/Api.csproj --output ./account-management/Api/publish
 docker compose up -d
-open https://localhost:8443/swagger
+open https://localhost:8443
 ```
 
 While developing you might want to only run the SQL Server, and compile and debug the source code from Rider or Visual Studio:
 
 ```bash
 # Run from the application folder
+cd ./application
 docker compose up sql-server -d
 ```
 

--- a/application/README.md
+++ b/application/README.md
@@ -123,7 +123,7 @@ The architecture is designed following [screaming architecture](https://blog.cle
 Below is a visual representation of the layers. An important constraint is that inner layers cannot reference outer layers. This means that the Domain layer has no knowledge of other layers, and the Application layer only knows about the Domain layer. Also, the API and Infrastructure layer cannot reference each other. However, to allow dependency injection registration, the startup class [Program.cs](/application/account-management/Api/Program.cs) in API calls the Infrastructure layer.
 
 <p align="center">
-  <img src="https://camo.githubusercontent.com/a1eb8809505b6ff0f3c76861c75df8e48faa1805b5fb7a13aa25cefc9654dce2/68747470733a2f2f6d656e74756d74656d702e626c6f622e636f72652e77696e646f77732e6e65742f7075626c69632f436c65616e4172636869746563747572652e706e67" alt="Clean Architecture">
+  <img src="https://platformplatformgithub.blob.core.windows.net/CleanArchitecture.png" alt="Clean Architecture">
 </p>
 
 Tests for the Account Management system are conducted using xUnit, with SQLite for in-memory database testing. The tests can be run directly in JetBrains Rider, Visual Studio, or with the `dotnet test` command. The tests focus on the behavior of the system, not the implementation details. In fact, over 90% code coverage is achieved by testing only the API.

--- a/application/account-management/Api/Api.csproj
+++ b/application/account-management/Api/Api.csproj
@@ -31,11 +31,27 @@
         </Content>
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Remove="publish\**"/>
+        <None Remove="publish\**"/>
+    </ItemGroup>
+
+    <Target Name="InstallDependencies" BeforeTargets="Build">
+        <Exec Command="dotnet tool restore"/>
+        <Exec Command="bun install" WorkingDirectory="$(ProjectDir)/../WebApp/"/>
+    </Target>
+
     <Target Name="CreateSwaggerJson" AfterTargets="Build">
         <Exec Command="SWAGGER_GENERATOR=true dotnet swagger tofile --output $(OutputPath)swagger.json $(OutputPath)$(AssemblyName).dll v1" WorkingDirectory="$(ProjectDir)"/>
         <Exec Command="bunx openapi-typescript@latest $(OutputPath)swagger.json -o ../WebApp/src/lib/api/api.generated.d.ts" WorkingDirectory="$(ProjectDir)"/>
         <Exec Command="bunx prettier ../WebApp/src/lib/api/api.generated.d.ts --write" WorkingDirectory="$(ProjectDir)"/>
         <Exec Command="bun run build" WorkingDirectory="$(ProjectDir)/../WebApp/"/>
+
+        <ItemGroup>
+            <WebAppSourceFiles Include="$(ProjectDir)../WebApp/dist/**/*.*"/>
+        </ItemGroup>
+
+        <Copy SourceFiles="@(WebAppSourceFiles)" DestinationFolder="$(ProjectDir)publish/WebApp/dist/%(RecursiveDir)"/>
     </Target>
 
 </Project>

--- a/application/account-management/Api/Dockerfile
+++ b/application/account-management/Api/Dockerfile
@@ -1,49 +1,14 @@
-# Build stage
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
-# Use version 1.0.0.0 as default
-ARG VERSION=1.0.0.0
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
 
-SHELL ["/bin/bash", "-l", "-c"]
-RUN apt-get update
-RUN apt-get --no-install-recommends install zip unzip
-
-RUN curl -fsSL https://bun.sh/install | bash
-
-WORKDIR /src
-
-# Copy all source code to /src
-COPY ./ ./
-
-# Set the working directory to the WebApp project
-WORKDIR /src/account-management/WebApp
-RUN bun install --freeze-lockfile
-
-# Set the working directory to the API project
-WORKDIR /src/account-management/Api
-RUN dotnet tool restore
-RUN dotnet restore
-RUN dotnet publish -c Release -o /publish /p:Version="$VERSION"
-
-
-# Runtime stage (start with a clean image and copy only published binairies)
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS runtime
-
-WORKDIR /app/WebApp/dist
-COPY --from=build /src/account-management/WebApp/dist ./
-
-WORKDIR /app
-COPY --from=build /publish ./
-
-# Install ICU libraries and other essentials
 RUN apk add --no-cache icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
-# Create non-root user
 RUN adduser -S nonroot
 USER nonroot
 
-# Expose port 8443 (non-root user can't use ports below 1024)
+WORKDIR /app
+COPY ./Api/publish .
+
 EXPOSE 8443
 
-# Entry point
 ENTRYPOINT ["dotnet", "PlatformPlatform.AccountManagement.Api.dll"]

--- a/application/docker-compose.yml
+++ b/application/docker-compose.yml
@@ -15,8 +15,8 @@ services:
   account-management-api:
     container_name: account-management-api
     build:
-      context: .
-      dockerfile: ./account-management/Api/Dockerfile
+      context: ./account-management
+      dockerfile: Api/Dockerfile
     image: account-management-api
     depends_on:
       - sql-server

--- a/cloud-infrastructure/README.md
+++ b/cloud-infrastructure/README.md
@@ -13,7 +13,7 @@ Bicep is an Infrastructure-as-Code (IaC) language specific to Azure. While Bicep
 
 These are the resource groups created when deploying one staging cluster, and two production clusters:
 
-![PlatformPlatform Resource Groups](https://camo.githubusercontent.com/cfe23aa287e301b2cc4d510a510a8ba6f718de1b295ab6e4c2ecc9ea99ac7978/68747470733a2f2f6d656469612e636c65616e73686f742e636c6f75642f6d656469612f34363533392f7137446d537378583330544e614e61636c6d4148456d4769706b6c644d6f7235583139356e5161322e6a7065673f457870697265733d31363935343932393131265369676e61747572653d473461595775634853706655524169776e66456778646874414a7e38413442713656417a6639427469526746496b5238646a754647577a754f4d70714244477675773435527e75452d7a312d786b30613375614271383835475649756a5064622d397e48636c3046367577734f3169644f486c77586431726f47672d6e616e4a6b4461694d43593056763934797675486a5362774a696a4954754161736e77627867444370376372793258584f626f525978706a4178763346616872576c2d306f63555554747a77706f764b454472564843547638567968746b354f44664344666437454530713943434f6e4678575242396e39736e565676503451495975634c4e4d6d6a774d2d6974495277482d336c614b7e355674347132496e6c75427a74745842666c70613570676f755839543776574a5a4c4b7a7a4c466550367a4e68477171456279705547794f6e7033426b46703250415f5f264b65792d506169722d49643d4b3236394a4d4154395a4634475a)
+![PlatformPlatform Resource Groups](https://platformplatformgithub.blob.core.windows.net/PlatformPlatformResourceGroups.png)
 
 All Azure resources are tagged with `environment` (e.g., `staging`, `production`) and `managed-by` (e.g., `bicep`, `manual`) for easier cost tracking and resource management.
 
@@ -42,29 +42,29 @@ _What the script does_:
 - Prompts you for your Azure subscription ID
 - Ensures the `Microsoft.ContainerService` service provider is registered on the Azure Subscription
 - Prompts you for the GitHub repository URL that hosts the GitHub action used for deployment
-- Creates a Service Principal called `GitHub Azure Infrastructure - [GitHubOrg] - [GitHubRepo]` using [federated credentials](https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Clinux#add-federated-credentials)
-- Grants subscription-level `Contributor` and `User Access Administrator` role to the Infrastructure Service Principal
+- Creates a Service Principal called `GitHub Azure - [GitHubOrg] - [GitHubRepo]` using [federated credentials](https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Clinux#add-federated-credentials)
+- Grants subscription-level `Contributor`, `User Access Administrator`, and `AcrPush` role to the Service Principal
 - Creates an `Azure SQL Server Admins` Azure AD security group containing the Infrastructure service principal, allowing GitHub actions to grant Container Apps permissions to SQL databases
-- Creates a Service Principal called `GitHub Azure Container Registry - [GitHubOrg] - [GitHubRepo]` using [federated credentials](https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Clinux#add-federated-credentials)
-- Grants subscription-level 'AcrPush' role to the Container Registry Service Principal
-- Creates GitHub repository secrets and variables - While not truly secrets the TenantId, SubscriptionId, and Service Principal Ids are stored as GitHub repository secrets as it's best practice to not expose them
+- Creates GitHub repository secrets and variables - While not truly secrets the TenantId, SubscriptionId, and Service Principal Id are stored as GitHub repository secrets as it's best practice to not expose them
 
-To run the script, issue this command (use the terminal on macOS and WSL on Windows):
+To run the script, issue this command the follwoing command from a terminal on macOS (or WSL on Windows - not tested):
 
 ```bash
 bash ./cloud-infrastructure/initialize-azure.sh
 ```
+
+![Run initialize-azure bash script](https://platformplatformgithub.blob.core.windows.net/AzureGitHubBashScript.gif)
 
 _Manual steps required_:
 
 Setting up a forked version of PlatformPlatform also requires configuring SonarCloud static code analysis. To set this up follow these steps:
 
 - Sign up for a SonarCloud account here: https://sonarcloud.io using your GitHub account for authentication
-- Create a new Project here: https://sonarcloud.io/projects/create and select your fork of PlatformPlatform
+- Create a new project here: https://sonarcloud.io/projects/create and select your fork of PlatformPlatform
 - Set up the following GitHub repository variables here:
   - `SONAR_ORGANIZATION`. E.g., `platformplatform`
   - `SONAR_PROJECT_KEY`. E.g., `PlatformPlatform_platformplatform`
-- Set up the following GitHub repository secret here:
+- Set up the following GitHub repository secret:
   - `SONAR_TOKEN`
 
 Alternatively, delete the `test-with-code-coverage` from the [application.yml](/.github/workflows/application.yml) workflow.
@@ -85,7 +85,7 @@ The development scripts can be used for easy development, testing, and debugging
      echo "export CONTAINER_REGISTRY_NAME='acmedev'" >> ~/.zshrc  # or ~/.bashrc, ~/.bash_profile
      ```
 
-   - **Windows**:
+   - **Windows (not tested)**:
 
      ```powershell
      [Environment]::SetEnvironmentVariable("UNIQUE_CLUSTER_PREFIX", "acme", "User")
@@ -100,5 +100,3 @@ The development scripts can be used for easy development, testing, and debugging
 7. Run [`./development-west-europe.sh --plan`](/cloud-infrastructure/cluster/config/development-west-europe.sh)
 
 When ready to deploy to Azure, replace the `--plan` flag from the commands above with `--apply`.
-
-![Running Bicep plan for shared](https://camo.githubusercontent.com/29de58a8823f48e16dcbaea5dd6732c4d7a5d74cecea8e5eeb4555483d8e1d5f/68747470733a2f2f6d656469612e636c65616e73686f742e636c6f75642f6d656469612f34363533392f32644d38784371304c7a476d4d4e506f35554366507879417344725067413677535253364168324c2e6a7065673f457870697265733d31363935353837303531265369676e61747572653d664c36527e4773587234556d38725835496f5669426a4a424c66543375364563546b492d675a7057694f53725a6b745269484e7277434d44564b6953457750635666557750584d70367a4249445a73304242576e425834347e64464231786c4b6f52336557714d507654655647414542397363587e4a647873626d64466e6b41376f4a597a6a44512d434c375137304b79477a584f6b64424e7e3964465370524f7462424d722d626531536c3642556f67387a53566f4c547061786b782d62786f71686a4444366744624c5243696b446b484a736a434c664e48615a4d7253436c4d4c346832476e6e6b573269564855393250516b7579662d3945794e6972637842476156576c5741616e44394b442d7867576950705368315265654c556c6b306c46594146716a7138704c426a6f6661643236705a6f536b7751766c78714477654551566d716f637a30626672694e7737765a65515f5f264b65792d506169722d49643d4b3236394a4d4154395a4634475a)


### PR DESCRIPTION
### Summary & Motivation

The strategy for creating container images has been revised to optimize the build process. Instead of building self-contained systems within a multi-stage Dockerfile, the new approach reuses the build artifacts from the GitHub build when creating container images. This change addresses a critical issue that arose with the recent update, where the build of frontend artifacts inside the Docker build was failing in the GitHub runner. Specifically, failures were due to warnings during the `rspack build`, such as "warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)".

This change also opens up for completely removing the dependency on Dockerfiles and using the lightweight and secure .NET Chiseled Ubuntu images and using Aspire instead of Docker Compose for local orchestration.

With the reversal of the multi-stage Docker build approach, the publishing of both amd64 and arm64 container images has been reintroduced.

Additionally, the process for handling pull requests has been updated to publish container images on pull-requests build. This allows for catching errors before merging, and also opens up for testing on feature environments.

Finally, the README files have been updated to reflect recent changes, and also fix broken links to images.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
