### PR TITLE
Update code to use C# 12 primary constructors

### DIFF
--- a/application/account-management/Application/Tenants/DeleteTenant.cs
+++ b/application/account-management/Application/Tenants/DeleteTenant.cs
@@ -6,21 +6,15 @@ namespace PlatformPlatform.AccountManagement.Application.Tenants;
 public sealed record DeleteTenantCommand(TenantId Id) : ICommand, IRequest<Result>;
 
 [UsedImplicitly]
-public sealed class DeleteTenantHandler : IRequestHandler<DeleteTenantCommand, Result>
+public sealed class DeleteTenantHandler(ITenantRepository tenantRepository)
+    : IRequestHandler<DeleteTenantCommand, Result>
 {
-    private readonly ITenantRepository _tenantRepository;
-
-    public DeleteTenantHandler(ITenantRepository tenantRepository)
-    {
-        _tenantRepository = tenantRepository;
-    }
-
     public async Task<Result> Handle(DeleteTenantCommand command, CancellationToken cancellationToken)
     {
-        var tenant = await _tenantRepository.GetByIdAsync(command.Id, cancellationToken);
+        var tenant = await tenantRepository.GetByIdAsync(command.Id, cancellationToken);
         if (tenant is null) return Result.NotFound($"Tenant with id '{command.Id}' not found.");
 
-        _tenantRepository.Remove(tenant);
+        tenantRepository.Remove(tenant);
         return Result.Success();
     }
 }

--- a/application/account-management/Application/Tenants/GetTenant.cs
+++ b/application/account-management/Application/Tenants/GetTenant.cs
@@ -6,18 +6,12 @@ namespace PlatformPlatform.AccountManagement.Application.Tenants;
 public sealed record GetTenantQuery(TenantId Id) : IRequest<Result<TenantResponseDto>>;
 
 [UsedImplicitly]
-public sealed class GetTenantHandler : IRequestHandler<GetTenantQuery, Result<TenantResponseDto>>
+public sealed class GetTenantHandler(ITenantRepository tenantRepository)
+    : IRequestHandler<GetTenantQuery, Result<TenantResponseDto>>
 {
-    private readonly ITenantRepository _tenantRepository;
-
-    public GetTenantHandler(ITenantRepository tenantRepository)
-    {
-        _tenantRepository = tenantRepository;
-    }
-
     public async Task<Result<TenantResponseDto>> Handle(GetTenantQuery request, CancellationToken cancellationToken)
     {
-        var tenant = await _tenantRepository.GetByIdAsync(request.Id, cancellationToken);
+        var tenant = await tenantRepository.GetByIdAsync(request.Id, cancellationToken);
         return tenant?.Adapt<TenantResponseDto>()
                ?? Result<TenantResponseDto>.NotFound($"Tenant with id '{request.Id}' not found.");
     }

--- a/application/account-management/Application/Tenants/TenantCreatedEventHandler.cs
+++ b/application/account-management/Application/Tenants/TenantCreatedEventHandler.cs
@@ -1,18 +1,12 @@
 namespace PlatformPlatform.AccountManagement.Application.Tenants;
 
 [UsedImplicitly]
-public sealed class TenantCreatedEventHandler : INotificationHandler<TenantCreatedEvent>
+public sealed class TenantCreatedEventHandler(ILogger<TenantCreatedEventHandler> logger)
+    : INotificationHandler<TenantCreatedEvent>
 {
-    private readonly ILogger<TenantCreatedEventHandler> _logger;
-
-    public TenantCreatedEventHandler(ILogger<TenantCreatedEventHandler> logger)
-    {
-        _logger = logger;
-    }
-
     public Task Handle(TenantCreatedEvent notification, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Raise event to send Welcome mail to tenant");
+        logger.LogInformation("Raise event to send Welcome mail to tenant");
         return Task.CompletedTask;
     }
 }

--- a/application/account-management/Application/Tenants/UpdateTenant.cs
+++ b/application/account-management/Application/Tenants/UpdateTenant.cs
@@ -13,22 +13,16 @@ public sealed record UpdateTenantCommand : ICommand, ITenantValidation, IRequest
 }
 
 [UsedImplicitly]
