### PR TITLE
Upgrade JetBrains tools to 2023.3 EAP for .NET 8 support

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -136,6 +136,10 @@ jobs:
           dotnet tool restore &&
           dotnet workload install aspire
 
+      - name: Restore .NET dependencies
+        working-directory: application
+        run: dotnet restore
+
       - name: Run code inspections
         working-directory: application
         run: |

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -114,12 +114,9 @@ jobs:
           dotnet dotcover test PlatformPlatform.sln --dcOutput="coverage/dotCover.html" --dcReportType=HTML &&
           dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
 
-  # Temporarily disable jetbrains-code-inspection until .NET 8 support is added
-  # See https://youtrack.jetbrains.com/issue/RSRP-494775 and https://youtrack.jetbrains.com/issue/RSRP-494809
   jetbrains-code-inspection:
     name: JetBrains Code Inspections
     needs: build
-    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -142,7 +139,7 @@ jobs:
       - name: Run code inspections
         working-directory: application
         run: |
-          dotnet jb inspectcode PlatformPlatform.sln --build --output=result.xml --severity=SUGGESTION --exclude="**/*.csproj" # Exclude .csproj. See https://youtrack.jetbrains.com/issue/RSRP-490866
+          dotnet jb inspectcode PlatformPlatform.sln --build --output=result.xml --severity=SUGGESTION
 
           # Check if there are any issues. <Issues /> indicates no issues found.
           if ! grep -q '<Issues />' result.xml; then
@@ -178,10 +175,11 @@ jobs:
   account-management-deploy:
     name: Account Management Deploy
     if: github.ref == 'refs/heads/main'
