### PR TITLE
Temporarily disable production cluster to conserve Azure resources

### DIFF
--- a/.github/workflows/_deploy-container.yml
+++ b/.github/workflows/_deploy-container.yml
@@ -30,7 +30,7 @@ jobs:
 
   production-west-europe-deploy:
     name: Production
-    if: github.ref == 'refs/heads/main'
+    if: false && github.ref == 'refs/heads/main' ## Disable production for now
     needs: staging-west-europe-deploy
     runs-on: ubuntu-latest
     environment: "production" ## Force a manual approval

--- a/.github/workflows/cloud-infrastructure.yml
+++ b/.github/workflows/cloud-infrastructure.yml
@@ -58,9 +58,11 @@ jobs:
         run: bash ./cloud-infrastructure/cluster/config/staging-west-europe.sh --plan
 
       - name: Plan Changes to Shared Production Environment Resources
+        if: false ## Disable production for now
         run: bash ./cloud-infrastructure/environment/config/production.sh --plan
 
       - name: Plan Changes to Production West Europe Cluster
+        if: false ## Disable production for now
         env:
           ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: ${{ secrets.ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID }}
           CONTAINER_REGISTRY_NAME: ${{ vars.CONTAINER_REGISTRY_NAME }}
@@ -159,7 +161,7 @@ jobs:
 
   production:
     name: Production
-    if: github.ref == 'refs/heads/main'
+    if: false && github.ref == 'refs/heads/main' ## Disable production for now
     needs: staging
     runs-on: ubuntu-latest
     environment: "production" ## Force a manual approval


### PR DESCRIPTION
### Summary & Motivation

This change temporarily disables the production cluster, a strategic move to conserve Azure resources. This includes both the deployment of infrastructure shared resources, such as log analytics, and the production-west-europe cluster, as well as suspending the deployment of application docker images to the production-west-europe cluster.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
