### PR TITLE
Update infrastructure to reflect combined API and WebApp

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -58,15 +58,15 @@ jobs:
       - name: Build
         run: dotnet build application/PlatformPlatform.sln --no-restore --configuration Release /p:Version=${{ steps.generate_version.outputs.version }}
 
-      - name: Publish Account Management API build
+      - name: Publish Account Management build
         working-directory: application/account-management
         run: |
           dotnet publish ./Api/Api.csproj --no-restore --configuration Release --output ./Api/publish --version-suffix ${{ steps.generate_version.outputs.version }}
 
-      - name: Save Account Management API artifacts
+      - name: Save Account Management artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: account-management-api
+          name: account-management
           path: application/account-management/Api/publish/**/*
 
   test-with-code-coverage:
@@ -131,31 +131,31 @@ jobs:
           dotnet tool restore
           dotnet jb inspectcode PlatformPlatform.sln --build --output=result.xml --severity=WARNING
 
-  account-management-api-publish:
-    name: Account Management API Publish
+  account-management-publish:
+    name: Account Management Publish
     needs: [build]
     uses: ./.github/workflows/_publish-container.yml
     secrets: inherit
     with:
-      artifacts_name: account-management-api
+      artifacts_name: account-management
       artifacts_path: application/account-management/Api/publish
-      image_name: account-management-api
+      image_name: account-management
       version: ${{ needs.build.outputs.version }}
       docker_context: ./application/account-management
       docker_file: ./Api/Dockerfile
 
-  account-management-api-deploy:
-    name: Account Management API Deploy
+  account-management-deploy:
+    name: Account Management Deploy
     if: github.ref == 'refs/heads/main'
     needs:
       [
         build,
         test-with-code-coverage,
         jetbrains-code-inspection,
-        account-management-api-publish,
+        account-management-publish,
       ]
     uses: ./.github/workflows/_deploy-container.yml
     secrets: inherit
     with:
-      image_name: account-management-api
+      image_name: account-management
       version: ${{ needs.build.outputs.version }}

--- a/application/docker-compose.yml
+++ b/application/docker-compose.yml
@@ -12,12 +12,12 @@ services:
     volumes:
       - sql-server-data:/var/opt/mssql
 
-  account-management-api:
-    container_name: account-management-api
+  account-management:
+    container_name: account-management
     build:
       context: ./account-management
       dockerfile: Api/Dockerfile
-    image: account-management-api
+    image: account-management
     depends_on:
       - sql-server
     ports:

--- a/application/docker-compose.yml
+++ b/application/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       ACCEPT_EULA: "Y"
     volumes:
       - sql-server-data:/var/opt/mssql
+    stop_grace_period: 1s
 
   account-management:
     container_name: account-management

--- a/cloud-infrastructure/cluster/deploy-cluster.sh
+++ b/cloud-infrastructure/cluster/deploy-cluster.sh
@@ -103,5 +103,7 @@ then
   ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID=$(echo "$output" | jq -r '.properties.outputs.accountManagementIdentityClientId.value')
   if [[ -n "$GITHUB_OUTPUT" ]]; then
     echo "ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID=$ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID" >> $GITHUB_OUTPUT
+  else
+    . ./grant-database-permissions.sh 'account-management' $ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID
   fi
 fi

--- a/cloud-infrastructure/cluster/deploy-cluster.sh
+++ b/cloud-infrastructure/cluster/deploy-cluster.sh
@@ -47,12 +47,12 @@ function is_domain_configured() {
 }
 
 RESOURCE_GROUP_NAME="$ENVIRONMENT-$LOCATION_PREFIX"
-ACTIVE_ACCOUNT_MANAGEMENT_API=$(get_active_version account-management-api)
-ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED=$(is_domain_configured "account-management-api" "$RESOURCE_GROUP_NAME")
+ACTIVE_ACCOUNT_MANAGEMENT_VERSION=$(get_active_version account-management)
+ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED=$(is_domain_configured "account-management" "$RESOURCE_GROUP_NAME")
 
 DEPLOYMENT_COMMAND="az deployment sub create"
 CURRENT_DATE=$(date +'%Y-%m-%dT%H-%M')
