### PR TITLE
Wait for WebApp build to be ready in development mode

### DIFF
--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
@@ -142,8 +142,18 @@ public static class WebAppMiddlewareExtensions
         var buildRootPath = GetWebAppDistRoot(webAppProjectName, "dist");
         var templateFilePath = Path.Combine(buildRootPath, "index.html");
 
-        if (!File.Exists(templateFilePath) &&
-            Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") != "development")
+        if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "development")
+        {
+            var tryUntil = DateTime.UtcNow.AddSeconds(10);
+            while (!File.Exists(templateFilePath))
+            {
+                if (DateTime.UtcNow > tryUntil) break;
+                Debug.WriteLine($"Waiting for {webAppProjectName} build to be ready...");
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+            }
+        }
+
+        if (!File.Exists(templateFilePath))
         {
             throw new FileNotFoundException("index.html does not exist.", templateFilePath);
         }


### PR DESCRIPTION
### Summary & Motivation

In development mode it often happens that the WebApp build folder is being created as the server starts up - the UseStaticFiles middleware throws an exception if the folder doesn't exist.

This is only an issue in development mode.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
