### PR TITLE
Streamline creation of problem details to align with RFC standards

### DIFF
--- a/application/account-management/Tests/Api/ApiCore/CustomExceptionHandlingTests.cs
+++ b/application/account-management/Tests/Api/ApiCore/CustomExceptionHandlingTests.cs
@@ -45,7 +45,8 @@ public sealed class CustomExceptionHandlingTests : BaseApiTests<AccountManagemen
             await EnsureErrorStatusCode(
                 response,
                 HttpStatusCode.InternalServerError,
-                "An error occurred while processing the request."
+                "An error occurred while processing the request.",
+                hasTraceId: true
             );
         }
     }
@@ -86,7 +87,8 @@ public sealed class CustomExceptionHandlingTests : BaseApiTests<AccountManagemen
             await EnsureErrorStatusCode(
                 response,
                 HttpStatusCode.RequestTimeout,
-                "GET /api/throwTimeoutException"
+                "GET /api/throwTimeoutException",
+                hasTraceId: true
             );
         }
     }

--- a/application/account-management/Tests/Api/ApiCore/CustomExceptionHandlingTests.cs
+++ b/application/account-management/Tests/Api/ApiCore/CustomExceptionHandlingTests.cs
@@ -35,7 +35,7 @@ public sealed class CustomExceptionHandlingTests : BaseApiTests<AccountManagemen
         {
             // In Development we use app.UseDeveloperExceptionPage() which returns a HTML response.
             response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
-            response.Content.Headers.ContentType!.MediaType.Should().Be("text/plain");
+            response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
             var errorResponse = await response.Content.ReadAsStringAsync();
             errorResponse.Contains("Simulate an exception.").Should().BeTrue();
         }
@@ -76,7 +76,7 @@ public sealed class CustomExceptionHandlingTests : BaseApiTests<AccountManagemen
         {
             // In Development we use app.UseDeveloperExceptionPage() which returns a HTML response.
             response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
-            response.Content.Headers.ContentType!.MediaType.Should().Be("text/plain");
+            response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
             var errorResponse = await response.Content.ReadAsStringAsync();
             errorResponse.Contains("Simulating a timeout exception.").Should().BeTrue();
         }

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -103,7 +103,7 @@ public abstract class BaseApiTests<TContext> : BaseTest<TContext> where TContext
 
         problemDetails.Should().NotBeNull();
         problemDetails!.Status.Should().Be((int)statusCode);
-        problemDetails.Type.Should().Be($"https://httpstatuses.com/{(int)statusCode}");
+        problemDetails.Type.Should().StartWith("https://tools.ietf.org/html/rfc9110#section-15.");
         problemDetails.Title.Should().Be(ApiResult.GetHttpStatusDisplayName(statusCode));
 
         if (expectedDetail is not null)

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -93,7 +93,8 @@ public abstract class BaseApiTests<TContext> : BaseTest<TContext> where TContext
         HttpResponseMessage response,
         HttpStatusCode statusCode,
         string? expectedDetail,
-        IEnumerable<ErrorDetail>? expectedErrors = null
+        IEnumerable<ErrorDetail>? expectedErrors = null,
+        bool hasTraceId = false
     )
     {
         response.StatusCode.Should().Be(statusCode);
@@ -118,6 +119,11 @@ public abstract class BaseApiTests<TContext> : BaseTest<TContext> where TContext
             var actualErrors = JsonSerializer.Deserialize<ErrorDetail[]>(actualErrorsJson.GetRawText(), options);
 
             actualErrors.Should().BeEquivalentTo(expectedErrors);
+        }
+
+        if (hasTraceId)
+        {
+            problemDetails.Extensions["traceId"]!.ToString().Should().NotBeEmpty();
         }
     }
 

