### PR TITLE
Optimize build process and refine codebase with .NET 8 tooling enhancements

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -87,6 +87,7 @@ jobs:
 
   jetbrains-code-inspection:
     name: JetBrains Code Inspections
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -58,9 +58,6 @@ jobs:
         working-directory: application
         run: dotnet restore
 
-      - name: Build
-        run: dotnet build application/PlatformPlatform.sln --no-restore --configuration Release /p:Version=${{ steps.generate_version.outputs.version }}
-
       - name: Setup-java
         uses: actions/setup-java@v3
         with:

--- a/application/AppHost/FrontendAppHostingExtension.cs
+++ b/application/AppHost/FrontendAppHostingExtension.cs
@@ -41,8 +41,9 @@ internal static class FrontendAppHostingExtension
     {
         var resource = new FrontendAppResource(name, "bun", workingDirectory, new[] { "run", bunCommand });
 
-        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IDistributedApplicationLifecycleHook,
-            FrontendAppAddPortLifecycleHook>());
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IDistributedApplicationLifecycleHook, FrontendAppAddPortLifecycleHook>()
+        );
 
         return builder.AddResource(resource)
             .WithOtlpExporter()

--- a/application/AppHost/Properties/launchSettings.json
+++ b/application/AppHost/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "http": {
+    "AppHost": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -11,8 +11,7 @@
   <ItemGroup>
     <!-- PlatformPlatform dependencies - Api -->
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
-    <!-- <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0"/> -->
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EfCoreVersion)" />
     <!-- PlatformPlatform dependencies - Application -->
     <PackageVersion Include="Mapster" Version="7.4.0" />
     <PackageVersion Include="MediatR" Version="12.2.0" />
@@ -21,20 +20,17 @@
     <PackageVersion Include="IdGen" Version="3.0.3" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="NUlid" Version="1.7.1" />
     <!-- PlatformPlatform dependencies - Infrastructure -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
-    <!-- <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(EfCoreVersion)"/> -->
-    <!-- <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(EfCoreVersion)"/> -->
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EfCoreVersion)" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />
     <!-- PlatformPlatform dependencies - Tests -->
     <PackageVersion Include="Bogus" Version="34.0.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
-    <!-- <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/> -->
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersion)" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="NJsonSchema" Version="10.9.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -6,7 +6,6 @@
     <AspNetCoreVersion>8.0.0</AspNetCoreVersion>
     <EfCoreVersion>8.0.0</EfCoreVersion>
     <RuntimeVersion>8.0.0</RuntimeVersion>
-    <GrpcVersion>2.58.0</GrpcVersion>
     <AspireVersion>8.0.0-preview.1.23557.2</AspireVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -46,8 +45,6 @@
     <!-- Version together with Aspire -->
     <PackageVersion Include="Aspire.Hosting" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Dapr" Version="$(AspireVersion)" />
-    <PackageVersion Include="Aspire.Npgsql" Version="$(AspireVersion)" />
-    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.StackExchange.Redis" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Abstractions" Version="$(AspireVersion)" />
@@ -73,14 +70,6 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(RuntimeVersion)" />
-    <!-- gRPC -->
-    <PackageVersion Include="Grpc.AspNetCore" Version="$(GrpcVersion)" />
-    <PackageVersion Include="Grpc.AspNetCore.HealthChecks" Version="$(GrpcVersion)" />
-    <PackageVersion Include="Grpc.HealthCheck" Version="$(GrpcVersion)" />
-    <PackageVersion Include="Grpc.Net.Client" Version="$(GrpcVersion)" />
-    <PackageVersion Include="Grpc.Net.ClientFactory" Version="$(GrpcVersion)" />
-    <PackageVersion Include="Grpc.Net.Server" Version="$(GrpcVersion)" />
-    <PackageVersion Include="Grpc.Tools" Version="2.59.0" />
     <!-- Open Telemetry -->
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-alpha.1" />

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -1,5 +1,4 @@
 <Project>
-
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
@@ -10,96 +9,93 @@
     <GrpcVersion>2.58.0</GrpcVersion>
     <AspireVersion>8.0.0-preview.1.23557.2</AspireVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- PlatformPlatform dependencies - Api -->
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0"/>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
     <!-- <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0"/> -->
     <!-- PlatformPlatform dependencies - Application -->
-    <PackageVersion Include="Mapster" Version="7.4.0"/>
-    <PackageVersion Include="MediatR" Version="12.2.0"/>
-    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0"/>
+    <PackageVersion Include="Mapster" Version="7.4.0" />
+    <PackageVersion Include="MediatR" Version="12.2.0" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.1" />
     <!-- PlatformPlatform dependencies - Domain-->
-    <PackageVersion Include="IdGen" Version="3.0.3"/>
-    <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0"/>
-    <PackageVersion Include="MediatR.Contracts" Version="2.0.1"/>
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
-    <PackageVersion Include="NUlid" Version="1.7.1"/>
+    <PackageVersion Include="IdGen" Version="3.0.3" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
+    <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="NUlid" Version="1.7.1" />
     <!-- PlatformPlatform dependencies - Infrastructure -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <!-- <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(EfCoreVersion)"/> -->
     <!-- <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(EfCoreVersion)"/> -->
