### PR TITLE
Integrate Application Insights connection string with Azure Container App

### DIFF
--- a/cloud-infrastructure/cluster/deploy-cluster.sh
+++ b/cloud-infrastructure/cluster/deploy-cluster.sh
@@ -50,9 +50,12 @@ RESOURCE_GROUP_NAME="$ENVIRONMENT-$LOCATION_PREFIX"
 ACTIVE_ACCOUNT_MANAGEMENT_VERSION=$(get_active_version account-management)
 ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED=$(is_domain_configured "account-management" "$RESOURCE_GROUP_NAME")
 
+az extension add --name application-insights
+APPLICATION_INSIGHTS_CONNECTION_STRING=$(az monitor app-insights component show --app $ENVIRONMENT-application-insights --resource-group $ENVIRONMENT --query connectionString --output tsv)
+
 DEPLOYMENT_COMMAND="az deployment sub create"
 CURRENT_DATE=$(date +'%Y-%m-%dT%H-%M')
-DEPLOYMENT_PARAMETERS="-l $LOCATION -n $CURRENT_DATE-$RESOURCE_GROUP_NAME --output json -f ./main-cluster.bicep -p environment=$ENVIRONMENT locationPrefix=$LOCATION_PREFIX resourceGroupName=$RESOURCE_GROUP_NAME clusterUniqueName=$CLUSTER_UNIQUE_NAME useMssqlElasticPool=$USE_MSSQL_ELASTIC_POOL containerRegistryName=$CONTAINER_REGISTRY_NAME domainName=$DOMAIN_NAME sqlAdminObjectId=$ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID accountManagementVersion=$ACTIVE_ACCOUNT_MANAGEMENT_VERSION accountManagementDomainConfigured=$ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED"
+DEPLOYMENT_PARAMETERS="-l $LOCATION -n $CURRENT_DATE-$RESOURCE_GROUP_NAME --output json -f ./main-cluster.bicep -p environment=$ENVIRONMENT locationPrefix=$LOCATION_PREFIX resourceGroupName=$RESOURCE_GROUP_NAME clusterUniqueName=$CLUSTER_UNIQUE_NAME useMssqlElasticPool=$USE_MSSQL_ELASTIC_POOL containerRegistryName=$CONTAINER_REGISTRY_NAME domainName=$DOMAIN_NAME sqlAdminObjectId=$ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID accountManagementVersion=$ACTIVE_ACCOUNT_MANAGEMENT_VERSION accountManagementDomainConfigured=$ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED applicationInsightsConnectionString=$APPLICATION_INSIGHTS_CONNECTION_STRING"
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 . ../deploy.sh
@@ -89,7 +92,7 @@ then
   if [[ "$ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED" == "false" ]] && [[ "$DOMAIN_NAME" != "" ]]; then
     echo "Running deployment again to finalize setting up SSL certificate for account-management"
     ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED=true
-    DEPLOYMENT_PARAMETERS="-l $LOCATION -n $CURRENT_DATE-$RESOURCE_GROUP_NAME --output json -f ./main-cluster.bicep -p environment=$ENVIRONMENT locationPrefix=$LOCATION_PREFIX resourceGroupName=$RESOURCE_GROUP_NAME clusterUniqueName=$CLUSTER_UNIQUE_NAME useMssqlElasticPool=$USE_MSSQL_ELASTIC_POOL containerRegistryName=$CONTAINER_REGISTRY_NAME domainName=$DOMAIN_NAME sqlAdminObjectId=$ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID accountManagementVersion=$ACTIVE_ACCOUNT_MANAGEMENT_VERSION accountManagementDomainConfigured=$ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED"
+    DEPLOYMENT_PARAMETERS="-l $LOCATION -n $CURRENT_DATE-$RESOURCE_GROUP_NAME --output json -f ./main-cluster.bicep -p environment=$ENVIRONMENT locationPrefix=$LOCATION_PREFIX resourceGroupName=$RESOURCE_GROUP_NAME clusterUniqueName=$CLUSTER_UNIQUE_NAME useMssqlElasticPool=$USE_MSSQL_ELASTIC_POOL containerRegistryName=$CONTAINER_REGISTRY_NAME domainName=$DOMAIN_NAME sqlAdminObjectId=$ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID accountManagementVersion=$ACTIVE_ACCOUNT_MANAGEMENT_VERSION accountManagementDomainConfigured=$ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED applicationInsightsConnectionString=$APPLICATION_INSIGHTS_CONNECTION_STRING"
 
     . ../deploy.sh
 

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -11,6 +11,7 @@ param sqlAdminObjectId string
 param domainName string
 param accountManagementVersion string = ''
 param accountManagementDomainConfigured bool
