### PR TITLE
Upgrade to .NET 8 in projects, Dockerfile, GitHub workflows, etc.

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -106,9 +106,12 @@ jobs:
           dotnet dotcover test PlatformPlatform.sln --dcOutput="coverage/dotCover.html" --dcReportType=HTML &&
           dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
 
+  # Temporarily disable jetbrains-code-inspection until .NET 8 support is added
+  # See https://youtrack.jetbrains.com/issue/RSRP-494775 and https://youtrack.jetbrains.com/issue/RSRP-494809
   jetbrains-code-inspection:
     name: JetBrains Code Inspections
     needs: build
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -162,11 +165,10 @@ jobs:
   account-management-deploy:
     name: Account Management Deploy
     if: github.ref == 'refs/heads/main'
-    needs:
-      [
+    needs: [
         build,
         test-with-code-coverage,
-        jetbrains-code-inspection,
+        #jetbrains-code-inspection,
         account-management-publish,
       ]
     uses: ./.github/workflows/_deploy-container.yml

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
 
       - name: Restore .NET tools
         working-directory: application
@@ -79,6 +79,11 @@ jobs:
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v1
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
 
       - name: Restore Node modules
         working-directory: application/account-management/WebApp
@@ -115,7 +120,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
 
       - name: Run code inspections
         working-directory: application

--- a/application/.run/Api_ WebApi.run.xml
+++ b/application/.run/Api_ WebApi.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Api: WebApi" type="LaunchSettings" factoryName=".NET Launch Settings Profile">
     <option name="LAUNCH_PROFILE_PROJECT_FILE_PATH" value="$PROJECT_DIR$/account-management/Api/Api.csproj" />
-    <option name="LAUNCH_PROFILE_TFM" value="net7.0" />
+    <option name="LAUNCH_PROFILE_TFM" value="net8.0" />
     <option name="LAUNCH_PROFILE_NAME" value="WebApi" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <option name="USE_MONO" value="0" />

--- a/application/account-management/Api/Api.csproj
+++ b/application/account-management/Api/Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>PlatformPlatform.AccountManagement.Api</AssemblyName>
         <RootNamespace>PlatformPlatform.AccountManagement.Api</RootNamespace>
         <Nullable>enable</Nullable>

--- a/application/account-management/Api/Api.csproj
+++ b/application/account-management/Api/Api.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/application/account-management/Api/Dockerfile
+++ b/application/account-management/Api/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
 
 RUN apk add --no-cache icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false

--- a/application/account-management/Application/Application.csproj
+++ b/application/account-management/Application/Application.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>PlatformPlatform.AccountManagement.Application</AssemblyName>
         <RootNamespace>PlatformPlatform.AccountManagement.Application</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/application/account-management/Domain/Domain.csproj
+++ b/application/account-management/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>PlatformPlatform.AccountManagement.Domain</AssemblyName>
         <RootNamespace>PlatformPlatform.AccountManagement.Domain</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/application/account-management/Infrastructure/Infrastructure.csproj
+++ b/application/account-management/Infrastructure/Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>PlatformPlatform.AccountManagement.Infrastructure</AssemblyName>
         <RootNamespace>PlatformPlatform.AccountManagement.Infrastructure</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -113,7 +113,9 @@ public abstract partial class BaseApiTests<TContext> : BaseTest<TContext> where 
     private static async Task<ProblemDetails?> DeserializeProblemDetails(HttpResponseMessage response)
     {
         var content = await response.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<ProblemDetails>(content);
+
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        return JsonSerializer.Deserialize<ProblemDetails>(content, options);
     }
 
     private static string SplitCamelCaseTitle(string title)

--- a/application/account-management/Tests/Application/Tenants/CreateTenantValidationTests.cs
+++ b/application/account-management/Tests/Application/Tenants/CreateTenantValidationTests.cs
@@ -13,7 +13,7 @@ public sealed class CreateTenantValidationTests : BaseTest<AccountManagementDbCo
     [InlineData("Valid properties - No phone", "tenant2", "Tenant 2", null, "test@test.com")]
     [InlineData("Valid properties - Empty phone", "tenant2", "Tenant 2", "", "test@test.com")]
     public async Task CreateTenant_WhenValidCommand_ShouldReturnSuccessfulResult(string scenario, string subdomain,
-        string name, string phone, string email)
+        string name, string? phone, string email)
     {
         // Arrange
         var command = new CreateTenantCommand(subdomain, name, phone, email);

--- a/application/account-management/Tests/Tests.csproj
+++ b/application/account-management/Tests/Tests.csproj
@@ -24,15 +24,15 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.11.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.7"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.7"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2"/>
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
         <PackageReference Include="NJsonSchema" Version="10.9.0"/>
-        <PackageReference Include="NSubstitute" Version="5.0.0"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
+        <PackageReference Include="xunit" Version="2.6.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/application/account-management/Tests/Tests.csproj
+++ b/application/account-management/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>PlatformPlatform.AccountManagement.Tests</AssemblyName>
         <RootNamespace>PlatformPlatform.AccountManagement.Tests</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/application/global.json
+++ b/application/global.json
@@ -1,6 +1,6 @@
 {
-    "sdk": {
-        "version": "7.0.403",
-        "rollForward": "latestMinor"
-    }
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestMinor"
+  }
 }