-public sealed class UpdateTenantHandler : IRequestHandler<UpdateTenantCommand, Result>
+public sealed class UpdateTenantHandler(ITenantRepository tenantRepository)
+    : IRequestHandler<UpdateTenantCommand, Result>
 {
-    private readonly ITenantRepository _tenantRepository;
-
-    public UpdateTenantHandler(ITenantRepository tenantRepository)
-    {
-        _tenantRepository = tenantRepository;
-    }
-
     public async Task<Result> Handle(UpdateTenantCommand command, CancellationToken cancellationToken)
     {
-        var tenant = await _tenantRepository.GetByIdAsync(command.Id, cancellationToken);
+        var tenant = await tenantRepository.GetByIdAsync(command.Id, cancellationToken);
         if (tenant is null) return Result.NotFound($"Tenant with id '{command.Id}' not found.");
 
         tenant.Update(command.Name, command.Phone);
-        _tenantRepository.Update(tenant);
+        tenantRepository.Update(tenant);
         return Result.Success();
     }
 }

--- a/application/account-management/Infrastructure/AccountManagementDbContext.cs
+++ b/application/account-management/Infrastructure/AccountManagementDbContext.cs
@@ -3,12 +3,9 @@ using PlatformPlatform.SharedKernel.InfrastructureCore.EntityFramework;
 
 namespace PlatformPlatform.AccountManagement.Infrastructure;
 
