### PR TITLE
Shift code inspections to execute on pull requests

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -87,7 +87,7 @@ jobs:
 
   jetbrains-code-inspection:
     name: JetBrains Code Inspections
-    if: github.ref == 'refs/heads/main'
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
### Summary & Motivation

In a previous update (refer to [pull request #229](https://github.com/PlatformPlatform/platformplatform/pull/229)), code inspections were inadvertently disabled for pull requests and enabled for the main branch. This reverts that change, so code inspections now run on pull requests.


### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