--- a/application/shared-kernel/ApiCore/ApiCore.csproj
+++ b/application/shared-kernel/ApiCore/ApiCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AssemblyName>PlatformPlatform.SharedKernel.ApiCore</AssemblyName>

--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Json;
@@ -39,6 +40,7 @@ public static class ApiCoreConfiguration
         services.Configure<JsonOptions>(options =>
         {
             options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
+            options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
         });
 
         if (builder.Environment.IsDevelopment())

--- a/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -2,16 +2,21 @@ using System.Net;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
 
 namespace PlatformPlatform.SharedKernel.ApiCore.Middleware;
 
 public sealed class GlobalExceptionHandlerMiddleware : IMiddleware
 {
+    private readonly JsonSerializerOptions _jsonSerializerOptions;
     private readonly ILogger _logger;
 
-    public GlobalExceptionHandlerMiddleware(ILogger<GlobalExceptionHandlerMiddleware> logger)
+    public GlobalExceptionHandlerMiddleware(ILogger<GlobalExceptionHandlerMiddleware> logger,
+        IOptions<JsonOptions> jsonOptions)
     {
         _logger = logger;
+        _jsonSerializerOptions = jsonOptions.Value.SerializerOptions;
     }
 
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
@@ -35,7 +40,7 @@ public sealed class GlobalExceptionHandlerMiddleware : IMiddleware
                 Detail = "An error occurred while processing the request."
             };
 
-            var jsonResponse = JsonSerializer.Serialize(problemDetails);
+            var jsonResponse = JsonSerializer.Serialize(problemDetails, _jsonSerializerOptions);
             await context.Response.WriteAsync(jsonResponse);
         }
     }

--- a/application/shared-kernel/ApiCore/Middleware/ModelBindingExceptionHandlerMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/ModelBindingExceptionHandlerMiddleware.cs
@@ -2,11 +2,20 @@ using System.Net;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
 
 namespace PlatformPlatform.SharedKernel.ApiCore.Middleware;
 
 public sealed class ModelBindingExceptionHandlerMiddleware : IMiddleware
 {
+    private readonly JsonSerializerOptions _jsonSerializerOptions;
+
+    public ModelBindingExceptionHandlerMiddleware(IOptions<JsonOptions> jsonOptions)
+    {
+        _jsonSerializerOptions = jsonOptions.Value.SerializerOptions;
+    }
+
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
         try
@@ -26,7 +35,7 @@ public sealed class ModelBindingExceptionHandlerMiddleware : IMiddleware
                 Detail = ex.Message
             };
 
-            var jsonResponse = JsonSerializer.Serialize(problemDetails);
+            var jsonResponse = JsonSerializer.Serialize(problemDetails, _jsonSerializerOptions);
             await context.Response.WriteAsync(jsonResponse);
         }
     }

