### PR TITLE
Speed up tests with parallel execution

### DIFF
--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="Bogus" Version="34.0.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="Meziantou.Xunit.ParallelTestFramework" Version="2.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersion)" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />

--- a/application/account-management/Tests/Tests.csproj
+++ b/application/account-management/Tests/Tests.csproj
@@ -25,6 +25,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions"/>
+        <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>

--- a/application/shared-kernel/Tests/Tests.csproj
+++ b/application/shared-kernel/Tests/Tests.csproj
@@ -19,6 +19,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />


### PR DESCRIPTION
### Summary & Motivation

Configure Xunit tests to run in parallel using the `Meziantou.Xunit.ParallelTestFramework` NuGet package. This change reduces the test execution time of the test suite on a developer's laptop from 16 to 6 seconds. On GitHub runners, the `Run Test with dotCover and SonarScanner reporting` step is shortened from an average of 1m 55s to 1m 35s.

By default, Xunit treats each class as a test collection, and tests within a test collection run sequentially. The `Meziantou.Xunit.ParallelTestFramework` package configures tests to run in parallel by default, with each test in its own test collection. Tests that require sequential execution can be marked with the `[Collection("Sequential")]` attribute.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