-    needs: [
+    needs:
+      [
         build,
         test-with-code-coverage,
-        #jetbrains-code-inspection,
+        jetbrains-code-inspection,
         account-management-publish,
       ]
     uses: ./.github/workflows/_deploy-container.yml

--- a/application/AppHost/FrontendAppHostingExtension.cs
+++ b/application/AppHost/FrontendAppHostingExtension.cs
@@ -32,8 +32,12 @@ internal class FrontendAppAddPortLifecycleHook : IDistributedApplicationLifecycl
 
 internal static class FrontendAppHostingExtension
 {
-    public static IResourceBuilder<FrontendAppResource> AddBunApp(this IDistributedApplicationBuilder builder,
-        string name, string workingDirectory, string bunCommand)
+    public static IResourceBuilder<FrontendAppResource> AddBunApp(
+        this IDistributedApplicationBuilder builder,
+        string name,
+        string workingDirectory,
+        string bunCommand
+    )
     {
         var resource = new FrontendAppResource(name, "bun", workingDirectory, new[] { "run", bunCommand });
 

--- a/application/PlatformPlatform.sln.DotSettings
+++ b/application/PlatformPlatform.sln.DotSettings
@@ -78,6 +78,9 @@
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_AROUND_SINGLE_LINE_AUTO_PROPERTY/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_AROUND_SINGLE_LINE_INVOCABLE/@EntryValue">1</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_DECLARATION_LPAR/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_DECLARATION_RPAR/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_PARAMETERS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>

--- a/application/account-management/Application/Tenants/CreateTenant.cs
+++ b/application/account-management/Application/Tenants/CreateTenant.cs
@@ -41,8 +41,7 @@ public sealed class CreateTenantValidator : TenantValidator<CreateTenantCommand>
         RuleFor(x => x.Subdomain)
             .Matches("^[a-z0-9]{3,30}$")
             .WithMessage("Subdomain must be between 3-30 alphanumeric and lowercase characters.")
-            .MustAsync(async (subdomain, cancellationToken) =>
-                await tenantRepository.IsSubdomainFreeAsync(subdomain, cancellationToken))
+            .MustAsync(tenantRepository.IsSubdomainFreeAsync)
             .WithMessage("The subdomain is not available.")
             .When(x => !string.IsNullOrEmpty(x.Subdomain));
     }

--- a/application/account-management/Application/Tenants/CreateTenant.cs
+++ b/application/account-management/Application/Tenants/CreateTenant.cs
@@ -21,8 +21,11 @@ public sealed class CreateTenantHandler(ITenantRepository tenantRepository, ISen
         return tenant.Id;
     }
 
-    private async Task CreateTenantOwnerAsync(TenantId tenantId, string tenantOwnerEmail,
-        CancellationToken cancellationToken)
+    private async Task CreateTenantOwnerAsync(
+        TenantId tenantId,
+        string tenantOwnerEmail,
+        CancellationToken cancellationToken
+    )
     {
         var createTenantOwnerUserCommand = new CreateUserCommand(tenantId, tenantOwnerEmail, UserRole.TenantOwner);
         var result = await mediator.Send(createTenantOwnerUserCommand, cancellationToken);

--- a/application/account-management/Application/Tenants/TenantResponseDto.cs
+++ b/application/account-management/Application/Tenants/TenantResponseDto.cs
@@ -1,5 +1,11 @@
 namespace PlatformPlatform.AccountManagement.Application.Tenants;
 
 [UsedImplicitly]
-public sealed record TenantResponseDto(string Id, DateTime CreatedAt, DateTime? ModifiedAt, string Name,
-    TenantState State, string? Phone);
+public sealed record TenantResponseDto(
+    string Id,
+    DateTime CreatedAt,
+    DateTime? ModifiedAt,
+    string Name,
+    TenantState State,
+    string? Phone
+);

--- a/application/account-management/Application/Tenants/UpdateTenant.cs
+++ b/application/account-management/Application/Tenants/UpdateTenant.cs
@@ -28,6 +28,4 @@ public sealed class UpdateTenantHandler(ITenantRepository tenantRepository)
 }
 
 [UsedImplicitly]
-public sealed class UpdateTenantValidator : TenantValidator<UpdateTenantCommand>
-{
-}
+public sealed class UpdateTenantValidator : TenantValidator<UpdateTenantCommand>;

--- a/application/account-management/Application/Users/CreateUser.cs
+++ b/application/account-management/Application/Users/CreateUser.cs
@@ -7,7 +7,8 @@ public sealed record CreateUserCommand(TenantId TenantId, string Email, UserRole
     : ICommand, IUserValidation, IRequest<Result<UserId>>;
 
 [UsedImplicitly]
-public sealed class CreateUserHandler(IUserRepository userRepository) : IRequestHandler<CreateUserCommand, Result<UserId>>
+public sealed class CreateUserHandler(IUserRepository userRepository)
+    : IRequestHandler<CreateUserCommand, Result<UserId>>
 {
     public async Task<Result<UserId>> Handle(CreateUserCommand command, CancellationToken cancellationToken)
     {
@@ -23,14 +24,13 @@ public sealed class CreateUserValidator : UserValidator<CreateUserCommand>
     public CreateUserValidator(IUserRepository userRepository, ITenantRepository tenantRepository)
     {
         RuleFor(x => x.TenantId)
-            .MustAsync(async (tenantId, cancellationToken) =>
-                await tenantRepository.ExistsAsync(tenantId, cancellationToken))
+            .MustAsync(tenantRepository.ExistsAsync)
             .WithMessage(x => $"The tenant '{x.TenantId}' does not exist.")
             .When(x => !string.IsNullOrEmpty(x.Email));
 
         RuleFor(x => x)
-            .MustAsync(async (x, cancellationToken)
-                => await userRepository.IsEmailFreeAsync(x.TenantId, x.Email, cancellationToken))
+            .MustAsync((x, cancellationToken)
+                => userRepository.IsEmailFreeAsync(x.TenantId, x.Email, cancellationToken))
             .WithName("Email")
             .WithMessage(x => $"The email '{x.Email}' is already in use by another user on this tenant.")
             .When(x => !string.IsNullOrEmpty(x.Email));

--- a/application/account-management/Application/Users/GetUser.cs
+++ b/application/account-management/Application/Users/GetUser.cs
@@ -6,7 +6,8 @@ namespace PlatformPlatform.AccountManagement.Application.Users;
 public sealed record GetUserQuery(UserId Id) : IRequest<Result<UserResponseDto>>;
 
 [UsedImplicitly]
-public sealed class GetUserHandler(IUserRepository userRepository) : IRequestHandler<GetUserQuery, Result<UserResponseDto>>
+public sealed class GetUserHandler(IUserRepository userRepository)
+    : IRequestHandler<GetUserQuery, Result<UserResponseDto>>
 {
     public async Task<Result<UserResponseDto>> Handle(GetUserQuery request, CancellationToken cancellationToken)
     {

--- a/application/account-management/Application/Users/UpdateUser.cs
+++ b/application/account-management/Application/Users/UpdateUser.cs
@@ -27,6 +27,4 @@ public sealed class UpdateUserHandler(IUserRepository userRepository) : IRequest
 }
 
 [UsedImplicitly]
-public sealed class UpdateUserValidator : UserValidator<UpdateUserCommand>
-{
-}
+public sealed class UpdateUserValidator : UserValidator<UpdateUserCommand>;

--- a/application/account-management/Application/Users/UserResponseDto.cs
+++ b/application/account-management/Application/Users/UserResponseDto.cs
@@ -1,5 +1,10 @@
 namespace PlatformPlatform.AccountManagement.Application.Users;
 
 [UsedImplicitly]
-public sealed record UserResponseDto(string Id, DateTime CreatedAt, DateTime? ModifiedAt, string Email,
-    UserRole UserRole);
+public sealed record UserResponseDto(
+    string Id,
+    DateTime CreatedAt,
+    DateTime? ModifiedAt,
+    string Email,
+    UserRole UserRole
+);

--- a/application/account-management/Domain/Tenants/TenantTypes.cs
+++ b/application/account-management/Domain/Tenants/TenantTypes.cs
@@ -24,9 +24,7 @@ public sealed record TenantId(string Value) : StronglyTypedId<string, TenantId>(
     }
 }
 
-public sealed class TenantIdTypeConverter : StronglyTypedIdTypeConverter<string, TenantId>
-{
-}
+public sealed class TenantIdTypeConverter : StronglyTypedIdTypeConverter<string, TenantId>;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
 [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/application/account-management/Domain/Users/UserTypes.cs
+++ b/application/account-management/Domain/Users/UserTypes.cs
@@ -12,9 +12,7 @@ public sealed record UserId(string Value) : StronglyTypedUlid<UserId>(Value)
     }
 }
 
-public sealed class UserIdTypeConverter : StronglyTypedIdTypeConverter<string, UserId>
-{
-}
+public sealed class UserIdTypeConverter : StronglyTypedIdTypeConverter<string, UserId>;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
 [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/application/account-management/Infrastructure/AccountManagementDbContext.cs
+++ b/application/account-management/Infrastructure/AccountManagementDbContext.cs
@@ -20,7 +20,10 @@ public sealed class AccountManagementDbContext(DbContextOptions<AccountManagemen
         // User
         modelBuilder.MapStronglyTypedUuid<User, UserId>(u => u.Id);
         modelBuilder.MapStronglyTypedId<User, TenantId, string>(u => u.TenantId);
-        modelBuilder.Entity<User>().HasOne<Tenant>().WithMany().HasForeignKey(u => u.TenantId)
+        modelBuilder.Entity<User>()
+            .HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(u => u.TenantId)
             .HasPrincipalKey(t => t.Id);
     }
 }

--- a/application/account-management/Infrastructure/InfrastructureConfiguration.cs
+++ b/application/account-management/Infrastructure/InfrastructureConfiguration.cs
@@ -8,8 +8,10 @@ public static class InfrastructureConfiguration
 {
     public static Assembly Assembly => Assembly.GetExecutingAssembly();
 
-    public static IServiceCollection AddInfrastructureServices(this IServiceCollection services,
-        IConfiguration configuration)
+    public static IServiceCollection AddInfrastructureServices(
+        this IServiceCollection services,
+        IConfiguration configuration
+    )
     {
         services.ConfigureInfrastructureCoreServices<AccountManagementDbContext>(configuration, Assembly);
 

--- a/application/account-management/Infrastructure/Users/UserRepository.cs
+++ b/application/account-management/Infrastructure/Users/UserRepository.cs
@@ -4,12 +4,9 @@ using PlatformPlatform.SharedKernel.InfrastructureCore.Persistence;
 namespace PlatformPlatform.AccountManagement.Infrastructure.Users;
 
 [UsedImplicitly]
-internal sealed class UserRepository : RepositoryBase<User, UserId>, IUserRepository
+internal sealed class UserRepository(AccountManagementDbContext accountManagementDbContext)
+    : RepositoryBase<User, UserId>(accountManagementDbContext), IUserRepository
 {
-    public UserRepository(AccountManagementDbContext accountManagementDbContext) : base(accountManagementDbContext)
-    {
-    }
-
     public async Task<bool> IsEmailFreeAsync(TenantId tenantId, string email, CancellationToken cancellationToken)
     {
         return !await DbSet.AnyAsync(u => u.TenantId == tenantId && u.Email == email, cancellationToken);

--- a/application/account-management/Tests/Api/ApiCore/CustomExceptionHandlingTests.cs
+++ b/application/account-management/Tests/Api/ApiCore/CustomExceptionHandlingTests.cs
@@ -42,8 +42,11 @@ public class CustomExceptionHandlingTests : BaseApiTests<AccountManagementDbCont
         else
         {
             // In Production we use GlobalExceptionHandlerMiddleware which returns a JSON response.
-            await EnsureErrorStatusCode(response, HttpStatusCode.InternalServerError,
-                "An error occurred while processing the request.");
+            await EnsureErrorStatusCode(
+                response,
+                HttpStatusCode.InternalServerError,
+                "An error occurred while processing the request."
+            );
         }
     }
 }

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -49,8 +49,11 @@ public abstract partial class BaseApiTests<TContext> : BaseTest<TContext> where 
         response.Headers.Location.Should().BeNull();
     }
 
-    protected static async Task EnsureSuccessPostRequest(HttpResponseMessage response, string? exact = null,
-        string? startsWith = null)
+    protected static async Task EnsureSuccessPostRequest(
+        HttpResponseMessage response,
+        string? exact = null,
+        string? startsWith = null
+    )
     {
         var responseBody = await response.Content.ReadAsStringAsync();
         responseBody.Should().BeEmpty();
@@ -77,14 +80,21 @@ public abstract partial class BaseApiTests<TContext> : BaseTest<TContext> where 
     }
 
     [UsedImplicitly]
-    protected Task EnsureErrorStatusCode(HttpResponseMessage response, HttpStatusCode statusCode,
-        IEnumerable<ErrorDetail> expectedErrors)
+    protected Task EnsureErrorStatusCode(
+        HttpResponseMessage response,
+        HttpStatusCode statusCode,
+        IEnumerable<ErrorDetail> expectedErrors
+    )
     {
         return EnsureErrorStatusCode(response, statusCode, null, expectedErrors);
     }
 
-    protected async Task EnsureErrorStatusCode(HttpResponseMessage response, HttpStatusCode statusCode,
-        string? expectedDetail, IEnumerable<ErrorDetail>? expectedErrors = null)
+    protected async Task EnsureErrorStatusCode(
+        HttpResponseMessage response,
+        HttpStatusCode statusCode,
+        string? expectedDetail,
+        IEnumerable<ErrorDetail>? expectedErrors = null
+    )
     {
         response.StatusCode.Should().Be(statusCode);
         response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -76,6 +76,7 @@ public abstract partial class BaseApiTests<TContext> : BaseTest<TContext> where 
         response.Headers.Location.Should().BeNull();
     }
 
+    [UsedImplicitly]
     protected Task EnsureErrorStatusCode(HttpResponseMessage response, HttpStatusCode statusCode,
         IEnumerable<ErrorDetail> expectedErrors)
     {

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -76,10 +76,10 @@ public abstract partial class BaseApiTests<TContext> : BaseTest<TContext> where 
         response.Headers.Location.Should().BeNull();
     }
 
-    protected async Task EnsureErrorStatusCode(HttpResponseMessage response, HttpStatusCode statusCode,
+    protected Task EnsureErrorStatusCode(HttpResponseMessage response, HttpStatusCode statusCode,
         IEnumerable<ErrorDetail> expectedErrors)
     {
-        await EnsureErrorStatusCode(response, statusCode, null, expectedErrors);
+        return EnsureErrorStatusCode(response, statusCode, null, expectedErrors);
     }
 
     protected async Task EnsureErrorStatusCode(HttpResponseMessage response, HttpStatusCode statusCode,

--- a/application/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
@@ -54,8 +54,11 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         var response = await TestHttpClient.GetAsync($"/api/tenants/{unknownTenantId}");
 
         // Assert
-        await EnsureErrorStatusCode(response, HttpStatusCode.NotFound,
-            $"Tenant with id '{unknownTenantId}' not found.");
+        await EnsureErrorStatusCode(
+            response,
+            HttpStatusCode.NotFound,
+            $"Tenant with id '{unknownTenantId}' not found."
+        );
     }
 
     [Fact]
@@ -68,8 +71,11 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         var response = await TestHttpClient.GetAsync($"/api/tenants/{invalidTenantId}");
 
         // Assert
-        await EnsureErrorStatusCode(response, HttpStatusCode.BadRequest,
-            $"""Failed to bind parameter "TenantId id" from "{invalidTenantId}".""");
+        await EnsureErrorStatusCode(
+            response,
+            HttpStatusCode.BadRequest,
+            $"""Failed to bind parameter "TenantId id" from "{invalidTenantId}"."""
+        );
     }
 
     [Fact]
@@ -178,8 +184,11 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         var response = await TestHttpClient.PutAsJsonAsync($"/api/tenants/{unknownTenantId}", command);
 
         //Assert
-        await EnsureErrorStatusCode(response, HttpStatusCode.NotFound,
-            $"Tenant with id '{unknownTenantId}' not found.");
+        await EnsureErrorStatusCode(
+            response,
+            HttpStatusCode.NotFound,
+            $"Tenant with id '{unknownTenantId}' not found."
+        );
     }
 
     [Fact]
@@ -192,8 +201,11 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         var response = await TestHttpClient.DeleteAsync($"/api/tenants/{unknownTenantId}");
 
         //Assert
-        await EnsureErrorStatusCode(response, HttpStatusCode.NotFound,
-            $"Tenant with id '{unknownTenantId}' not found.");
+        await EnsureErrorStatusCode(
+            response,
+            HttpStatusCode.NotFound,
+            $"Tenant with id '{unknownTenantId}' not found."
+        );
     }
 
     [Fact]

--- a/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
@@ -118,8 +118,10 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
         // Assert
         var expectedErrors = new[]
         {
-            new ErrorDetail("Email",
-                $"The email '{existingUserEmail}' is already in use by another user on this tenant.")
+            new ErrorDetail(
+                "Email",
+                $"The email '{existingUserEmail}' is already in use by another user on this tenant."
+            )
         };
         await EnsureErrorStatusCode(response, HttpStatusCode.BadRequest, expectedErrors);
     }

--- a/application/account-management/Tests/Application/Tenants/CreateTenantValidationTests.cs
+++ b/application/account-management/Tests/Application/Tenants/CreateTenantValidationTests.cs
@@ -12,8 +12,13 @@ public sealed class CreateTenantValidationTests : BaseTest<AccountManagementDbCo
     [InlineData("Valid properties", "tenant2", "Tenant 2", "+44 (0)20 7946 0123", "test@test.com")]
     [InlineData("Valid properties - No phone", "tenant2", "Tenant 2", null, "test@test.com")]
     [InlineData("Valid properties - Empty phone", "tenant2", "Tenant 2", "", "test@test.com")]
-    public async Task CreateTenant_WhenValidCommand_ShouldReturnSuccessfulResult(string scenario, string subdomain,
-        string name, string? phone, string email)
+    public async Task CreateTenant_WhenValidCommand_ShouldReturnSuccessfulResult(
+        string scenario,
+        string subdomain,
+        string name,
+        string? phone,
+        string email
+    )
     {
         // Arrange
         var command = new CreateTenantCommand(subdomain, name, phone, email);
@@ -40,8 +45,13 @@ public sealed class CreateTenantValidationTests : BaseTest<AccountManagementDbCo
     [InlineData("Subdomain with uppercase", "Tenant2", "Tenant 2", "1234567890", "test@test.com")]
     [InlineData("Subdomain special characters", "tenant-2", "Tenant 2", "1234567890", "test@test.com")]
     [InlineData("Subdomain with spaces", "tenant 2", "Tenant 2", "1234567890", "test@test.com")]
-    public async Task CreateTenant_WhenInvalidCommand_ShouldReturnUnsuccessfulResultWithOneError(string scenario,
-        string subdomain, string name, string phone, string email)
+    public async Task CreateTenant_WhenInvalidCommand_ShouldReturnUnsuccessfulResultWithOneError(
+        string scenario,
+        string subdomain,
+        string name,
+        string phone,
+        string email
+    )
     {
         // Arrange
         var command = new CreateTenantCommand(subdomain, name, phone, email);

--- a/application/dotnet-tools.json
+++ b/application/dotnet-tools.json
@@ -11,7 +11,7 @@
       "commands": ["dotnet-dotcover"]
     },
     "jetbrains.resharper.globaltools": {
-      "version": "2023.2.3",
+      "version": "2023.3.0-eap08",
       "commands": ["jb"]
     },
     "swashbuckle.aspnetcore.cli": {

--- a/application/shared-kernel/ApiCore/ApiResults/ApiResult.cs
+++ b/application/shared-kernel/ApiCore/ApiResults/ApiResult.cs
@@ -8,20 +8,20 @@ namespace PlatformPlatform.SharedKernel.ApiCore.ApiResults;
 
 public partial class ApiResult(ResultBase result, string? routePrefix = null) : IResult
 {
+    protected string? RoutePrefix { get; } = routePrefix;
+
     public Task ExecuteAsync(HttpContext httpContext)
     {
-        return routePrefix == null
-            ? ConvertResult().ExecuteAsync(httpContext)
-            : ConvertResult(routePrefix).ExecuteAsync(httpContext);
+        return ConvertResult().ExecuteAsync(httpContext);
     }
 
-    protected virtual IResult ConvertResult(string? routePrefix = null)
+    protected virtual IResult ConvertResult()
     {
         if (!result.IsSuccess) return GetProblemDetailsAsJson();
 
-        return routePrefix == null
+        return RoutePrefix == null
             ? Results.Ok()
-            : Results.Created($"{routePrefix}/{result}", null);
+            : Results.Created($"{RoutePrefix}/{result}", null);
     }
 
     protected IResult GetProblemDetailsAsJson()
@@ -63,13 +63,13 @@ public partial class ApiResult(ResultBase result, string? routePrefix = null) : 
 
 public class ApiResult<T>(Result<T> result, string? routePrefix = null) : ApiResult(result, routePrefix)
 {
-    protected override IResult ConvertResult(string? routePrefix = null)
+    protected override IResult ConvertResult()
     {
         if (!result.IsSuccess) return GetProblemDetailsAsJson();
 
-        return routePrefix == null
+        return RoutePrefix == null
             ? Results.Ok(result.Value!.Adapt<T>())
-            : Results.Created($"{routePrefix}/{result.Value}", null);
+            : Results.Created($"{RoutePrefix}/{result.Value}", null);
     }
 
     public static implicit operator ApiResult<T>(Result<T> result)

--- a/application/shared-kernel/ApiCore/ApiResults/ApiResult.cs
+++ b/application/shared-kernel/ApiCore/ApiResults/ApiResult.cs
@@ -26,8 +26,11 @@ public partial class ApiResult(ResultBase result, string? routePrefix = null) : 
 
     protected IResult GetProblemDetailsAsJson()
     {
-        return Results.Json(CreateProblemDetails(), statusCode: (int)result.StatusCode,
-            contentType: "application/problem+json");
+        return Results.Json(
+            CreateProblemDetails(),
+            statusCode: (int)result.StatusCode,
+            contentType: "application/problem+json"
+        );
     }
 
     private ProblemDetails CreateProblemDetails()

--- a/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -7,8 +7,10 @@ using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
 
 namespace PlatformPlatform.SharedKernel.ApiCore.Middleware;
 
-public sealed class GlobalExceptionHandlerMiddleware(ILogger<GlobalExceptionHandlerMiddleware> logger,
-    IOptions<JsonOptions> jsonOptions) : IMiddleware
+public sealed class GlobalExceptionHandlerMiddleware(
+    ILogger<GlobalExceptionHandlerMiddleware> logger,
+    IOptions<JsonOptions> jsonOptions
+) : IMiddleware
 {
     private readonly JsonSerializerOptions _jsonSerializerOptions = jsonOptions.Value.SerializerOptions;
     private readonly ILogger _logger = logger;

--- a/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -8,7 +8,7 @@ using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
 namespace PlatformPlatform.SharedKernel.ApiCore.Middleware;
 
 public sealed class GlobalExceptionHandlerMiddleware(ILogger<GlobalExceptionHandlerMiddleware> logger,
-        IOptions<JsonOptions> jsonOptions) : IMiddleware
+    IOptions<JsonOptions> jsonOptions) : IMiddleware
 {
     private readonly JsonSerializerOptions _jsonSerializerOptions = jsonOptions.Value.SerializerOptions;
     private readonly ILogger _logger = logger;

--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
@@ -28,8 +28,12 @@ public class WebAppMiddleware
     private readonly Dictionary<string, string> _runtimeEnvironment;
     private string? _htmlTemplate;
 
-    public WebAppMiddleware(RequestDelegate next, Dictionary<string, string> runtimeEnvironment,
-        string htmlTemplatePath, IOptions<JsonOptions> jsonOptions)
+    public WebAppMiddleware(
+        RequestDelegate next,
+        Dictionary<string, string> runtimeEnvironment,
+        string htmlTemplatePath,
+        IOptions<JsonOptions> jsonOptions
+    )
     {
         _next = next;
         _runtimeEnvironment = runtimeEnvironment;
@@ -92,8 +96,7 @@ public class WebAppMiddleware
 
         return string.Join(
             " ",
-            contentSecurityPolicies.Select(policy => $"{policy.Key} {string.Join(" ", policy.Value)};"
-            )
+            contentSecurityPolicies.Select(policy => $"{policy.Key} {string.Join(" ", policy.Value)};")
         );
     }
 
@@ -109,8 +112,11 @@ public class WebAppMiddleware
 public static class WebAppMiddlewareExtensions
 {
     [UsedImplicitly]
-    public static IApplicationBuilder UseWebAppMiddleware(this IApplicationBuilder builder,
-        string webAppProjectName = "WebApp", Dictionary<string, string>? publicEnvironmentVariables = null)
+    public static IApplicationBuilder UseWebAppMiddleware(
+        this IApplicationBuilder builder,
+        string webAppProjectName = "WebApp",
+        Dictionary<string, string>? publicEnvironmentVariables = null
+    )
     {
         if (Environment.GetEnvironmentVariable("SWAGGER_GENERATOR") == "true") return builder;
 
@@ -157,8 +163,10 @@ public static class WebAppMiddlewareExtensions
         var assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
 
         var directoryInfo = new DirectoryInfo(assemblyPath);
-        while (directoryInfo is not null && !directoryInfo.GetDirectories(webAppProjectName).Any() &&
-               !Path.Exists(Path.Join(directoryInfo.FullName, webAppProjectName, webAppDistRootName)))
+        while (directoryInfo is not null &&
+               directoryInfo.GetDirectories(webAppProjectName).Length == 0 &&
+               !Path.Exists(Path.Join(directoryInfo.FullName, webAppProjectName, webAppDistRootName))
+              )
         {
             directoryInfo = directoryInfo.Parent;
         }

--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
@@ -97,17 +97,12 @@ public class WebAppMiddleware
         );
     }
 
-    public async Task InvokeAsync(HttpContext context)
+    public Task InvokeAsync(HttpContext context)
     {
-        if (context.Request.Path.ToString().StartsWith("/api/"))
-        {
-            await _next(context);
-        }
-        else
-        {
-            context.Response.Headers.Append("Content-Security-Policy", _contentSecurityPolicy);
-            await context.Response.WriteAsync(GetHtmlWithEnvironment());
-        }
+        if (context.Request.Path.ToString().StartsWith("/api/")) return _next(context);
+
+        context.Response.Headers.Append("Content-Security-Policy", _contentSecurityPolicy);
+        return context.Response.WriteAsync(GetHtmlWithEnvironment());
     }
 }
 

--- a/application/shared-kernel/ApplicationCore/ApplicationCoreConfiguration.cs
+++ b/application/shared-kernel/ApplicationCore/ApplicationCoreConfiguration.cs
@@ -7,8 +7,10 @@ namespace PlatformPlatform.SharedKernel.ApplicationCore;
 public static class ApplicationCoreConfiguration
 {
     [UsedImplicitly]
-    public static IServiceCollection AddApplicationCoreServices(this IServiceCollection services,
-        Assembly applicationAssembly)
+    public static IServiceCollection AddApplicationCoreServices(
+        this IServiceCollection services,
+        Assembly applicationAssembly
+    )
     {
         // Order is important. First all Pre behaviors run (top to bottom), then the command is handled, then all Post
         // behaviors run (bottom to top). So Validation -> Command -> PublishDomainEvents -> UnitOfWork.

--- a/application/shared-kernel/ApplicationCore/Behaviors/PublishDomainEventsPipelineBehavior.cs
+++ b/application/shared-kernel/ApplicationCore/Behaviors/PublishDomainEventsPipelineBehavior.cs
@@ -11,12 +11,16 @@ namespace PlatformPlatform.SharedKernel.ApplicationCore.Behaviors;
 ///     services (e.g., send emails) that are not part of the same database transaction. For such tasks, use Integration
 ///     Events instead.
 /// </summary>
-public sealed class PublishDomainEventsPipelineBehavior<TRequest, TResponse>
-    (IDomainEventCollector domainEventCollector, IPublisher mediator) : IPipelineBehavior<TRequest, TResponse>
-    where TRequest : ICommand where TResponse : ResultBase
+public sealed class PublishDomainEventsPipelineBehavior<TRequest, TResponse>(
+    IDomainEventCollector domainEventCollector,
+    IPublisher mediator
+) : IPipelineBehavior<TRequest, TResponse> where TRequest : ICommand where TResponse : ResultBase
 {
-    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next,
-        CancellationToken cancellationToken)
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken
+    )
     {
         var response = await next();
 

--- a/application/shared-kernel/ApplicationCore/Behaviors/UnitOfWorkPipelineBehavior.cs
+++ b/application/shared-kernel/ApplicationCore/Behaviors/UnitOfWorkPipelineBehavior.cs
@@ -10,12 +10,16 @@ namespace PlatformPlatform.SharedKernel.ApplicationCore.Behaviors;
 ///     are successfully handled. If an exception occurs the UnitOfWork.Commit will never be called, and all changes
 ///     will be lost.
 /// </summary>
-public sealed class UnitOfWorkPipelineBehavior<TRequest, TResponse>
-    (IUnitOfWork unitOfWork, UnitOfWorkPipelineBehaviorConcurrentCounter unitOfWorkPipelineBehaviorConcurrentCounter)
-    : IPipelineBehavior<TRequest, TResponse> where TRequest : ICommand where TResponse : ResultBase
+public sealed class UnitOfWorkPipelineBehavior<TRequest, TResponse>(
+    IUnitOfWork unitOfWork,
+    UnitOfWorkPipelineBehaviorConcurrentCounter unitOfWorkPipelineBehaviorConcurrentCounter
+) : IPipelineBehavior<TRequest, TResponse> where TRequest : ICommand where TResponse : ResultBase
 {
-    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next,
-        CancellationToken cancellationToken)
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken
+    )
     {
         unitOfWorkPipelineBehaviorConcurrentCounter.Increment();
         var response = await next();

--- a/application/shared-kernel/ApplicationCore/Behaviors/ValidationPipelineBehavior.cs
+++ b/application/shared-kernel/ApplicationCore/Behaviors/ValidationPipelineBehavior.cs
@@ -13,8 +13,11 @@ namespace PlatformPlatform.SharedKernel.ApplicationCore.Behaviors;
 public sealed class ValidationPipelineBehavior<TRequest, TResponse>(IEnumerable<IValidator<TRequest>> validators)
     : IPipelineBehavior<TRequest, TResponse> where TRequest : ICommand where TResponse : ResultBase
 {
-    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next,
-        CancellationToken cancellationToken)
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken
+    )
     {
         if (!validators.Any())
         {

--- a/application/shared-kernel/ApplicationCore/Cqrs/ICommand.cs
+++ b/application/shared-kernel/ApplicationCore/Cqrs/ICommand.cs
@@ -3,6 +3,4 @@ namespace PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 /// <summary>
 ///     A marker interface for commands, that ensures that only Commands are processed by pipeline behaviors.
 /// </summary>
-public interface ICommand
-{
-}
+public interface ICommand;

--- a/application/shared-kernel/DomainCore/DomainEvents/IDomainEvent.cs
+++ b/application/shared-kernel/DomainCore/DomainEvents/IDomainEvent.cs
@@ -14,6 +14,4 @@ namespace PlatformPlatform.SharedKernel.DomainCore.DomainEvents;
 ///     be used to invoke other services (e.g., send emails) that are not part of the same database transaction. For
 ///     such tasks, use Integration Events instead.
 /// </summary>
-public interface IDomainEvent : INotification
-{
-}
+public interface IDomainEvent : INotification;

--- a/application/shared-kernel/DomainCore/Entities/AggregateRoot.cs
+++ b/application/shared-kernel/DomainCore/Entities/AggregateRoot.cs
@@ -19,13 +19,9 @@ public interface IAggregateRoot : IAuditableEntity
     void ClearDomainEvents();
 }
 
-public abstract class AggregateRoot<T> : AudibleEntity<T>, IAggregateRoot where T : IComparable<T>
+public abstract class AggregateRoot<T>(T id) : AudibleEntity<T>(id), IAggregateRoot where T : IComparable<T>
 {
     private readonly List<IDomainEvent> _domainEvents = new();
-
-    protected AggregateRoot(T id) : base(id)
-    {
-    }
 
     [NotMapped]
     public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();

--- a/application/shared-kernel/DomainCore/Entities/AudibleEntity.cs
+++ b/application/shared-kernel/DomainCore/Entities/AudibleEntity.cs
@@ -9,7 +9,7 @@ namespace PlatformPlatform.SharedKernel.DomainCore.Entities;
 public abstract class AudibleEntity<T>(T id) : Entity<T>(id), IAuditableEntity where T : IComparable<T>
 {
     [UsedImplicitly]
-    public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
 
     [ConcurrencyCheck]
     public DateTime? ModifiedAt { get; private set; }

--- a/application/shared-kernel/DomainCore/Entities/Entity.cs
+++ b/application/shared-kernel/DomainCore/Entities/Entity.cs
@@ -20,8 +20,7 @@ public abstract class Entity<T>(T id) : IEquatable<Entity<T>> where T : ICompara
     public virtual bool Equals(Entity<T>? other)
     {
         return !ReferenceEquals(null, other) &&
-               (ReferenceEquals(this, other) ||
-                EqualityComparer<T>.Default.Equals(Id, other.Id));
+               (ReferenceEquals(this, other) || EqualityComparer<T>.Default.Equals(Id, other.Id));
     }
 
     public override bool Equals(object? obj)

--- a/application/shared-kernel/DomainCore/Identity/IdGenerator.cs
+++ b/application/shared-kernel/DomainCore/Identity/IdGenerator.cs
@@ -34,9 +34,10 @@ public static class IdGenerator
     private static int GetUniqueGeneratorIdFromIpAddress()
     {
         var host = Dns.GetHostEntry(Dns.GetHostName());
-        var ipAddress = host.AddressList.FirstOrDefault(ip => ip.AddressFamily == AddressFamily.InterNetwork) ??
-                        throw new InvalidOperationException(
-                            "No network adapters with an IPv4 address in the system. IdGenerator is meant to create unique IDs across multiple machines, and requires an IP address to do so.");
+        const string noNetworkAdapters =
+            "No network adapters with an IPv4 address in the system. IdGenerator is meant to create unique IDs across multiple machines, and requires an IP address to do so.";
+        var ipAddress = host.AddressList.FirstOrDefault(ip =>
+            ip.AddressFamily == AddressFamily.InterNetwork) ?? throw new InvalidOperationException(noNetworkAdapters);
 
         var lastSegment = ipAddress.ToString().Split('.').Last();
         return int.Parse(lastSegment);

--- a/application/shared-kernel/DomainCore/Identity/StronglyTypedLongId.cs
+++ b/application/shared-kernel/DomainCore/Identity/StronglyTypedLongId.cs
@@ -23,7 +23,12 @@ public abstract record StronglyTypedLongId<T>(long Value) : StronglyTypedId<long
 
     private static T FormLong(long newValue)
     {
-        return (T)Activator.CreateInstance(typeof(T),
-            BindingFlags.Instance | BindingFlags.Public, null, new object[] { newValue }, null)!;
+        return (T)Activator.CreateInstance(
+            typeof(T),
+            BindingFlags.Instance | BindingFlags.Public,
+            null,
+            new object[] { newValue },
+            null
+        )!;
     }
 }

--- a/application/shared-kernel/DomainCore/Identity/StronglyTypedUlid.cs
+++ b/application/shared-kernel/DomainCore/Identity/StronglyTypedUlid.cs
@@ -26,6 +26,10 @@ public abstract record StronglyTypedUlid<T>(string Value) : StronglyTypedId<stri
     private static T FormUlid(Ulid newValue)
     {
         return (T)Activator.CreateInstance(typeof(T),
-            BindingFlags.Instance | BindingFlags.Public, null, new object[] { newValue.ToString() }, null)!;
+            BindingFlags.Instance | BindingFlags.Public,
+            null,
+            new object[] { newValue.ToString() },
+            null
+        )!;
     }
 }

--- a/application/shared-kernel/InfrastructureCore/EntityFramework/ModelBuilderExtensions.cs
+++ b/application/shared-kernel/InfrastructureCore/EntityFramework/ModelBuilderExtensions.cs
@@ -12,8 +12,10 @@ public static class ModelBuilderExtensions
     ///     underlying type of the strongly-typed ID.
     /// </summary>
     [UsedImplicitly]
-    public static void MapStronglyTypedLongId<T, TId>(this ModelBuilder modelBuilder,
-        Expression<Func<T, TId>> expression) where T : class where TId : StronglyTypedLongId<TId>
+    public static void MapStronglyTypedLongId<T, TId>(
+        this ModelBuilder modelBuilder,
+        Expression<Func<T, TId>> expression
+    ) where T : class where TId : StronglyTypedLongId<TId>
     {
         modelBuilder
             .Entity<T>()
@@ -30,8 +32,10 @@ public static class ModelBuilderExtensions
             .HasConversion(v => v.Value, v => (Activator.CreateInstance(typeof(TId), v) as TId)!);
     }
 
-    public static void MapStronglyTypedId<T, TId, TValue>(this ModelBuilder modelBuilder,
-        Expression<Func<T, TId>> expression)
+    public static void MapStronglyTypedId<T, TId, TValue>(
+        this ModelBuilder modelBuilder,
+        Expression<Func<T, TId>> expression
+    )
         where T : class
         where TValue : IComparable<TValue>
         where TId : StronglyTypedId<TValue, TId>

--- a/application/shared-kernel/InfrastructureCore/EntityFramework/SharedKernelDbContext.cs
+++ b/application/shared-kernel/InfrastructureCore/EntityFramework/SharedKernelDbContext.cs
@@ -7,12 +7,9 @@ namespace PlatformPlatform.SharedKernel.InfrastructureCore.EntityFramework;
 ///     The SharedKernelDbContext class represents the Entity Framework Core DbContext for managing data access to the
 ///     database, like creation, querying, and updating of <see cref="IAggregateRoot" /> entities.
 /// </summary>
-public abstract class SharedKernelDbContext<TContext> : DbContext where TContext : DbContext
+public abstract class SharedKernelDbContext<TContext>(DbContextOptions<TContext> options)
+    : DbContext(options) where TContext : DbContext
 {
-    protected SharedKernelDbContext(DbContextOptions<TContext> options) : base(options)
-    {
-    }
-
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);

--- a/application/shared-kernel/InfrastructureCore/EntityFramework/UpdateAuditableEntitiesInterceptor.cs
+++ b/application/shared-kernel/InfrastructureCore/EntityFramework/UpdateAuditableEntitiesInterceptor.cs
@@ -17,8 +17,11 @@ public sealed class UpdateAuditableEntitiesInterceptor : SaveChangesInterceptor
         return base.SavingChanges(eventData, result);
     }
 
-    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData,
-        InterceptionResult<int> result, CancellationToken cancellationToken = default)
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default
+    )
     {
         UpdateEntities(eventData);
 

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -12,8 +12,11 @@ public static class InfrastructureCoreConfiguration
     private static string? _cachedConnectionString;
 
     [UsedImplicitly]
-    public static IServiceCollection ConfigureInfrastructureCoreServices<T>(this IServiceCollection services,
-        IConfiguration configuration, Assembly assembly) where T : DbContext
+    public static IServiceCollection ConfigureInfrastructureCoreServices<T>(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        Assembly assembly
+    ) where T : DbContext
     {
         services.ConfigureDatabaseContext<T>(configuration);
 
@@ -23,8 +26,10 @@ public static class InfrastructureCoreConfiguration
     }
 
     [UsedImplicitly]
-    private static IServiceCollection ConfigureDatabaseContext<T>(this IServiceCollection services,
-        IConfiguration configuration) where T : DbContext
+    private static IServiceCollection ConfigureDatabaseContext<T>(
+        this IServiceCollection services,
+        IConfiguration configuration
+    ) where T : DbContext
     {
         if (Environment.GetEnvironmentVariable("SWAGGER_GENERATOR") == "true") return services;
 

--- a/application/shared-kernel/InfrastructureCore/Persistence/DomainEventCollector.cs
+++ b/application/shared-kernel/InfrastructureCore/Persistence/DomainEventCollector.cs
@@ -10,7 +10,7 @@ public sealed class DomainEventCollector(DbContext dbContext) : IDomainEventColl
     {
         return dbContext.ChangeTracker
             .Entries<IAggregateRoot>()
-            .Where(e => e.Entity.DomainEvents.Any())
+            .Where(e => e.Entity.DomainEvents.Count != 0)
             .Select(e => e.Entity);
     }
 }

--- a/application/shared-kernel/InfrastructureCore/Persistence/RepositoryBase.cs
+++ b/application/shared-kernel/InfrastructureCore/Persistence/RepositoryBase.cs
@@ -33,19 +33,19 @@ public abstract class RepositoryBase<T, TId>(DbContext context)
 
     public async Task AddAsync(T aggregate, CancellationToken cancellationToken)
     {
-        if (aggregate is null) throw new ArgumentNullException(nameof(aggregate));
+        ArgumentNullException.ThrowIfNull(aggregate);
         await DbSet.AddAsync(aggregate, cancellationToken);
     }
 
     public void Update(T aggregate)
     {
-        if (aggregate is null) throw new ArgumentNullException(nameof(aggregate));
+        ArgumentNullException.ThrowIfNull(aggregate);
         DbSet.Update(aggregate);
     }
 
     public void Remove(T aggregate)
     {
-        if (aggregate is null) throw new ArgumentNullException(nameof(aggregate));
+        ArgumentNullException.ThrowIfNull(aggregate);
         DbSet.Remove(aggregate);
     }
 }

--- a/application/shared-kernel/InfrastructureCore/Persistence/UnitOfWork.cs
+++ b/application/shared-kernel/InfrastructureCore/Persistence/UnitOfWork.cs
@@ -15,7 +15,7 @@ public sealed class UnitOfWork(DbContext dbContext) : IUnitOfWork
 {
     public async Task CommitAsync(CancellationToken cancellationToken)
     {
-        if (dbContext.ChangeTracker.Entries<IAggregateRoot>().Any(e => e.Entity.DomainEvents.Any()))
+        if (dbContext.ChangeTracker.Entries<IAggregateRoot>().Any(e => e.Entity.DomainEvents.Count != 0))
         {
             throw new InvalidOperationException("Domain events must be handled before committing the UnitOfWork.");
         }

--- a/application/shared-kernel/Tests/ApplicationCore/Behaviors/PublishDomainEventsPipelineBehaviorTests.cs
+++ b/application/shared-kernel/Tests/ApplicationCore/Behaviors/PublishDomainEventsPipelineBehaviorTests.cs
@@ -16,9 +16,10 @@ public class PublishDomainEventsPipelineBehaviorTests
         // Arrange
         var domainEventCollector = Substitute.For<IDomainEventCollector>();
         var publisher = Substitute.For<IPublisher>();
-        var behavior =
-            new PublishDomainEventsPipelineBehavior<TestCommand, Result<TestAggregate>>(domainEventCollector,
-                publisher);
+        var behavior = new PublishDomainEventsPipelineBehavior<TestCommand, Result<TestAggregate>>(
+            domainEventCollector,
+            publisher
+        );
         var request = new TestCommand();
         var cancellationToken = new CancellationToken();
         var next = Substitute.For<RequestHandlerDelegate<Result<TestAggregate>>>();

--- a/application/shared-kernel/Tests/ApplicationCore/Behaviors/UnitOfWorkPipelineBehaviorTests.cs
+++ b/application/shared-kernel/Tests/ApplicationCore/Behaviors/UnitOfWorkPipelineBehaviorTests.cs
@@ -18,8 +18,10 @@ public class UnitOfWorkPipelineBehaviorTests
         var services = new ServiceCollection();
         _unitOfWork = Substitute.For<IUnitOfWork>();
         services.AddSingleton(_unitOfWork);
-        _behavior = new UnitOfWorkPipelineBehavior<TestCommand, Result<TestAggregate>>(_unitOfWork,
-            new UnitOfWorkPipelineBehaviorConcurrentCounter());
+        _behavior = new UnitOfWorkPipelineBehavior<TestCommand, Result<TestAggregate>>(
+            _unitOfWork,
+            new UnitOfWorkPipelineBehaviorConcurrentCounter()
+        );
     }
 
     [Fact]

--- a/application/shared-kernel/Tests/DomainCore/Entities/EntityTests.cs
+++ b/application/shared-kernel/Tests/DomainCore/Entities/EntityTests.cs
@@ -167,31 +167,19 @@ public static class EntityTests
 public sealed record StronglyTypedId(long Value) : StronglyTypedLongId<StronglyTypedId>(Value);
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public class StronglyTypedIdEntity : Entity<StronglyTypedId>
+public class StronglyTypedIdEntity() : Entity<StronglyTypedId>(StronglyTypedId.NewId())
 {
-    public StronglyTypedIdEntity() : base(StronglyTypedId.NewId())
-    {
-    }
-
     public required string Name { get; init; }
 }
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public class GuidEntity : Entity<Guid>
+public class GuidEntity(Guid id) : Entity<Guid>(id)
 {
-    public GuidEntity(Guid id) : base(id)
-    {
-    }
-
     public required string Name { get; init; }
 }
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public class StringEntity : Entity<string>
+public class StringEntity(string id) : Entity<string>(id)
 {
-    public StringEntity(string id) : base(id)
-    {
-    }
-
     public required string Name { get; init; }
 }

--- a/application/shared-kernel/Tests/TestEntities/ITestAggregateRepository.cs
+++ b/application/shared-kernel/Tests/TestEntities/ITestAggregateRepository.cs
@@ -1,5 +1,3 @@
 namespace PlatformPlatform.SharedKernel.Tests.TestEntities;
 
-public interface ITestAggregateRepository
-{
-}
+public interface ITestAggregateRepository;


### PR DESCRIPTION
### Summary & Motivation

Re-enables JetBrains code inspections by upgrading JetBrains.ReSharper.GlobalTools to the 2023.3 Early Access Program (EAP) version with .NET 8 support.

Fix all warnings generated by the new tooling for code optimizations such as `RedundantTypeDeclarationBody`, `ConvertToPrimaryConstructor`, `PropertyCanBeMadeInitOnly`, `ParameterHidesPrimaryConstructorParameter`, etc.

Update JetBrains formatting rules to place parameters on separate lines for long signatures. Format the entire codebase for consistency, and ensure adherence to conventions.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