--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
@@ -100,7 +100,7 @@ public class WebAppMiddleware
     {
         if (context.Request.Path.ToString().EndsWith("/"))
         {
-            context.Response.Headers.Add("Content-Security-Policy", _contentSecurityPolicy);
+            context.Response.Headers.Append("Content-Security-Policy", _contentSecurityPolicy);
             await context.Response.WriteAsync(GetHtmlWithEnvironment());
         }
         else

--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
@@ -3,7 +3,9 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 
 namespace PlatformPlatform.SharedKernel.ApiCore.Middleware;
@@ -19,6 +21,7 @@ public class WebAppMiddleware
     private readonly StringValues _contentSecurityPolicy;
     private readonly string _htmlTemplatePath;
     private readonly bool _isDevelopment;
+    private readonly JsonSerializerOptions _jsonSerializerOptions;
     private readonly RequestDelegate _next;
     private readonly string[] _publicAllowedKeys = { CdnUrlKey, ApplicationVersion };
     private readonly string _publicUrl;
@@ -26,11 +29,12 @@ public class WebAppMiddleware
     private string? _htmlTemplate;
 
     public WebAppMiddleware(RequestDelegate next, Dictionary<string, string> runtimeEnvironment,
-        string htmlTemplatePath)
+        string htmlTemplatePath, IOptions<JsonOptions> jsonOptions)
     {
         _next = next;
         _runtimeEnvironment = runtimeEnvironment;
         _htmlTemplatePath = htmlTemplatePath;
+        _jsonSerializerOptions = jsonOptions.Value.SerializerOptions;
 
         VerifyRuntimeEnvironment(runtimeEnvironment);
 
@@ -58,7 +62,7 @@ public class WebAppMiddleware
         }
 
         var encodeRuntimeEnvironment = Convert.ToBase64String(
-            Encoding.UTF8.GetBytes(JsonSerializer.Serialize(_runtimeEnvironment))
+            Encoding.UTF8.GetBytes(JsonSerializer.Serialize(_runtimeEnvironment, _jsonSerializerOptions))
         );
         var result = _htmlTemplate.Replace("<ENCODED_RUNTIME_ENV>", encodeRuntimeEnvironment);
 

--- a/application/shared-kernel/ApplicationCore/ApplicationCore.csproj
+++ b/application/shared-kernel/ApplicationCore/ApplicationCore.csproj
@@ -13,9 +13,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Mapster" Version="7.3.0"/>
-        <PackageReference Include="MediatR" Version="12.0.1"/>
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.2"/>
+        <PackageReference Include="Mapster" Version="7.4.0" />
+        <PackageReference Include="MediatR" Version="12.2.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
     </ItemGroup>
 
 </Project>

--- a/application/shared-kernel/ApplicationCore/ApplicationCore.csproj
+++ b/application/shared-kernel/ApplicationCore/ApplicationCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>PlatformPlatform.SharedKernel.ApplicationCore</RootNamespace>

--- a/application/shared-kernel/DomainCore/DomainCore.csproj
+++ b/application/shared-kernel/DomainCore/DomainCore.csproj
@@ -10,9 +10,9 @@
 
     <ItemGroup>
         <PackageReference Include="IdGen" Version="3.0.3"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
         <PackageReference Include="MediatR.Contracts" Version="2.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="NUlid" Version="1.7.1"/>
     </ItemGroup>
 

--- a/application/shared-kernel/DomainCore/DomainCore.csproj
+++ b/application/shared-kernel/DomainCore/DomainCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>PlatformPlatform.SharedKernel.DomainCore</RootNamespace>

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
@@ -14,9 +14,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.7"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.7"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>PlatformPlatform.SharedKernel.InfrastructureCore</RootNamespace>

--- a/application/shared-kernel/Tests/Tests.csproj
+++ b/application/shared-kernel/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>PlatformPlatform.SharedKernel.Tests</AssemblyName>
         <RootNamespace>PlatformPlatform.SharedKernel.Tests</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/application/shared-kernel/Tests/Tests.csproj
+++ b/application/shared-kernel/Tests/Tests.csproj
@@ -18,14 +18,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.11.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.7"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.7"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2"/>
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
-        <PackageReference Include="NSubstitute" Version="5.0.0"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
+        <PackageReference Include="xunit" Version="2.6.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
### Summary & Motivation

Upgrade of all project files to .NET 8, including updating of `global.json`, Dockerfile, and related files. Update GitHub workflows to utilize .NET 8, aligning CI/CD processes with the latest .NET version.

Update all NuGet packages to their latest versions for .NET 8 compatibility. This is essential for Microsoft packages like Entity Framework to benefit from the new .NET 8 improvements.

Fix various regression bugs and warnings post-upgrade. This includes configuring JSON serialization globally to use camelCase for consistent and readable JSON data. Also, address the warning in Content-Security-Policy headers from using 'add' to 'append', preventing an "IDictionary.Add will throw..." warning.

Temporarily disable jetbrains-code-inspection until .NET 8 support is added.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