--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -22,11 +22,12 @@ public static class ApiCoreConfiguration
     [UsedImplicitly]
     public static IServiceCollection AddApiCoreServices(this IServiceCollection services, WebApplicationBuilder builder)
     {
-        builder.Services.AddExceptionHandler<TimeoutExceptionHandler>();
-        builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
-        services.AddTransient<ModelBindingExceptionHandlerMiddleware>();
-
-        services.AddEndpointsApiExplorer();
+        services
+            .AddExceptionHandler<TimeoutExceptionHandler>()
+            .AddExceptionHandler<GlobalExceptionHandler>()
+            .AddTransient<ModelBindingExceptionHandlerMiddleware>()
+            .AddProblemDetails()
+            .AddEndpointsApiExplorer();
 
         services.AddSwaggerGen(c =>
         {

--- a/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandler.cs
+++ b/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandler.cs
@@ -12,12 +12,18 @@ public sealed class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logge
         CancellationToken cancellationToken
     )
     {
-        logger.LogError(exception, "An error occurred while processing the request.");
+        var traceId = Activity.Current?.Id ?? httpContext.TraceIdentifier;
+
+        logger.LogError(
+            exception, "An error occurred while processing the request. TraceId: {TraceId}.",
+            traceId
+        );
 
         await Results.Problem(
             title: "Internal Server Error",
             detail: "An error occurred while processing the request.",
-            statusCode: (int)HttpStatusCode.InternalServerError
+            statusCode: (int)HttpStatusCode.InternalServerError,
+            extensions: new Dictionary<string, object?> { { "traceId", traceId } }
         ).ExecuteAsync(httpContext);
 
         // Return true to signal that this exception is handled

--- a/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandler.cs
+++ b/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandler.cs
@@ -1,42 +1,24 @@
 using System.Net;
-using System.Text.Json;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
 
 namespace PlatformPlatform.SharedKernel.ApiCore.Middleware;
 
-public sealed class GlobalExceptionHandler(
-    ILogger<GlobalExceptionHandler> logger,
-    IOptions<JsonOptions> jsonOptions
-) : IExceptionHandler
+public sealed class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IExceptionHandler
 {
-    private readonly JsonSerializerOptions _jsonSerializerOptions = jsonOptions.Value.SerializerOptions;
-    private readonly ILogger _logger = logger;
-
     public async ValueTask<bool> TryHandleAsync(
         HttpContext httpContext,
         Exception exception,
         CancellationToken cancellationToken
     )
     {
-        _logger.LogError(exception, "An error occurred while processing the request.");
+        logger.LogError(exception, "An error occurred while processing the request.");
 
-        httpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
-        httpContext.Response.ContentType = "application/problem+json";
-
-        var problemDetails = new ProblemDetails
-        {
-            Type = $"https://httpstatuses.com/{(int)HttpStatusCode.InternalServerError}",
-            Title = "Internal Server Error",
-            Status = (int)HttpStatusCode.InternalServerError,
-            Detail = "An error occurred while processing the request."
-        };
-
-        var jsonResponse = JsonSerializer.Serialize(problemDetails, _jsonSerializerOptions);
-        await httpContext.Response.WriteAsync(jsonResponse, cancellationToken);
+        await Results.Problem(
+            title: "Internal Server Error",
+            detail: "An error occurred while processing the request.",
+            statusCode: (int)HttpStatusCode.InternalServerError
+        ).ExecuteAsync(httpContext);
 
         // Return true to signal that this exception is handled
         return true;

--- a/application/shared-kernel/ApiCore/Middleware/TimeoutExceptionHandler.cs
+++ b/application/shared-kernel/ApiCore/Middleware/TimeoutExceptionHandler.cs
@@ -1,21 +1,11 @@
 using System.Net;
-using System.Text.Json;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
 
 namespace PlatformPlatform.SharedKernel.ApiCore.Middleware;
 
-public sealed class TimeoutExceptionHandler(
-    ILogger<TimeoutExceptionHandler> logger,
-    IOptions<JsonOptions> jsonOptions
-) : IExceptionHandler
+public sealed class TimeoutExceptionHandler(ILogger<TimeoutExceptionHandler> logger) : IExceptionHandler
 {
-    private readonly JsonSerializerOptions _jsonSerializerOptions = jsonOptions.Value.SerializerOptions;
-    private readonly ILogger _logger = logger;
-
     public async ValueTask<bool> TryHandleAsync(
         HttpContext httpContext,
         Exception exception,
@@ -28,21 +18,13 @@ public sealed class TimeoutExceptionHandler(
             return false;
         }
 
-        _logger.LogError(exception, "An timeout exception occurred while processing the request.");
+        logger.LogError(exception, "An timeout exception occurred while processing the request.");
 
-        httpContext.Response.StatusCode = (int)HttpStatusCode.RequestTimeout;
-        httpContext.Response.ContentType = "application/problem+json";
-
-        var problemDetails = new ProblemDetails
-        {
-            Type = $"https://httpstatuses.com/{(int)HttpStatusCode.RequestTimeout}",
-            Title = "Request Timeout",
-            Status = (int)HttpStatusCode.RequestTimeout,
-            Detail = $"{httpContext.Request.Method} {httpContext.Request.Path} {httpContext.Request.QueryString}".Trim()
-        };
-
-        var jsonResponse = JsonSerializer.Serialize(problemDetails, _jsonSerializerOptions);
-        await httpContext.Response.WriteAsync(jsonResponse, cancellationToken);
+        await Results.Problem(
+            title: "Request Timeout",
+            detail: $"{httpContext.Request.Method} {httpContext.Request.Path} {httpContext.Request.QueryString}".Trim(),
+            statusCode: (int)HttpStatusCode.RequestTimeout
+        ).ExecuteAsync(httpContext);
 
         // Return true to signal that this exception is handled
         return true;

--- a/application/shared-kernel/ApiCore/Middleware/TimeoutExceptionHandler.cs
+++ b/application/shared-kernel/ApiCore/Middleware/TimeoutExceptionHandler.cs
@@ -18,12 +18,18 @@ public sealed class TimeoutExceptionHandler(ILogger<TimeoutExceptionHandler> log
             return false;
         }
 
-        logger.LogError(exception, "An timeout exception occurred while processing the request.");
+        var traceId = Activity.Current?.Id ?? httpContext.TraceIdentifier;
+
+        logger.LogError(
+            exception, "An timeout exception occurred while processing the request. TraceId: {TraceId}.",
+            traceId
+        );
 
         await Results.Problem(
             title: "Request Timeout",
             detail: $"{httpContext.Request.Method} {httpContext.Request.Path} {httpContext.Request.QueryString}".Trim(),
-            statusCode: (int)HttpStatusCode.RequestTimeout
+            statusCode: (int)HttpStatusCode.RequestTimeout,
+            extensions: new Dictionary<string, object?> { { "traceId", traceId } }
         ).ExecuteAsync(httpContext);
 
         // Return true to signal that this exception is handled


### PR DESCRIPTION
### Summary & Motivation

Simplify the creation of problem details to adhere to RFC standards, using .NET to set the 'Type' field to relevant URLs, like `https://tools.ietf.org/html/rfc9110#section-15.5.5` for a `404 Not Found` error. 

Also, implement the built-in `Results.Problem(...)` method to automatically set the `httpContext.Response.ContentType` to `application/problem+json` and ensure correct JSON serialization. Update tests accordingly. This greatly simplifies the code.

Additionally, add a `traceId` to the ProblemDetails extension for server-side exceptions. The can be shown in the client and used in support scenarios. 

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