-public sealed class AccountManagementDbContext : SharedKernelDbContext<AccountManagementDbContext>
+public sealed class AccountManagementDbContext(DbContextOptions<AccountManagementDbContext> options)
+    : SharedKernelDbContext<AccountManagementDbContext>(options)
 {
-    public AccountManagementDbContext(DbContextOptions<AccountManagementDbContext> options) : base(options)
-    {
-    }
-
     public DbSet<Tenant> Tenants => Set<Tenant>();
 
     public DbSet<User> Users => Set<User>();

--- a/application/account-management/Infrastructure/Tenants/TenantRepository.cs
+++ b/application/account-management/Infrastructure/Tenants/TenantRepository.cs
@@ -4,12 +4,9 @@ using PlatformPlatform.SharedKernel.InfrastructureCore.Persistence;
 namespace PlatformPlatform.AccountManagement.Infrastructure.Tenants;
 
 [UsedImplicitly]
-internal sealed class TenantRepository : RepositoryBase<Tenant, TenantId>, ITenantRepository
+internal sealed class TenantRepository(AccountManagementDbContext accountManagementDbContext)
+    : RepositoryBase<Tenant, TenantId>(accountManagementDbContext), ITenantRepository
 {
-    public TenantRepository(AccountManagementDbContext accountManagementDbContext) : base(accountManagementDbContext)
-    {
-    }
-
     public Task<bool> IsSubdomainFreeAsync(string subdomain, CancellationToken cancellationToken)
     {
         return DbSet.AllAsync(tenant => tenant.Id != subdomain, cancellationToken);

--- a/application/shared-kernel/ApplicationCore/Behaviors/PublishDomainEventsPipelineBehavior.cs
+++ b/application/shared-kernel/ApplicationCore/Behaviors/PublishDomainEventsPipelineBehavior.cs
@@ -11,18 +11,10 @@ namespace PlatformPlatform.SharedKernel.ApplicationCore.Behaviors;
 ///     services (e.g., send emails) that are not part of the same database transaction. For such tasks, use Integration
 ///     Events instead.
 /// </summary>
-public sealed class PublishDomainEventsPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+public sealed class PublishDomainEventsPipelineBehavior<TRequest, TResponse>
+    (IDomainEventCollector domainEventCollector, IPublisher mediator) : IPipelineBehavior<TRequest, TResponse>
     where TRequest : ICommand where TResponse : ResultBase
 {
-    private readonly IDomainEventCollector _domainEventCollector;
-    private readonly IPublisher _mediator;
-
-    public PublishDomainEventsPipelineBehavior(IDomainEventCollector domainEventCollector, IPublisher mediator)
-    {
-        _domainEventCollector = domainEventCollector;
-        _mediator = mediator;
-    }
-
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next,
         CancellationToken cancellationToken)
     {
@@ -39,7 +31,7 @@ public sealed class PublishDomainEventsPipelineBehavior<TRequest, TResponse> : I
             // Publish the domain event to the MediatR pipeline. Any registered event handlers will be invoked. These
             // event handlers can then carry out any necessary actions, such as managing side effects, updating read
             // models, and so forth.
-            await _mediator.Publish(domainEvent, cancellationToken);
+            await mediator.Publish(domainEvent, cancellationToken);
 
             // It is possible that a domain event handler creates a new domain event, so we need to check if there are
             // any new domain events that need to be published and handled before continuing.
@@ -54,7 +46,7 @@ public sealed class PublishDomainEventsPipelineBehavior<TRequest, TResponse> : I
     /// </summary>
     private void EnqueueAndClearDomainEvents(Queue<IDomainEvent> domainEvents)
     {
-        foreach (var aggregate in _domainEventCollector.GetAggregatesWithDomainEvents())
+        foreach (var aggregate in domainEventCollector.GetAggregatesWithDomainEvents())
         {
             foreach (var domainEvent in aggregate.DomainEvents)
             {

--- a/application/shared-kernel/DomainCore/Entities/AudibleEntity.cs
+++ b/application/shared-kernel/DomainCore/Entities/AudibleEntity.cs
@@ -6,15 +6,10 @@ namespace PlatformPlatform.SharedKernel.DomainCore.Entities;
 ///     The AudibleEntity class extends Entity and implements IAuditableEntity, which adds
 ///     a readonly CreatedAt and private ModifiedAt properties to derived entities.
 /// </summary>
-public abstract class AudibleEntity<T> : Entity<T>, IAuditableEntity where T : IComparable<T>
+public abstract class AudibleEntity<T>(T id) : Entity<T>(id), IAuditableEntity where T : IComparable<T>
 {
-    protected AudibleEntity(T id) : base(id)
-    {
-        CreatedAt = DateTime.UtcNow;
-    }
-
     [UsedImplicitly]
-    public DateTime CreatedAt { get; private set; }
+    public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
 
     [ConcurrencyCheck]
     public DateTime? ModifiedAt { get; private set; }

--- a/application/shared-kernel/DomainCore/Entities/Entity.cs
+++ b/application/shared-kernel/DomainCore/Entities/Entity.cs
@@ -10,18 +10,12 @@ namespace PlatformPlatform.SharedKernel.DomainCore.Entities;
 ///     If two entities have the same identity, they are considered to be the same entity.
 ///     It is recommended to use a <see cref="StronglyTypedLongId{T}" /> for the ID to make the domain more meaningful.
 /// </summary>
-public abstract class Entity<T> : IEquatable<Entity<T>>
-    where T : IComparable<T>
+public abstract class Entity<T>(T id) : IEquatable<Entity<T>> where T : IComparable<T>
 {
-    protected Entity(T id)
-    {
-        Id = id;
-    }
-
     [Key]
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     [UsedImplicitly]
-    public T Id { get; init; }
+    public T Id { get; init; } = id;
 
     public virtual bool Equals(Entity<T>? other)
     {

--- a/application/shared-kernel/DomainCore/Identity/StronglyTypedId.cs
+++ b/application/shared-kernel/DomainCore/Identity/StronglyTypedId.cs
@@ -8,8 +8,7 @@ namespace PlatformPlatform.SharedKernel.DomainCore.Identity;
 ///     When used with Entity Framework, make sure to register the type in the OnModelCreating method in the DbContext.
 /// </summary>
 public abstract record StronglyTypedId<TValue, T>(TValue Value) : IComparable<StronglyTypedId<TValue, T>>
-    where T : StronglyTypedId<TValue, T>
-    where TValue : IComparable<TValue>
+    where T : StronglyTypedId<TValue, T> where TValue : IComparable<TValue>
 {
     public int CompareTo(StronglyTypedId<TValue, T>? other)
     {

--- a/application/shared-kernel/DomainCore/Identity/StronglyTypedIdTypeConverter.cs
+++ b/application/shared-kernel/DomainCore/Identity/StronglyTypedIdTypeConverter.cs
@@ -3,8 +3,7 @@ using System.Globalization;
 namespace PlatformPlatform.SharedKernel.DomainCore.Identity;
 
 public abstract class StronglyTypedIdTypeConverter<TValue, T> : TypeConverter
-    where T : StronglyTypedId<TValue, T>
-    where TValue : IComparable<TValue>
+    where T : StronglyTypedId<TValue, T> where TValue : IComparable<TValue>
 {
     private static readonly MethodInfo? TryParseMethod = typeof(T).GetMethod("TryParse");
 

--- a/application/shared-kernel/InfrastructureCore/EntityFramework/ModelBuilderExtensions.cs
+++ b/application/shared-kernel/InfrastructureCore/EntityFramework/ModelBuilderExtensions.cs
@@ -13,8 +13,7 @@ public static class ModelBuilderExtensions
     /// </summary>
     [UsedImplicitly]
     public static void MapStronglyTypedLongId<T, TId>(this ModelBuilder modelBuilder,
-        Expression<Func<T, TId>> expression)
-        where T : class where TId : StronglyTypedLongId<TId>
+        Expression<Func<T, TId>> expression) where T : class where TId : StronglyTypedLongId<TId>
     {
         modelBuilder
             .Entity<T>()

--- a/application/shared-kernel/InfrastructureCore/EntityFramework/UpdateAuditableEntitiesInterceptor.cs
+++ b/application/shared-kernel/InfrastructureCore/EntityFramework/UpdateAuditableEntitiesInterceptor.cs
@@ -17,10 +17,8 @@ public sealed class UpdateAuditableEntitiesInterceptor : SaveChangesInterceptor
         return base.SavingChanges(eventData, result);
     }
 
-    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
-        DbContextEventData eventData,
-        InterceptionResult<int> result,
-        CancellationToken cancellationToken = default)
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData,
+        InterceptionResult<int> result, CancellationToken cancellationToken = default)
     {
         UpdateEntities(eventData);
 

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -24,8 +24,7 @@ public static class InfrastructureCoreConfiguration
 
     [UsedImplicitly]
     private static IServiceCollection ConfigureDatabaseContext<T>(this IServiceCollection services,
-        IConfiguration configuration)
-        where T : DbContext
+        IConfiguration configuration) where T : DbContext
     {
         if (Environment.GetEnvironmentVariable("SWAGGER_GENERATOR") == "true") return services;
 

--- a/application/shared-kernel/InfrastructureCore/Persistence/RepositoryBase.cs
+++ b/application/shared-kernel/InfrastructureCore/Persistence/RepositoryBase.cs
@@ -15,16 +15,10 @@ namespace PlatformPlatform.SharedKernel.InfrastructureCore.Persistence;
 ///     marked to be added, updated, or deleted, and it's not until the <see cref="IUnitOfWork" /> is committed that the
 ///     changes are actually persisted to the database.
 /// </summary>
-public abstract class RepositoryBase<T, TId>
-    where T : AggregateRoot<TId>
-    where TId : IComparable<TId>
+public abstract class RepositoryBase<T, TId>(DbContext context)
+    where T : AggregateRoot<TId> where TId : IComparable<TId>
 {
-    protected readonly DbSet<T> DbSet;
-
-    protected RepositoryBase(DbContext context)
-    {
-        DbSet = context.Set<T>();
-    }
+    protected readonly DbSet<T> DbSet = context.Set<T>();
 
     public async Task<T?> GetByIdAsync(TId id, CancellationToken cancellationToken)
     {

--- a/application/shared-kernel/InfrastructureCore/Persistence/UnitOfWork.cs
+++ b/application/shared-kernel/InfrastructureCore/Persistence/UnitOfWork.cs
@@ -11,22 +11,15 @@ namespace PlatformPlatform.SharedKernel.InfrastructureCore.Persistence;
 ///     called from the <see cref="UnitOfWorkPipelineBehavior{TRequest,TResponse}" /> in the Application layer.
 /// </summary>
 [UsedImplicitly]
-public sealed class UnitOfWork : IUnitOfWork
+public sealed class UnitOfWork(DbContext dbContext) : IUnitOfWork
 {
-    private readonly DbContext _dbContext;
-
-    public UnitOfWork(DbContext dbContext)
-    {
-        _dbContext = dbContext;
-    }
-
     public async Task CommitAsync(CancellationToken cancellationToken)
     {
-        if (_dbContext.ChangeTracker.Entries<IAggregateRoot>().Any(e => e.Entity.DomainEvents.Any()))
+        if (dbContext.ChangeTracker.Entries<IAggregateRoot>().Any(e => e.Entity.DomainEvents.Any()))
         {
             throw new InvalidOperationException("Domain events must be handled before committing the UnitOfWork.");
         }
 
-        await _dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
### Summary & Motivation

Refactoring applicable constructors across the project to leverage the new C# 12 primary constructors. This change simplifies the constructor syntax and enhances code readability and maintainability.

Additionally, the formatting of existing type declarations has been standardized to ensure consistency throughout the codebase.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