+param applicationInsightsConnectionString string
 
 var tags = { environment: environment, 'managed-by': 'bicep' }
 var diagnosticStorageAccountName = '${clusterUniqueName}diagnostic'
@@ -182,6 +183,7 @@ module accountManagement '../modules/container-app.bicep' = {
     userAssignedIdentityName: 'account-management-${resourceGroupName}'
     domainName: domainName == '' ? '' : 'account-management.${domainName}'
     domainConfigured: domainName != '' && accountManagementDomainConfigured
+    applicationInsightsConnectionString: applicationInsightsConnectionString
   }
   dependsOn: [accountManagementDatabase]
 }

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -138,7 +138,7 @@ module accountManagementDatabase '../modules/microsoft-sql-database.bicep' = {
   dependsOn: [microsoftSqlServer]
 }
 
-module contaionerAppsEnvironment '../modules/container-apps-environment.bicep' = {
+module containerAppsEnvironment '../modules/container-apps-environment.bicep' = {
   scope: clusterResourceGroup
   name: 'container-apps-environment'
   params: {
@@ -168,8 +168,8 @@ module accountManagement '../modules/container-app.bicep' = {
     location: location
     tags: tags
     resourceGroupName: resourceGroupName
-    environmentId: contaionerAppsEnvironment.outputs.environmentId
-    environmentName: contaionerAppsEnvironment.outputs.name
+    containerAppsEnvironmentId: containerAppsEnvironment.outputs.environmentId
+    containerAppsEnvironmentName: containerAppsEnvironment.outputs.name
     containerRegistryName: containerRegistryName
     containerImageName: 'account-management'
     containerImageTag: accountManagementVersion

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -2,8 +2,8 @@ param name string
 param location string
 param tags object
 param resourceGroupName string
-param environmentId string
-param environmentName string
+param containerAppsEnvironmentId string
+param containerAppsEnvironmentName string
 param containerRegistryName string
 param containerImageName string
 param containerImageTag string
@@ -44,14 +44,14 @@ module newManagedCertificate './managed-certificate.bicep' =
       name: certificateName
       location: location
       tags: tags
-      environmentName: environmentName
+      containerAppsEnvironmentName: containerAppsEnvironmentName
       domainName: domainName
     }
   }
 
 resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-02-preview' existing =
   if (isCustomDomainSet) {
-    name: environmentName
+    name: containerAppsEnvironmentName
   }
 
 resource existingManagedCertificate 'Microsoft.App/managedEnvironments/managedCertificates@2023-05-02-preview' existing =
@@ -89,7 +89,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
     }
   }
   properties: {
-    environmentId: environmentId
+    environmentId: containerAppsEnvironmentId
     template: {
       containers: [
         {

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -16,6 +16,7 @@ param sqlDatabaseName string
 param userAssignedIdentityName string
 param domainName string
 param domainConfigured bool
+param applicationInsightsConnectionString string
 
 resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
   scope: resourceGroup(resourceGroupName)
@@ -111,6 +112,10 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
             {
               name: 'MANAGED_IDENTITY_CLIENT_ID'
               value: userAssignedIdentity.properties.clientId
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              value: applicationInsightsConnectionString
             }
             {
               name: 'PUBLIC_URL'

--- a/cloud-infrastructure/modules/managed-certificate.bicep
+++ b/cloud-infrastructure/modules/managed-certificate.bicep
@@ -1,11 +1,11 @@
 param name string
 param location string
 param tags object
-param environmentName string
+param containerAppsEnvironmentName string
 param domainName string
 
 resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-02-preview' existing = {
-  name: environmentName
+  name: containerAppsEnvironmentName
 }
 
 resource managedCertificate 'Microsoft.App/managedEnvironments/managedCertificates@2023-05-02-preview' = {


### PR DESCRIPTION
### Summary & Motivation

Add the Application Insights connection string as an environment variable, named `APPLICATIONINSIGHTS_CONNECTION_STRING`, to the Azure Container App. This is a special name that enables the Application Insights SDK to automatically recognize and use this connection string, eliminating the need for additional configuration.

Opting not to retrieve the connection string via Bicep due to a known issue (see [GitHub Issue #157](https://github.com/Azure/arm-template-whatif/issues/157)), which affects the `--what-if` functionality. Instead, the Azure CLI is used to fetch the connection string and pass it as a parameter to Bicep, ensuring the `--what-if` functionality remains effective.

To enhance clarity, the `environmentName` and `environmentId` parameters in the Bicep container App module have been renamed to `containerAppsEnvironmentName` and `containerAppsEnvironmentId`, respectively.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