-DEPLOYMENT_PARAMETERS="-l $LOCATION -n $CURRENT_DATE-$RESOURCE_GROUP_NAME --output json -f ./main-cluster.bicep -p environment=$ENVIRONMENT locationPrefix=$LOCATION_PREFIX resourceGroupName=$RESOURCE_GROUP_NAME clusterUniqueName=$CLUSTER_UNIQUE_NAME useMssqlElasticPool=$USE_MSSQL_ELASTIC_POOL containerRegistryName=$CONTAINER_REGISTRY_NAME domainName=$DOMAIN_NAME sqlAdminObjectId=$ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID accountManagementApiVersion=$ACTIVE_ACCOUNT_MANAGEMENT_API accountManagementDomainConfigured=$ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED"
+DEPLOYMENT_PARAMETERS="-l $LOCATION -n $CURRENT_DATE-$RESOURCE_GROUP_NAME --output json -f ./main-cluster.bicep -p environment=$ENVIRONMENT locationPrefix=$LOCATION_PREFIX resourceGroupName=$RESOURCE_GROUP_NAME clusterUniqueName=$CLUSTER_UNIQUE_NAME useMssqlElasticPool=$USE_MSSQL_ELASTIC_POOL containerRegistryName=$CONTAINER_REGISTRY_NAME domainName=$DOMAIN_NAME sqlAdminObjectId=$ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID accountManagementVersion=$ACTIVE_ACCOUNT_MANAGEMENT_VERSION accountManagementDomainConfigured=$ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED"
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 . ../deploy.sh
@@ -77,8 +77,8 @@ then
 
     # Display instructions for setting up DNS entries
     echo -e "${RED}$(date +"%Y-%m-%dT%H:%M:%S") Please add the following DNS entries to $DOMAIN_NAME, and then retry:${RESET}"
-    echo -e "${RED}- A TXT record with the name 'asuid.account-management-api' and the value '$custom_domain_verification_id'.${RESET}"
-    echo -e "${RED}- A CNAME record with the Host name 'account-management-api' that points to address 'account-management-api.$default_domain'.${RESET}"
+    echo -e "${RED}- A TXT record with the name 'asuid.account-management' and the value '$custom_domain_verification_id'.${RESET}"
+    echo -e "${RED}- A CNAME record with the Host name 'account-management' that points to address 'account-management.$default_domain'.${RESET}"
     exit 1
   elif [[ $output == "ERROR:"* ]]; then
     echo -e "${RED}$output${RESET}"
@@ -87,9 +87,9 @@ then
 
   # If the domain was not configured during the first run and we didn't receive any warnings about missing DNS entries, we trigger the deployment again to complete the binding of the SSL Certificate to the domain.
   if [[ "$ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED" == "false" ]] && [[ "$DOMAIN_NAME" != "" ]]; then
-    echo "Running deployment again to finalize setting up SSL certificate for account-management-api"
+    echo "Running deployment again to finalize setting up SSL certificate for account-management"
     ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED=true
-    DEPLOYMENT_PARAMETERS="-l $LOCATION -n $CURRENT_DATE-$RESOURCE_GROUP_NAME --output json -f ./main-cluster.bicep -p environment=$ENVIRONMENT locationPrefix=$LOCATION_PREFIX resourceGroupName=$RESOURCE_GROUP_NAME clusterUniqueName=$CLUSTER_UNIQUE_NAME useMssqlElasticPool=$USE_MSSQL_ELASTIC_POOL containerRegistryName=$CONTAINER_REGISTRY_NAME domainName=$DOMAIN_NAME sqlAdminObjectId=$ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID accountManagementApiVersion=$ACTIVE_ACCOUNT_MANAGEMENT_API accountManagementDomainConfigured=$ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED"
+    DEPLOYMENT_PARAMETERS="-l $LOCATION -n $CURRENT_DATE-$RESOURCE_GROUP_NAME --output json -f ./main-cluster.bicep -p environment=$ENVIRONMENT locationPrefix=$LOCATION_PREFIX resourceGroupName=$RESOURCE_GROUP_NAME clusterUniqueName=$CLUSTER_UNIQUE_NAME useMssqlElasticPool=$USE_MSSQL_ELASTIC_POOL containerRegistryName=$CONTAINER_REGISTRY_NAME domainName=$DOMAIN_NAME sqlAdminObjectId=$ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID accountManagementVersion=$ACTIVE_ACCOUNT_MANAGEMENT_VERSION accountManagementDomainConfigured=$ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED"
 
     . ../deploy.sh
 

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -9,7 +9,7 @@ param containerRegistryName string
 param location string = deployment().location
 param sqlAdminObjectId string
 param domainName string
