### PR TITLE
Use central package management for easy updates NuGet packages

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -53,7 +53,8 @@ jobs:
         run: dotnet tool restore
 
       - name: Restore .NET dependencies
-        run: dotnet restore application/PlatformPlatform.sln
+        working-directory: application
+        run: dotnet restore
 
       - name: Build
         run: dotnet build application/PlatformPlatform.sln --no-restore --configuration Release /p:Version=${{ steps.generate_version.outputs.version }}

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -1,0 +1,43 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- PlatformPlatform dependencies - Api -->
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0"/>
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+    <!-- PlatformPlatform dependencies - Application -->
+    <PackageVersion Include="Mapster" Version="7.4.0"/>
+    <PackageVersion Include="MediatR" Version="12.2.0"/>
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0"/>
+    <!-- PlatformPlatform dependencies - Domain-->
+    <PackageVersion Include="IdGen" Version="3.0.3"/>
+    <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0"/>
+    <PackageVersion Include="MediatR.Contracts" Version="2.0.1"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
+    <PackageVersion Include="NUlid" Version="1.7.1"/>
+    <!-- PlatformPlatform dependencies - Infrastructure -->
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.0"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0"/>
+    <PackageVersion Include="Scrutor" Version="4.2.2"/>
+    <!-- PlatformPlatform dependencies - Tests -->
+    <PackageVersion Include="Bogus" Version="34.0.2"/>
+    <PackageVersion Include="coverlet.collector" Version="6.0.0"/>
+    <PackageVersion Include="FluentAssertions" Version="6.12.0"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+    <PackageVersion Include="NetArchTest.Rules" Version="1.3.2"/>
+    <PackageVersion Include="NJsonSchema" Version="10.9.0"/>
+    <PackageVersion Include="NSubstitute" Version="5.1.0"/>
+    <PackageVersion Include="xunit" Version="2.6.2"/>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4"/>
+  </ItemGroup>
+
+</Project>

--- a/application/account-management/Api/Api.csproj
+++ b/application/account-management/Api/Api.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/application/account-management/Tests/Tests.csproj
+++ b/application/account-management/Tests/Tests.csproj
@@ -19,20 +19,20 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="34.0.2"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="Bogus"/>
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
-        <PackageReference Include="NJsonSchema" Version="10.9.0"/>
-        <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="FluentAssertions"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="NetArchTest.Rules"/>
+        <PackageReference Include="NJsonSchema"/>
+        <PackageReference Include="NSubstitute"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/application/shared-kernel/ApiCore/ApiCore.csproj
+++ b/application/shared-kernel/ApiCore/ApiCore.csproj
@@ -18,8 +18,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
 </Project>

--- a/application/shared-kernel/ApplicationCore/ApplicationCore.csproj
+++ b/application/shared-kernel/ApplicationCore/ApplicationCore.csproj
@@ -13,9 +13,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Mapster" Version="7.4.0" />
-        <PackageReference Include="MediatR" Version="12.2.0" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
+        <PackageReference Include="Mapster"/>
+        <PackageReference Include="MediatR" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     </ItemGroup>
 
 </Project>

--- a/application/shared-kernel/DomainCore/DomainCore.csproj
+++ b/application/shared-kernel/DomainCore/DomainCore.csproj
@@ -9,11 +9,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="IdGen" Version="3.0.3"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
-        <PackageReference Include="MediatR.Contracts" Version="2.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="NUlid" Version="1.7.1"/>
+        <PackageReference Include="IdGen" />
+        <PackageReference Include="JetBrains.Annotations" />
+        <PackageReference Include="MediatR.Contracts" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="NUlid" />
     </ItemGroup>
 
 </Project>

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
@@ -14,13 +14,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Scrutor" Version="4.2.2"/>
+        <PackageReference Include="Scrutor" />
     </ItemGroup>
 
 </Project>

--- a/application/shared-kernel/Tests/Tests.csproj
+++ b/application/shared-kernel/Tests/Tests.csproj
@@ -18,18 +18,18 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
-        <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NetArchTest.Rules" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
### Summary & Motivation

This update introduces central package management for NuGet packages, a feature from .NET 6. It involves adding a `Directory.Packages.props` file in the root of the solution. All `.csproj` files have been updated to not specify versions.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