-    <PackageVersion Include="Scrutor" Version="4.2.2"/>
+    <PackageVersion Include="Scrutor" Version="4.2.2" />
     <!-- PlatformPlatform dependencies - Tests -->
-    <PackageVersion Include="Bogus" Version="34.0.2"/>
-    <PackageVersion Include="coverlet.collector" Version="6.0.0"/>
-    <PackageVersion Include="FluentAssertions" Version="6.12.0"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0"/>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0"/>
+    <PackageVersion Include="Bogus" Version="34.0.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
     <!-- <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/> -->
-    <PackageVersion Include="NetArchTest.Rules" Version="1.3.2"/>
-    <PackageVersion Include="NJsonSchema" Version="10.9.0"/>
-    <PackageVersion Include="NSubstitute" Version="5.1.0"/>
-    <PackageVersion Include="xunit" Version="2.6.2"/>
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4"/>
+    <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
+    <PackageVersion Include="NJsonSchema" Version="10.9.0" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="xunit" Version="2.6.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
-
   <ItemGroup>
     <!-- Version together with Aspire -->
-    <PackageVersion Include="Aspire.Hosting" Version="$(AspireVersion)"/>
-    <PackageVersion Include="Aspire.Hosting.Dapr" Version="$(AspireVersion)"/>
-    <PackageVersion Include="Aspire.Npgsql" Version="$(AspireVersion)"/>
-    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(AspireVersion)"/>
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="$(AspireVersion)"/>
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)"/>
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Abstractions" Version="$(AspireVersion)"/>
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="$(AspireVersion)"/>
+    <PackageVersion Include="Aspire.Hosting" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Dapr" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Npgsql" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="$(AspireVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Abstractions" Version="$(AspireVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="$(AspireVersion)" />
     <!-- Version together with ASP.NET -->
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetCoreVersion)"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="$(AspNetCoreVersion)"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(AspNetCoreVersion)"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="$(AspNetCoreVersion)"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(AspNetCoreVersion)"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(AspNetCoreVersion)"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="$(AspNetCoreVersion)"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(AspNetCoreVersion)"/>
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(AspNetCoreVersion)"/>
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="$(AspNetCoreVersion)"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="$(AspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(AspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="$(AspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(AspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(AspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(AspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="$(AspNetCoreVersion)" />
     <!-- Version together with EF -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(EfCoreVersion)"/>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EfCoreVersion)"/>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(EfCoreVersion)"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(EfCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EfCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(EfCoreVersion)" />
     <!-- Version together with runtime -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(RuntimeVersion)"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(RuntimeVersion)"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(RuntimeVersion)"/>
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="$(RuntimeVersion)"/>
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(RuntimeVersion)"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(RuntimeVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(RuntimeVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(RuntimeVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="$(RuntimeVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(RuntimeVersion)" />
     <!-- gRPC -->
-    <PackageVersion Include="Grpc.AspNetCore" Version="$(GrpcVersion)"/>
-    <PackageVersion Include="Grpc.AspNetCore.HealthChecks" Version="$(GrpcVersion)"/>
-    <PackageVersion Include="Grpc.HealthCheck" Version="$(GrpcVersion)"/>
-    <PackageVersion Include="Grpc.Net.Client" Version="$(GrpcVersion)"/>
-    <PackageVersion Include="Grpc.Net.ClientFactory" Version="$(GrpcVersion)"/>
-    <PackageVersion Include="Grpc.Net.Server" Version="$(GrpcVersion)"/>    
-    <PackageVersion Include="Grpc.Tools" Version="2.59.0"/>
+    <PackageVersion Include="Grpc.AspNetCore" Version="$(GrpcVersion)" />
+    <PackageVersion Include="Grpc.AspNetCore.HealthChecks" Version="$(GrpcVersion)" />
+    <PackageVersion Include="Grpc.HealthCheck" Version="$(GrpcVersion)" />
+    <PackageVersion Include="Grpc.Net.Client" Version="$(GrpcVersion)" />
+    <PackageVersion Include="Grpc.Net.ClientFactory" Version="$(GrpcVersion)" />
+    <PackageVersion Include="Grpc.Net.Server" Version="$(GrpcVersion)" />
+    <PackageVersion Include="Grpc.Tools" Version="2.59.0" />
     <!-- Open Telemetry -->
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0-alpha.1"/>
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-alpha.1"/>
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0-alpha.1"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.EventCounters" Version="1.5.1-alpha.1"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.2"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.2"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1"/>
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0-alpha.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-alpha.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0-alpha.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.EventCounters" Version="1.5.1-alpha.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />
     <!-- VS Test -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <!-- Miscellaneous -->
-    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="7.0.0"/>
-    <PackageVersion Include="Dapr.AspNetCore" Version="1.12.0"/>
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
-    <PackageVersion Include="Yarp.ReverseProxy" Version="2.1.0-preview.1.23556.5"/>
+    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="7.0.0" />
+    <PackageVersion Include="Dapr.AspNetCore" Version="1.12.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageVersion Include="Yarp.ReverseProxy" Version="2.1.0-preview.1.23556.5" />
   </ItemGroup>
-
 </Project>

--- a/application/README.md
+++ b/application/README.md
@@ -30,7 +30,7 @@ Self-contained systems in PlatformPlatform are divided into four core projects f
 2. `Api`: Built with ASP.NET Minimal API, this project implements the REST API. The API is also serving the `index.html` from the SPA using a middleware that injects environment configurations (app version, CDN urls) and user info to avoid an extra API call. This in turn also means the frontend and api is guaranteed to be in sync. All API endpoints are extremely thin, with only one line of code in each endpoint, delegating the work to the Application layer. Here's an example of an API endpoint that creates a new user:
 
     ```csharp
-     group.MapPost("/api/users", async Task<ApiResult> (CreateUser.Command command, ISender mediator)
+     group.MapPost("/api/users", async Task<ApiResult> (CreateUserCommand command, ISender mediator)
          => await mediator.Send(command);
     ```
 

--- a/application/account-management/Api/Properties/launchSettings.json
+++ b/application/account-management/Api/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "WebApi": {
+    "Api": {
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "",

--- a/application/account-management/Api/Properties/launchSettings.json
+++ b/application/account-management/Api/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",
         "PUBLIC_URL": "https://localhost:8443",
-        "CDN_URL": "https://localhost:8080"
+        "CDN_URL": "https://localhost:8444"
       },
       "applicationUrl": "https://localhost:8443"
     }

--- a/application/account-management/Application/Tenants/TenantCreatedEventHandler.cs
+++ b/application/account-management/Application/Tenants/TenantCreatedEventHandler.cs
@@ -6,7 +6,7 @@ public sealed class TenantCreatedEventHandler(ILogger<TenantCreatedEventHandler>
 {
     public Task Handle(TenantCreatedEvent notification, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Raise event to send Welcome mail to tenant");
+        logger.LogInformation("Raise event to send Welcome mail to tenant.");
         return Task.CompletedTask;
     }
 }

--- a/application/account-management/Directory.Build.props
+++ b/application/account-management/Directory.Build.props
@@ -1,4 +1,7 @@
 <Project>
+    <PropertyGroup>
+        <UseArtifactsOutput>true</UseArtifactsOutput>
+    </PropertyGroup>
     <ItemGroup>
         <Using Include="JetBrains.Annotations"/>
         <Using Include="MediatR"/>

--- a/application/account-management/Tests/Api/ApiCore/CustomExceptionHandlingTests.cs
+++ b/application/account-management/Tests/Api/ApiCore/CustomExceptionHandlingTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace PlatformPlatform.AccountManagement.Tests.Api.ApiCore;
 
-public class CustomExceptionHandlingTests : BaseApiTests<AccountManagementDbContext>
+public sealed class CustomExceptionHandlingTests : BaseApiTests<AccountManagementDbContext>
 {
     private readonly WebApplicationFactory<Program> _webApplicationFactory = new();
 

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -18,8 +18,8 @@ public abstract class BaseApiTests<TContext> : BaseTest<TContext> where TContext
 
     protected BaseApiTests()
     {
-        Environment.SetEnvironmentVariable(WebAppMiddleware.PublicUrlKey, "https://localhost");
-        Environment.SetEnvironmentVariable(WebAppMiddleware.CdnUrlKey, "https://localhost");
+        Environment.SetEnvironmentVariable(WebAppMiddleware.PublicUrlKey, "https://localhost:8444");
+        Environment.SetEnvironmentVariable(WebAppMiddleware.CdnUrlKey, "https://localhost:8444");
 
         _webApplicationFactory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
         {

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -12,7 +12,7 @@ using PlatformPlatform.SharedKernel.ApplicationCore.Validation;
 
 namespace PlatformPlatform.AccountManagement.Tests.Api;
 
-public abstract partial class BaseApiTests<TContext> : BaseTest<TContext> where TContext : DbContext
+public abstract class BaseApiTests<TContext> : BaseTest<TContext> where TContext : DbContext
 {
     private readonly WebApplicationFactory<Program> _webApplicationFactory;
 
@@ -131,9 +131,6 @@ public abstract partial class BaseApiTests<TContext> : BaseTest<TContext> where 
 
     private static string SplitCamelCaseTitle(string title)
     {
-        return SplitCamelCase().Replace(title, " $1");
+        return Regex.Replace(title, "(?<=[a-z])([A-Z])", " $1");
     }
-
-    [GeneratedRegex("(?<=[a-z])([A-Z])", RegexOptions.Compiled)]
-    private static partial Regex SplitCamelCase();
 }

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -1,12 +1,12 @@
 using System.Net;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using PlatformPlatform.SharedKernel.ApiCore.ApiResults;
 using PlatformPlatform.SharedKernel.ApiCore.Middleware;
 using PlatformPlatform.SharedKernel.ApplicationCore.Validation;
 
@@ -104,7 +104,7 @@ public abstract class BaseApiTests<TContext> : BaseTest<TContext> where TContext
         problemDetails.Should().NotBeNull();
         problemDetails!.Status.Should().Be((int)statusCode);
         problemDetails.Type.Should().Be($"https://httpstatuses.com/{(int)statusCode}");
-        problemDetails.Title.Should().Be(SplitCamelCaseTitle(statusCode.ToString()));
+        problemDetails.Title.Should().Be(ApiResult.GetHttpStatusDisplayName(statusCode));
 
         if (expectedDetail is not null)
         {
@@ -127,10 +127,5 @@ public abstract class BaseApiTests<TContext> : BaseTest<TContext> where TContext
 
         var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
         return JsonSerializer.Deserialize<ProblemDetails>(content, options);
-    }
-
-    private static string SplitCamelCaseTitle(string title)
-    {
-        return Regex.Replace(title, "(?<=[a-z])([A-Z])", " $1");
     }
 }

--- a/application/account-management/Tests/Application/Tenants/TenantCreatedEventHandlerTests.cs
+++ b/application/account-management/Tests/Application/Tenants/TenantCreatedEventHandlerTests.cs
@@ -21,6 +21,6 @@ public sealed class TenantCreatedEventHandlerTests : BaseTest<AccountManagementD
         _ = await mediator.Send(command);
 
         // Assert
-        mockLogger.Received().LogInformation("Raise event to send Welcome mail to tenant");
+        mockLogger.Received().LogInformation("Raise event to send Welcome mail to tenant.");
     }
 }

--- a/application/account-management/Tests/ArchitectureTests/PublicClassesTests.cs
+++ b/application/account-management/Tests/ArchitectureTests/PublicClassesTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace PlatformPlatform.AccountManagement.Tests.ArchitectureTests;
 
-public class PublicClassesTests
+public sealed class PublicClassesTests
 {
     [Fact]
     public void PublicClassesInDomain_Should_BeSealed()

--- a/application/account-management/Tests/DatabaseSeeder.cs
+++ b/application/account-management/Tests/DatabaseSeeder.cs
@@ -2,7 +2,7 @@ using PlatformPlatform.AccountManagement.Infrastructure;
 
 namespace PlatformPlatform.AccountManagement.Tests;
 
-public class DatabaseSeeder
+public sealed class DatabaseSeeder
 {
     public readonly Tenant Tenant1;
     public readonly User User1;

--- a/application/account-management/WebApp/WebApp.esproj
+++ b/application/account-management/WebApp/WebApp.esproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/0.5.88868-alpha">
+<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/0.5.151394-alpha">
 
     <PropertyGroup>
         <StartupCommand>set BROWSER=none;bun dev</StartupCommand>

--- a/application/account-management/WebApp/rspack.config.ts
+++ b/application/account-management/WebApp/rspack.config.ts
@@ -95,6 +95,7 @@ const configuration: Configuration = {
     headers: {
       "Access-Control-Allow-Origin": "*",
     },
+    port: 8444,
     server: {
       type: "https",
       options: {

--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -30,9 +30,6 @@ public static class ApiCoreConfiguration
         {
             c.SwaggerDoc("v1", new OpenApiInfo { Title = "PlatformPlatform API", Version = "v1" });
 
-            // This is needed because commands are nested so CreateTenant.Command becomes CreateTenant+Command 
-            c.CustomSchemaIds(type => type.FullName?.Split(".").Last().Replace("+", ""));
-
             // Ensure that enums are shown as strings in the Swagger UI
             c.SchemaFilter<XEnumNamesSchemaFilter>();
         });

--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -16,7 +16,8 @@ namespace PlatformPlatform.SharedKernel.ApiCore;
 
 public static class ApiCoreConfiguration
 {
-    private const string LocalhostCorsPolicyName = "localhost8080";
+    private const string LocalhostCorsPolicyName = "localhost8443";
+    private const string LocalhostUrl = "https://localhost:8443";
 
     [UsedImplicitly]
     public static IServiceCollection AddApiCoreServices(this IServiceCollection services, WebApplicationBuilder builder)
@@ -45,18 +46,10 @@ public static class ApiCoreConfiguration
 
         if (builder.Environment.IsDevelopment())
         {
-            builder.Services.AddCors(options =>
-            {
-                options.AddPolicy(
-                    LocalhostCorsPolicyName,
-                    policyBuilder =>
-                    {
-                        policyBuilder.WithOrigins("http://localhost:8080")
-                            .AllowAnyMethod()
-                            .AllowAnyHeader();
-                    }
-                );
-            });
+            builder.Services.AddCors(options => options.AddPolicy(
+                LocalhostCorsPolicyName,
+                policyBuilder => { policyBuilder.WithOrigins(LocalhostUrl).AllowAnyMethod().AllowAnyHeader(); }
+            ));
         }
         else
         {

--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -54,7 +54,7 @@ public static class ApiCoreConfiguration
         else
         {
             // When running inside a Docker container running as non-root we need to use a port higher than 1024.
-            builder.WebHost.ConfigureKestrel(options => { options.ListenAnyIP(8443, _ => { }); });
+            builder.WebHost.ConfigureKestrel(options => options.ListenAnyIP(8443, _ => { }));
         }
 
         return services;

--- a/application/shared-kernel/ApiCore/ApiResults/ApiResult.cs
+++ b/application/shared-kernel/ApiCore/ApiResults/ApiResult.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.RegularExpressions;
 using Mapster;
 using Microsoft.AspNetCore.Http;
@@ -6,7 +7,7 @@ using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
 namespace PlatformPlatform.SharedKernel.ApiCore.ApiResults;
 
-public partial class ApiResult(ResultBase result, string? routePrefix = null) : IResult
+public class ApiResult(ResultBase result, string? routePrefix = null) : IResult
 {
     protected string? RoutePrefix { get; } = routePrefix;
 
@@ -39,7 +40,7 @@ public partial class ApiResult(ResultBase result, string? routePrefix = null) : 
         var problemDetails = new ProblemDetails
         {
             Type = $"https://httpstatuses.com/{(int)result.StatusCode}",
-            Title = SplitCamelCaseTitle(statusCode.ToString()),
+            Title = GetHttpStatusDisplayName(statusCode),
             Status = (int)result.StatusCode
         };
 
@@ -50,13 +51,10 @@ public partial class ApiResult(ResultBase result, string? routePrefix = null) : 
         return problemDetails;
     }
 
-    private static string SplitCamelCaseTitle(string title)
+    public static string GetHttpStatusDisplayName(HttpStatusCode statusCode)
     {
-        return SplitCamelCase().Replace(title, " $1");
+        return Regex.Replace(statusCode.ToString(), "(?<=[a-z])([A-Z])", " $1");
     }
-
-    [GeneratedRegex("(?<=[a-z])([A-Z])", RegexOptions.Compiled)]
-    private static partial Regex SplitCamelCase();
 
     public static implicit operator ApiResult(Result result)
     {

--- a/application/shared-kernel/ApiCore/ApiResults/ApiResult.cs
+++ b/application/shared-kernel/ApiCore/ApiResults/ApiResult.cs
@@ -20,7 +20,7 @@ public class ApiResult(ResultBase result, string? routePrefix = null) : IResult
     {
         if (!result.IsSuccess) return GetProblemDetailsAsJson();
 
-        return RoutePrefix == null
+        return RoutePrefix is null
             ? Results.Ok()
             : Results.Created($"{RoutePrefix}/{result}", null);
     }
@@ -68,7 +68,7 @@ public class ApiResult<T>(Result<T> result, string? routePrefix = null) : ApiRes
     {
         if (!result.IsSuccess) return GetProblemDetailsAsJson();
 
-        return RoutePrefix == null
+        return RoutePrefix is null
             ? Results.Ok(result.Value!.Adapt<T>())
             : Results.Created($"{RoutePrefix}/{result.Value}", null);
     }

--- a/application/shared-kernel/ApiCore/ApiResults/ApiResult.cs
+++ b/application/shared-kernel/ApiCore/ApiResults/ApiResult.cs
@@ -62,7 +62,7 @@ public class ApiResult(ResultBase result, string? routePrefix = null) : IResult
     }
 }
 
-public class ApiResult<T>(Result<T> result, string? routePrefix = null) : ApiResult(result, routePrefix)
+public sealed class ApiResult<T>(Result<T> result, string? routePrefix = null) : ApiResult(result, routePrefix)
 {
     protected override IResult ConvertResult()
     {

--- a/application/shared-kernel/ApiCore/Filters/XEnumNamesSchemaFilter.cs
+++ b/application/shared-kernel/ApiCore/Filters/XEnumNamesSchemaFilter.cs
@@ -9,7 +9,7 @@ namespace PlatformPlatform.SharedKernel.ApiCore.Filters;
 ///     values.
 /// </summary>
 [UsedImplicitly]
-public class XEnumNamesSchemaFilter : ISchemaFilter
+public sealed class XEnumNamesSchemaFilter : ISchemaFilter
 {
     private const string Name = "x-enumNames";
 

--- a/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -23,7 +23,7 @@ public sealed class GlobalExceptionHandlerMiddleware(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "An error occurred while processing the request");
+            _logger.LogError(ex, "An error occurred while processing the request.");
 
             context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
             context.Response.ContentType = "application/problem+json";

--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
@@ -58,26 +58,6 @@ public class WebAppMiddleware
         }
     }
 
-    private string GetHtmlWithEnvironment()
-    {
-        if (_htmlTemplate == null || _isDevelopment)
-        {
-            _htmlTemplate = File.ReadAllText(_htmlTemplatePath, new UTF8Encoding());
-        }
-
-        var encodeRuntimeEnvironment = Convert.ToBase64String(
-            Encoding.UTF8.GetBytes(JsonSerializer.Serialize(_runtimeEnvironment, _jsonSerializerOptions))
-        );
-        var result = _htmlTemplate.Replace("<ENCODED_RUNTIME_ENV>", encodeRuntimeEnvironment);
-
-        foreach (var variable in _runtimeEnvironment)
-        {
-            result = result.Replace($"<{variable.Key}>", variable.Value);
-        }
-
-        return result;
-    }
-
     private StringValues GetContentSecurityPolicy()
     {
         var devServerWebsocket = _cdnUrl.Replace("https", "wss");
@@ -106,6 +86,26 @@ public class WebAppMiddleware
 
         context.Response.Headers.Append("Content-Security-Policy", _contentSecurityPolicy);
         return context.Response.WriteAsync(GetHtmlWithEnvironment());
+    }
+
+    private string GetHtmlWithEnvironment()
+    {
+        if (_htmlTemplate is null || _isDevelopment)
+        {
+            _htmlTemplate = File.ReadAllText(_htmlTemplatePath, new UTF8Encoding());
+        }
+
+        var encodeRuntimeEnvironment = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes(JsonSerializer.Serialize(_runtimeEnvironment, _jsonSerializerOptions))
+        );
+        var result = _htmlTemplate.Replace("<ENCODED_RUNTIME_ENV>", encodeRuntimeEnvironment);
+
+        foreach (var variable in _runtimeEnvironment)
+        {
+            result = result.Replace($"<{variable.Key}>", variable.Value);
+        }
+
+        return result;
     }
 }
 

--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace PlatformPlatform.SharedKernel.ApiCore.Middleware;
 
-public class WebAppMiddleware
+public sealed class WebAppMiddleware
 {
     private const string PublicKeyPrefix = "PUBLIC_";
     public const string PublicUrlKey = "PUBLIC_URL";

--- a/application/shared-kernel/ApplicationCore/Behaviors/UnitOfWorkPipelineBehavior.cs
+++ b/application/shared-kernel/ApplicationCore/Behaviors/UnitOfWorkPipelineBehavior.cs
@@ -24,7 +24,6 @@ public sealed class UnitOfWorkPipelineBehavior<TRequest, TResponse>(
         unitOfWorkPipelineBehaviorConcurrentCounter.Increment();
         var response = await next();
 
-        // ReSharper disable once InvertIf
         if (response is ResultBase { IsSuccess: true })
         {
             unitOfWorkPipelineBehaviorConcurrentCounter.Decrement();

--- a/application/shared-kernel/ApplicationCore/Cqrs/Result.cs
+++ b/application/shared-kernel/ApplicationCore/Cqrs/Result.cs
@@ -39,7 +39,7 @@ public abstract class ResultBase
 ///     Delete). On success the HttpStatusCode NoContent will be returned. In the case of a failure, the result will
 ///     contain either an <see cref="ErrorMessage" /> or a collection of a <see cref="ErrorMessage" />.
 /// </summary>
-public class Result : ResultBase
+public sealed class Result : ResultBase
 {
     private Result(HttpStatusCode httpStatusCode) : base(httpStatusCode)
     {
@@ -73,7 +73,7 @@ public class Result : ResultBase
 ///     Create). On success the HttpStatusCode OK will be returned. In the case of a failure, the result will
 ///     contain either an <see cref="ErrorMessage" /> or a collection of a <see cref="ErrorMessage" />.
 /// </summary>
-public class Result<T> : ResultBase
+public sealed class Result<T> : ResultBase
 {
     private Result(T value, HttpStatusCode httpStatusCode) : base(httpStatusCode)
     {

--- a/application/shared-kernel/ApplicationCore/Validation/SharedValidations.cs
+++ b/application/shared-kernel/ApplicationCore/Validation/SharedValidations.cs
@@ -4,15 +4,11 @@ namespace PlatformPlatform.SharedKernel.ApplicationCore.Validation;
 
 public static class SharedValidations
 {
-    // While emails can be longer, we will limit them to 100 characters which should be enough for most cases
-    private const int EmailMaxLength = 100;
-
-    // The ITU-T Recommendation E.164 limits phone numbers to 15 digits (including country code).
-    // We add 5 extra characters to allow for spaces, dashes, parentheses, etc. 
-    private const int PhoneMaxLength = 20;
-
     public sealed class Email : AbstractValidator<string>
     {
+        // While emails can be longer, we will limit them to 100 characters which should be enough for most cases
+        private const int EmailMaxLength = 100;
+
         public Email(string emailName = nameof(Email))
         {
             const string errorMessage = "Email must be in a valid format and no longer than 100 characters.";
@@ -28,6 +24,10 @@ public static class SharedValidations
 
     public sealed class Phone : AbstractValidator<string?>
     {
+        // The ITU-T E.164 standard limits phone numbers to 15 digits (including country code),
+        // Additional 5 characters are added to allow for spaces, dashes, parentheses, etc.
+        private const int PhoneMaxLength = 20;
+
         public Phone(string phoneName = nameof(Phone))
         {
             const string errorMessage = "Phone must be in a valid format and no longer than 20 characters.";

--- a/application/shared-kernel/Directory.Build.props
+++ b/application/shared-kernel/Directory.Build.props
@@ -1,4 +1,7 @@
 <Project>
+    <PropertyGroup>
+        <UseArtifactsOutput>true</UseArtifactsOutput>
+    </PropertyGroup>
     <ItemGroup>
         <Using Include="JetBrains.Annotations"/>
         <Using Include="MediatR"/>

--- a/application/shared-kernel/DomainCore/Identity/StronglyTypedId.cs
+++ b/application/shared-kernel/DomainCore/Identity/StronglyTypedId.cs
@@ -12,7 +12,7 @@ public abstract record StronglyTypedId<TValue, T>(TValue Value) : IComparable<St
 {
     public int CompareTo(StronglyTypedId<TValue, T>? other)
     {
-        return other == null ? 1 : Value.CompareTo(other.Value);
+        return other is null ? 1 : Value.CompareTo(other.Value);
     }
 
     public virtual bool Equals(StronglyTypedId<TValue, T>? other)

--- a/application/shared-kernel/DomainCore/Identity/StronglyTypedIdTypeConverter.cs
+++ b/application/shared-kernel/DomainCore/Identity/StronglyTypedIdTypeConverter.cs
@@ -9,7 +9,7 @@ public abstract class StronglyTypedIdTypeConverter<TValue, T> : TypeConverter
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
-        if (value is not string valueAsString || TryParseMethod == null)
+        if (value is not string valueAsString || TryParseMethod is null)
         {
             return base.ConvertFrom(context, culture, value);
         }

--- a/application/shared-kernel/DomainCore/Identity/StronglyTypedUlid.cs
+++ b/application/shared-kernel/DomainCore/Identity/StronglyTypedUlid.cs
@@ -25,7 +25,8 @@ public abstract record StronglyTypedUlid<T>(string Value) : StronglyTypedId<stri
 
     private static T FormUlid(Ulid newValue)
     {
-        return (T)Activator.CreateInstance(typeof(T),
+        return (T)Activator.CreateInstance(
+            typeof(T),
             BindingFlags.Instance | BindingFlags.Public,
             null,
             new object[] { newValue.ToString() },

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -111,11 +111,11 @@ public static class InfrastructureCoreConfiguration
                             throw new UnreachableException("Missing DbContext.");
             dbContext.Database.Migrate();
 
-            logger.LogInformation("Finished migrating database");
+            logger.LogInformation("Finished migrating database.");
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "An error occurred while applying migrations");
+            logger.LogError(ex, "An error occurred while applying migrations.");
 
             // Wait for the logger to flush
             Thread.Sleep(TimeSpan.FromSeconds(1));

--- a/application/shared-kernel/Tests/ApplicationCore/Behaviors/PublishDomainEventsPipelineBehaviorTests.cs
+++ b/application/shared-kernel/Tests/ApplicationCore/Behaviors/PublishDomainEventsPipelineBehaviorTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace PlatformPlatform.SharedKernel.Tests.ApplicationCore.Behaviors;
 
-public class PublishDomainEventsPipelineBehaviorTests
+public sealed class PublishDomainEventsPipelineBehaviorTests
 {
     [Fact]
     public async Task Handle_WhenCalled_ShouldPublishDomainEvents()

--- a/application/shared-kernel/Tests/ApplicationCore/Behaviors/UnitOfWorkPipelineBehaviorTests.cs
+++ b/application/shared-kernel/Tests/ApplicationCore/Behaviors/UnitOfWorkPipelineBehaviorTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace PlatformPlatform.SharedKernel.Tests.ApplicationCore.Behaviors;
 
-public class UnitOfWorkPipelineBehaviorTests
+public sealed class UnitOfWorkPipelineBehaviorTests
 {
     private readonly UnitOfWorkPipelineBehavior<TestCommand, Result<TestAggregate>> _behavior;
     private readonly IUnitOfWork _unitOfWork;

--- a/application/shared-kernel/Tests/DomainCore/DomainEvents/DomainEventTests.cs
+++ b/application/shared-kernel/Tests/DomainCore/DomainEvents/DomainEventTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace PlatformPlatform.SharedKernel.Tests.DomainCore.DomainEvents;
 
-public class DomainEventTests
+public sealed class DomainEventTests
 {
     [Fact]
     public void DomainEvent_WhenCreatingDomainEvents_ShouldTrackEventWithCorrectOccurrence()

--- a/application/shared-kernel/Tests/DomainCore/Entities/EntityEqualityComparerTests.cs
+++ b/application/shared-kernel/Tests/DomainCore/Entities/EntityEqualityComparerTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace PlatformPlatform.SharedKernel.Tests.DomainCore.Entities;
 
-public class EntityEqualityComparerTests
+public sealed class EntityEqualityComparerTests
 {
     private readonly EntityEqualityComparer<Guid> _comparer = new();
 

--- a/application/shared-kernel/Tests/DomainCore/Entities/EntityTests.cs
+++ b/application/shared-kernel/Tests/DomainCore/Entities/EntityTests.cs
@@ -7,7 +7,7 @@ namespace PlatformPlatform.SharedKernel.Tests.DomainCore.Entities;
 
 public static class EntityTests
 {
-    public class OperatorOverloadTests
+    public sealed class OperatorOverloadTests
     {
         [Fact]
         public void EqualsOperator_WhenIdIsAreGenerated_ShouldReturnFalse()
@@ -82,7 +82,7 @@ public static class EntityTests
         }
     }
 
-    public class EqualMethodTests
+    public sealed class EqualMethodTests
     {
         [Fact]
         public void Equal_WhenIdIsAreGenerated_ShouldReturnFalse()
@@ -128,7 +128,7 @@ public static class EntityTests
         }
     }
 
-    public class GetHashCodeTests
+    public sealed class GetHashCodeTests
     {
         [Fact]
         public void GetHashCode_DifferentIdsSameProperties_ShouldHaveDifferentHashCode()
@@ -167,19 +167,19 @@ public static class EntityTests
 public sealed record StronglyTypedId(long Value) : StronglyTypedLongId<StronglyTypedId>(Value);
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public class StronglyTypedIdEntity() : Entity<StronglyTypedId>(StronglyTypedId.NewId())
+public sealed class StronglyTypedIdEntity() : Entity<StronglyTypedId>(StronglyTypedId.NewId())
 {
     public required string Name { get; init; }
 }
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public class GuidEntity(Guid id) : Entity<Guid>(id)
+public sealed class GuidEntity(Guid id) : Entity<Guid>(id)
 {
     public required string Name { get; init; }
 }
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public class StringEntity(string id) : Entity<string>(id)
+public sealed class StringEntity(string id) : Entity<string>(id)
 {
     public required string Name { get; init; }
 }

--- a/application/shared-kernel/Tests/DomainCore/Identity/IdGeneratorTests.cs
+++ b/application/shared-kernel/Tests/DomainCore/Identity/IdGeneratorTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace PlatformPlatform.SharedKernel.Tests.DomainCore.Identity;
 
-public class IdGeneratorTests
+public sealed class IdGeneratorTests
 {
     [Fact]
     public void NewId_WhenGeneratingIds_IdsShouldBeUnique()

--- a/application/shared-kernel/Tests/TestEntities/TestAggregateRepository.cs
+++ b/application/shared-kernel/Tests/TestEntities/TestAggregateRepository.cs
@@ -2,5 +2,5 @@ using PlatformPlatform.SharedKernel.InfrastructureCore.Persistence;
 
 namespace PlatformPlatform.SharedKernel.Tests.TestEntities;
 
-public class TestAggregateRepository(TestDbContext testDbContext)
+public sealed class TestAggregateRepository(TestDbContext testDbContext)
     : RepositoryBase<TestAggregate, long>(testDbContext), ITestAggregateRepository;

--- a/application/shared-kernel/Tests/TestEntities/TestDbContext.cs
+++ b/application/shared-kernel/Tests/TestEntities/TestDbContext.cs
@@ -3,7 +3,8 @@ using PlatformPlatform.SharedKernel.InfrastructureCore.EntityFramework;
 
 namespace PlatformPlatform.SharedKernel.Tests.TestEntities;
 
-public class TestDbContext(DbContextOptions<TestDbContext> options) : SharedKernelDbContext<TestDbContext>(options)
+public sealed class TestDbContext(DbContextOptions<TestDbContext> options)
+    : SharedKernelDbContext<TestDbContext>(options)
 {
     public DbSet<TestAggregate> TestAggregates => Set<TestAggregate>();
 


### PR DESCRIPTION
### Summary & Motivation

This update encompasses a diverse set of changes aimed at enhancing the efficiency, clarity, and quality of the codebase.

The build process has been expedited by eliminating the explicit build step from the GitHub workflow, a change that addresses redundancy in subsequent steps. Additionally, JetBrains Code Inspections workflow has been disabled when running jobs on the main branch. This ensures that successful pull-request builds are not hindered by inspections during production pushes.

Tooling improvements include adopting .NET 8's `<UseArtifactsOutput>` feature, which consolidates `bin` and `obj` folders for each project into a single `artifacts` folder at the solution level. The frontend app's port on localhost has been updated to 8444 from 8080, reflecting its shift to HTTPS. Additionally, launch settings profiles have been renamed for clarity; previously displayed as `ProjectName: ProfileName`, they are now simplified to just `ProjectName`.

Various minor refactorings and improvements have been made throughout the codebase. These include upgrading .NET dependencies, removing unused gRPC and PostgreSQL packages, and updating `Directory.Packages.props` to use variables for EF Core and ASP.NET Core. Obsolete swagger schema generation for nested commands in static classes has been removed, with corresponding updates to documentation.

Other enhancements focus on code consistency and optimization. Minor code cleanups have been performed, constants for Email and Phone validation have been moved to specific validation classes, and `ApiResult.SplitCamelCaseTitle` has been refactored to `GetHttpStatusDisplayName`, now available for test reuse. Remaining classes have been set to be sealed by default. The `== null` syntax has been replaced with `is null` for clarity, a trailing period has been added to log outputs for consistency with exception messages, and compiled regex expressions have been converted to traditional regex to address a warning in Rider.


### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