-param accountManagementApiVersion string = ''
+param accountManagementVersion string = ''
 param accountManagementDomainConfigured bool
 
 var tags = { environment: environment, 'managed-by': 'bicep' }
@@ -160,19 +160,19 @@ module accountManagementIdentity '../modules/user-assigned-managed-identity.bice
   }
 }
 
-module accountManagementApi '../modules/container-app.bicep' = {
-  name: 'account-management-api'
+module accountManagement '../modules/container-app.bicep' = {
+  name: 'account-management'
   scope: clusterResourceGroup
   params: {
-    name: 'account-management-api'
+    name: 'account-management'
     location: location
     tags: tags
     resourceGroupName: resourceGroupName
     environmentId: contaionerAppsEnvironment.outputs.environmentId
     environmentName: contaionerAppsEnvironment.outputs.name
     containerRegistryName: containerRegistryName
-    containerImageName: 'account-management-api'
-    containerImageTag: accountManagementApiVersion
+    containerImageName: 'account-management'
+    containerImageTag: accountManagementVersion
     cpu: '0.25'
     memory: '0.5Gi'
     minReplicas: 1
@@ -180,7 +180,7 @@ module accountManagementApi '../modules/container-app.bicep' = {
     sqlServerName: clusterUniqueName
     sqlDatabaseName: 'account-management'
     userAssignedIdentityName: 'account-management-${resourceGroupName}'
-    domainName: domainName == '' ? '' : 'account-management-api.${domainName}'
+    domainName: domainName == '' ? '' : 'account-management.${domainName}'
     domainConfigured: domainName != '' && accountManagementDomainConfigured
   }
   dependsOn: [accountManagementDatabase]

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -70,6 +70,11 @@ var customDomainConfiguration = isCustomDomainSet
     ]
   : []
 
+var publicUrl = isCustomDomainSet
+  ? 'https://${domainName}'
+  : 'https://${name}.${containerAppsEnvironment.properties.defaultDomain}'
+var cdnUrl = publicUrl
+
 var imageTag = containerImageTag != '' ? containerImageTag : 'latest'
 
 var containerRegistryServerUrl = '${containerRegistryName}.azurecr.io'
@@ -106,6 +111,14 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
             {
               name: 'MANAGED_IDENTITY_CLIENT_ID'
               value: userAssignedIdentity.properties.clientId
+            }
+            {
+              name: 'PUBLIC_URL'
+              value: publicUrl
+            }
+            {
+              name: 'CDN_URL'
+              value: cdnUrl
             }
           ]
         }

--- a/cloud-infrastructure/modules/microsoft-sql-database.bicep
+++ b/cloud-infrastructure/modules/microsoft-sql-database.bicep
@@ -8,15 +8,12 @@ resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-05-01-preview' = {
   location: location
   tags: tags
   sku: {
-    name: 'GP_S_Gen5'
-    tier: 'GeneralPurpose'
-    family: 'Gen5'
-    capacity: 1
+    name: 'Basic'
+    tier: 'Basic'
+    capacity: 5
   }
   properties: {
     collation: 'SQL_Latin1_General_CP1_CI_AS'
     zoneRedundant: false
-    autoPauseDelay: 60
-    maxSizeBytes: 1073741824
   }
 }


### PR DESCRIPTION
### Summary & Motivation

Rename the `Account Management API` container app, image, domain prefix, and related components to `Account Management`. This change reflects the integration of the API and SPA into the same container.

Add logic in Bicep to set the `PUBLIC_URL` and `CDN_URL` environment variables based on whether the container app has an FQDN attached. These variables are injected into the SPA by the newly added `WebAppMiddleware`.

Change in the SQL database SKU to 'Basic' to reduce hosting costs. This size is adequate for the current workload.

Update to the cluster deployment script to grant database permissions when running outside the GitHub action, such as from a terminal.

Lastly, modify the Docker Compose configuration to enable a quick shutdown of the SQL server container in 1 second.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
