### PR TITLE
Add telemetry with Application Insights and OpenTelemetry

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Generate version
         id: generate_version
         run: |
-          VERSION=$(date +"%Y.%m.%d").$GITHUB_RUN_NUMBER
+          VERSION=$(date +"%Y.%-m.%-d.%-H%M")
           echo "Generated version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -68,6 +68,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(RuntimeVersion)" />
     <!-- Open Telemetry -->
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0-beta.8" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0-alpha.1" />

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -10,9 +10,11 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- PlatformPlatform dependencies - Api -->
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EfCoreVersion)" />
     <!-- PlatformPlatform dependencies - Application -->
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageVersion Include="Mapster" Version="7.4.0" />
     <PackageVersion Include="MediatR" Version="12.2.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.1" />

--- a/application/account-management/Application/Tenants/CreateTenant.cs
+++ b/application/account-management/Application/Tenants/CreateTenant.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using PlatformPlatform.AccountManagement.Application.Users;
 using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
+using PlatformPlatform.SharedKernel.ApplicationCore.Tracking;
 using PlatformPlatform.SharedKernel.ApplicationCore.Validation;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants;
@@ -9,15 +10,28 @@ public sealed record CreateTenantCommand(string Subdomain, string Name, string? 
     : ICommand, ITenantValidation, IRequest<Result<TenantId>>;
 
 [UsedImplicitly]
-public sealed class CreateTenantHandler(ITenantRepository tenantRepository, ISender mediator)
+public sealed class CreateTenantHandler(
+    ITenantRepository tenantRepository,
+    IAnalyticEventsCollector analyticEventsCollector,
+    ISender mediator
+)
     : IRequestHandler<CreateTenantCommand, Result<TenantId>>
 {
     public async Task<Result<TenantId>> Handle(CreateTenantCommand command, CancellationToken cancellationToken)
     {
         var tenant = Tenant.Create(command.Subdomain, command.Name, command.Phone);
         await tenantRepository.AddAsync(tenant, cancellationToken);
+        analyticEventsCollector.CollectEvent(
+            "TenantCreated",
+            new Dictionary<string, string>
+            {
+                { "Tenant_Id", tenant.Id.ToString() },
+                { "Event_TenantState", tenant.State.ToString() }
+            }
+        );
 
         await CreateTenantOwnerAsync(tenant.Id, command.Email, cancellationToken);
+
         return tenant.Id;
     }
 

--- a/application/account-management/Application/Tenants/UpdateTenant.cs
+++ b/application/account-management/Application/Tenants/UpdateTenant.cs
@@ -1,4 +1,5 @@
 using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
+using PlatformPlatform.SharedKernel.ApplicationCore.Tracking;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants;
 
@@ -13,7 +14,10 @@ public sealed record UpdateTenantCommand : ICommand, ITenantValidation, IRequest
 }
 
 [UsedImplicitly]
-public sealed class UpdateTenantHandler(ITenantRepository tenantRepository)
+public sealed class UpdateTenantHandler(
+    ITenantRepository tenantRepository,
+    IAnalyticEventsCollector analyticEventsCollector
+)
     : IRequestHandler<UpdateTenantCommand, Result>
 {
     public async Task<Result> Handle(UpdateTenantCommand command, CancellationToken cancellationToken)
@@ -23,6 +27,12 @@ public sealed class UpdateTenantHandler(ITenantRepository tenantRepository)
 
         tenant.Update(command.Name, command.Phone);
         tenantRepository.Update(tenant);
+
+        analyticEventsCollector.CollectEvent(
+            "TenantUpdated",
+            new Dictionary<string, string> { { "Tenant_Id", command.Id.ToString() } }
+        );
+
         return Result.Success();
     }
 }

--- a/application/account-management/Application/Users/DeleteUser.cs
+++ b/application/account-management/Application/Users/DeleteUser.cs
@@ -1,11 +1,15 @@
 using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
+using PlatformPlatform.SharedKernel.ApplicationCore.Tracking;
 
 namespace PlatformPlatform.AccountManagement.Application.Users;
 
 public sealed record DeleteUserCommand(UserId Id) : ICommand, IRequest<Result>;
 
 [UsedImplicitly]
-public sealed class DeleteUserHandler(IUserRepository userRepository) : IRequestHandler<DeleteUserCommand, Result>
+public sealed class DeleteUserHandler(
+    IUserRepository userRepository,
+    IAnalyticEventsCollector analyticEventsCollector
+) : IRequestHandler<DeleteUserCommand, Result>
 {
     public async Task<Result> Handle(DeleteUserCommand command, CancellationToken cancellationToken)
     {
@@ -13,6 +17,8 @@ public sealed class DeleteUserHandler(IUserRepository userRepository) : IRequest
         if (user is null) return Result.NotFound($"User with id '{command.Id}' not found.");
 
         userRepository.Remove(user);
+
+        analyticEventsCollector.CollectEvent("UserDeleted");
         return Result.Success();
     }
 }

--- a/application/account-management/Application/Users/UpdateUser.cs
+++ b/application/account-management/Application/Users/UpdateUser.cs
@@ -1,4 +1,5 @@
 using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
+using PlatformPlatform.SharedKernel.ApplicationCore.Tracking;
 
 namespace PlatformPlatform.AccountManagement.Application.Users;
 
@@ -13,7 +14,10 @@ public sealed record UpdateUserCommand : ICommand, IUserValidation, IRequest<Res
 }
 
 [UsedImplicitly]
-public sealed class UpdateUserHandler(IUserRepository userRepository) : IRequestHandler<UpdateUserCommand, Result>
+public sealed class UpdateUserHandler(
+    IUserRepository userRepository,
+    IAnalyticEventsCollector analyticEventsCollector
+) : IRequestHandler<UpdateUserCommand, Result>
 {
     public async Task<Result> Handle(UpdateUserCommand command, CancellationToken cancellationToken)
     {
@@ -22,6 +26,8 @@ public sealed class UpdateUserHandler(IUserRepository userRepository) : IRequest
 
         user.Update(command.Email, command.UserRole);
         userRepository.Update(user);
+
+        analyticEventsCollector.CollectEvent("UserUpdated");
         return Result.Success();
     }
 }

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -8,7 +8,9 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using PlatformPlatform.SharedKernel.ApiCore.ApiResults;
 using PlatformPlatform.SharedKernel.ApiCore.Middleware;
+using PlatformPlatform.SharedKernel.ApplicationCore.Tracking;
 using PlatformPlatform.SharedKernel.ApplicationCore.Validation;
+using PlatformPlatform.SharedKernel.Tests.ApplicationCore.Tracking;
 
 namespace PlatformPlatform.AccountManagement.Tests.Api;
 
@@ -28,6 +30,9 @@ public abstract class BaseApiTests<TContext> : BaseTest<TContext> where TContext
                 // Replace the default DbContext in the WebApplication to use an in-memory SQLite database 
                 services.Remove(services.Single(d => d.ServiceType == typeof(DbContextOptions<TContext>)));
                 services.AddDbContext<TContext>(options => { options.UseSqlite(Connection); });
+
+                AnalyticEventsCollectorSpy = new AnalyticEventsCollectorSpy(new AnalyticEventsCollector());
+                services.AddScoped<IAnalyticEventsCollector>(_ => AnalyticEventsCollectorSpy);
             });
         });
 

--- a/application/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
@@ -123,6 +123,8 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
             new ErrorDetail("Email", "Email must be in a valid format and no longer than 100 characters.")
         };
         await EnsureErrorStatusCode(response, HttpStatusCode.BadRequest, expectedErrors);
+
+        AnalyticEventsCollectorSpy.AreAllEventsDispatched.Should().BeFalse();
     }
 
     [Fact]
@@ -141,6 +143,8 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
             new ErrorDetail("Subdomain", "The subdomain is not available.")
         };
         await EnsureErrorStatusCode(response, HttpStatusCode.BadRequest, expectedErrors);
+
+        AnalyticEventsCollectorSpy.AreAllEventsDispatched.Should().BeFalse();
     }
 
     [Fact]
@@ -155,6 +159,10 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
 
         // Assert
         EnsureSuccessWithEmptyHeaderAndLocation(response);
+
+        AnalyticEventsCollectorSpy.CollectedEvents.Count.Should().Be(1);
+        AnalyticEventsCollectorSpy.CollectedEvents.Count(e => e.Name == "TenantUpdated").Should().Be(1);
+        AnalyticEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
     }
 
     [Fact]
@@ -176,6 +184,8 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
             new ErrorDetail("Phone", "Phone must be in a valid format and no longer than 20 characters.")
         };
         await EnsureErrorStatusCode(response, HttpStatusCode.BadRequest, expectedErrors);
+
+        AnalyticEventsCollectorSpy.AreAllEventsDispatched.Should().BeFalse();
     }
 
     [Fact]
@@ -194,6 +204,8 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
             HttpStatusCode.NotFound,
             $"Tenant with id '{unknownTenantId}' not found."
         );
+
+        AnalyticEventsCollectorSpy.AreAllEventsDispatched.Should().BeFalse();
     }
 
     [Fact]
@@ -211,6 +223,8 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
             HttpStatusCode.NotFound,
             $"Tenant with id '{unknownTenantId}' not found."
         );
+
+        AnalyticEventsCollectorSpy.AreAllEventsDispatched.Should().BeFalse();
     }
 
     [Fact]
@@ -219,6 +233,7 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         // Act
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
         var response = await TestHttpClient.DeleteAsync($"/api/tenants/{existingTenantId}");
+        AnalyticEventsCollectorSpy.Reset();
 
         // Assert
         var expectedErrors = new[]
@@ -226,6 +241,8 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
             new ErrorDetail("Id", "All users must be deleted before the tenant can be deleted.")
         };
         await EnsureErrorStatusCode(response, HttpStatusCode.BadRequest, expectedErrors);
+
+        AnalyticEventsCollectorSpy.AreAllEventsDispatched.Should().BeFalse();
     }
 
     [Fact]
@@ -235,6 +252,7 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
         var existingUserId = DatabaseSeeder.User1.Id;
         _ = await TestHttpClient.DeleteAsync($"/api/users/{existingUserId}");
+        AnalyticEventsCollectorSpy.Reset();
 
         // Act
         var response = await TestHttpClient.DeleteAsync($"/api/tenants/{existingTenantId}");
@@ -242,5 +260,9 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         // Assert
         EnsureSuccessWithEmptyHeaderAndLocation(response);
         Connection.RowExists("Tenants", existingTenantId).Should().BeFalse();
+
+        AnalyticEventsCollectorSpy.CollectedEvents.Count.Should().Be(1);
+        AnalyticEventsCollectorSpy.CollectedEvents.Count(e => e.Name == "TenantDeleted").Should().Be(1);
+        AnalyticEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
     }
 }

--- a/application/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
@@ -93,6 +93,11 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         await EnsureSuccessPostRequest(response, $"/api/tenants/{subdomain}");
         Connection.RowExists("Tenants", subdomain);
         Connection.ExecuteScalar("SELECT COUNT(*) FROM Users WHERE Email = @email", new { email }).Should().Be(1);
+
+        AnalyticEventsCollectorSpy.CollectedEvents.Count.Should().Be(2);
+        AnalyticEventsCollectorSpy.CollectedEvents.Count(e => e.Name == "TenantCreated").Should().Be(1);
+        AnalyticEventsCollectorSpy.CollectedEvents.Count(e => e.Name == "UserCreated").Should().Be(1);
+        AnalyticEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
     }
 
     [Fact]

--- a/application/account-management/Tests/Application/Tenants/CreateTenantValidationTests.cs
+++ b/application/account-management/Tests/Application/Tenants/CreateTenantValidationTests.cs
@@ -30,6 +30,19 @@ public sealed class CreateTenantValidationTests : BaseTest<AccountManagementDbCo
         // Assert
         result.IsSuccess.Should().BeTrue(scenario);
         result.Errors.Should().BeNull(scenario);
+
+        AnalyticEventsCollectorSpy.CollectedEvents.Count.Should().Be(2);
+
+        AnalyticEventsCollectorSpy.CollectedEvents.Count(e =>
+            e.Name == "TenantCreated" &&
+            e.Properties!["Tenant_Id"] == subdomain &&
+            e.Properties["Event_TenantState"] == "Trial"
+        ).Should().Be(1);
+
+        AnalyticEventsCollectorSpy.CollectedEvents.Count(e =>
+            e.Name == "UserCreated" &&
+            e.Properties!["Tenant_Id"] == subdomain
+        ).Should().Be(1);
     }
 
     [Theory]

--- a/application/account-management/Tests/Tests.csproj
+++ b/application/account-management/Tests/Tests.csproj
@@ -16,6 +16,7 @@
         <ProjectReference Include="..\Application\Application.csproj"/>
         <ProjectReference Include="..\Domain\Domain.csproj"/>
         <ProjectReference Include="..\Infrastructure\Infrastructure.csproj"/>
+        <ProjectReference Include="..\..\shared-kernel\Tests\Tests.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/application/shared-kernel/ApiCore/ApiCore.csproj
+++ b/application/shared-kernel/ApiCore/ApiCore.csproj
@@ -20,6 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" />
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
         <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />

--- a/application/shared-kernel/ApiCore/ApiCore.csproj
+++ b/application/shared-kernel/ApiCore/ApiCore.csproj
@@ -21,6 +21,7 @@
 
     <ItemGroup>
         <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
+        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" />
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
         <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />

--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Json;
@@ -27,8 +28,16 @@ public static class ApiCoreConfiguration
             .AddExceptionHandler<GlobalExceptionHandler>()
             .AddTransient<ModelBindingExceptionHandlerMiddleware>()
             .AddProblemDetails()
-            .AddEndpointsApiExplorer()
-            .AddApplicationInsightsTelemetry();
+            .AddEndpointsApiExplorer();
+
+        var applicationInsightsServiceOptions = new ApplicationInsightsServiceOptions
+        {
+            EnableRequestTrackingTelemetryModule = false,
+            EnableDependencyTrackingTelemetryModule = false,
+            RequestCollectionOptions = { TrackExceptions = false }
+        };
+
+        services.AddApplicationInsightsTelemetry(applicationInsightsServiceOptions);
 
         services.AddSwaggerGen(c =>
         {

--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -27,7 +27,8 @@ public static class ApiCoreConfiguration
             .AddExceptionHandler<GlobalExceptionHandler>()
             .AddTransient<ModelBindingExceptionHandlerMiddleware>()
             .AddProblemDetails()
-            .AddEndpointsApiExplorer();
+            .AddEndpointsApiExplorer()
+            .AddApplicationInsightsTelemetry();
 
         services.AddSwaggerGen(c =>
         {

--- a/application/shared-kernel/ApiCore/Aspire/ServiceDefaultsExtensions.cs
+++ b/application/shared-kernel/ApiCore/Aspire/ServiceDefaultsExtensions.cs
@@ -1,3 +1,4 @@
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
@@ -77,9 +78,11 @@ public static class ServiceDefaultsExtensions
             builder.Services.ConfigureOpenTelemetryTracerProvider(tracing => tracing.AddOtlpExporter());
         }
 
-        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.Exporter package)
-        // builder.Services.AddOpenTelemetry()
-        //    .UseAzureMonitor();
+        builder.Services.AddOpenTelemetry().UseAzureMonitor(options =>
+        {
+            options.ConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"] ??
+                                       "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://localhost;LiveEndpoint=https://localhost";
+        });
 
         return builder;
     }

--- a/application/shared-kernel/ApplicationCore/ApplicationCore.csproj
+++ b/application/shared-kernel/ApplicationCore/ApplicationCore.csproj
@@ -13,9 +13,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
         <PackageReference Include="Mapster"/>
         <PackageReference Include="MediatR" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+        <PackageReference Include="Microsoft.ApplicationInsights" />
     </ItemGroup>
 
 </Project>

--- a/application/shared-kernel/ApplicationCore/Behaviors/PublishAnalyticEventsPipelineBehavior.cs
+++ b/application/shared-kernel/ApplicationCore/Behaviors/PublishAnalyticEventsPipelineBehavior.cs
@@ -1,0 +1,29 @@
+using Microsoft.ApplicationInsights;
+using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
+using PlatformPlatform.SharedKernel.ApplicationCore.Tracking;
+
+namespace PlatformPlatform.SharedKernel.ApplicationCore.Behaviors;
+
+public sealed class PublishAnalyticEventsPipelineBehavior<TRequest, TResponse>(
+    IAnalyticEventsCollector analyticEventsCollector,
+    TelemetryClient telemetryClient
+)
+    : IPipelineBehavior<TRequest, TResponse> where TRequest : ICommand where TResponse : ResultBase
+{
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken
+    )
+    {
+        var result = await next();
+
+        while (analyticEventsCollector.HasEvents)
+        {
+            var analyticEvent = analyticEventsCollector.Dequeue();
+            telemetryClient.TrackEvent(analyticEvent.Name, analyticEvent.Properties);
+        }
+
+        return result;
+    }
+}

--- a/application/shared-kernel/ApplicationCore/Tracking/AnalyticEventCollector.cs
+++ b/application/shared-kernel/ApplicationCore/Tracking/AnalyticEventCollector.cs
@@ -1,0 +1,35 @@
+namespace PlatformPlatform.SharedKernel.ApplicationCore.Tracking;
+
+public interface IAnalyticEventsCollector
+{
+    bool HasEvents { get; }
+
+    void CollectEvent(string name, Dictionary<string, string>? properties = null);
+
+    AnalyticEvent Dequeue();
+}
+
+public class AnalyticEventsCollector : IAnalyticEventsCollector
+{
+    private readonly Queue<AnalyticEvent> _events = new();
+
+    public bool HasEvents => _events.Count > 0;
+
+    public void CollectEvent(string name, Dictionary<string, string>? properties = null)
+    {
+        var analyticEvent = new AnalyticEvent(name, properties);
+        _events.Enqueue(analyticEvent);
+    }
+
+    public AnalyticEvent Dequeue()
+    {
+        return _events.Dequeue();
+    }
+}
+
+public class AnalyticEvent(string name, Dictionary<string, string>? properties = null)
+{
+    public string Name { get; } = name;
+
+    public Dictionary<string, string>? Properties { get; } = properties;
+}

--- a/application/shared-kernel/Tests/ApplicationCore/Tracking/AnalyticEventsCollectorSpy.cs
+++ b/application/shared-kernel/Tests/ApplicationCore/Tracking/AnalyticEventsCollectorSpy.cs
@@ -1,0 +1,38 @@
+using PlatformPlatform.SharedKernel.ApplicationCore.Tracking;
+
+namespace PlatformPlatform.SharedKernel.Tests.ApplicationCore.Tracking;
+
+public class AnalyticEventsCollectorSpy(AnalyticEventsCollector realAnalyticEventsCollector) : IAnalyticEventsCollector
+{
+    private readonly List<AnalyticEvent> _collectedEvents = new();
+
+    public IReadOnlyList<AnalyticEvent> CollectedEvents => _collectedEvents;
+
+    public bool AreAllEventsDispatched { get; private set; }
+
+    public void CollectEvent(string name, Dictionary<string, string>? properties = null)
+    {
+        realAnalyticEventsCollector.CollectEvent(name, properties);
+        _collectedEvents.Add(new AnalyticEvent(name, properties));
+    }
+
+    public bool HasEvents => realAnalyticEventsCollector.HasEvents;
+
+    public AnalyticEvent Dequeue()
+    {
+        var analyticEvent = realAnalyticEventsCollector.Dequeue();
+        AreAllEventsDispatched = !realAnalyticEventsCollector.HasEvents;
+        return analyticEvent;
+    }
+
+    public void Reset()
+    {
+        while (realAnalyticEventsCollector.HasEvents)
+        {
+            realAnalyticEventsCollector.Dequeue();
+        }
+
+        _collectedEvents.Clear();
+        AreAllEventsDispatched = false;
+    }
+}


### PR DESCRIPTION
### Summary & Motivation

Configure Application Insights to track requests, exceptions, dependencies, traces, and custom events. To align with Application Insights' shift towards OpenTelemetry, the OpenTelemetry SDK is utilized for collecting all supported telemetry types (requests, exceptions, dependencies, and traces). However, for custom events, the traditional Microsoft.ApplicationInsights SDK is employed.

Custom events, termed "analytics events" to distinguish them from DDD Domain and Integration Events, are crucial for tracking specific feature usages for business insights. These events are not to be tracked until after an operation is successfully completed. For instance, `TenantCreated` and `UserCreated` events should only be logged in Application Insights once these entities are securely saved to the Database.

To coordinate this, a new `AnalyticsEventCollector` class is introduced to aggregate all events. Additionally, a MediatR pipeline is implemented to send these events to Application Insights *after* the UnitOfWork completes. If the UnitOfWork fails, no events are tracked. While there's a theoretical possibility of tracking failure, this risk is considered acceptable.

All CQRS commands have been extended to track analytics events. Events are named in past tense like `TenantCreated`, `TenantUpdated`, `TenantDeleted`, `UserCreated`, `UserUpdated`, and `UserDeleted`.

For testing, an `AnalyticEventsCollectorSpy` test double class has been created, and assertions have been added to all tests to ensure that the correct events are tracked. For the few Application layer tests, the assertions are also verifying that the correct event properties are tracked (e.g., `Tenant_Id` and `Event_TenantState`).

Change Version generator to yyyy.m.d.HMM format using hour and minutes instead of GitHub run number. This fixes a problem with the application workflow failing when day and month was below 10 and had invalid 0 prefix. E.g `2024.4.5.830` instead of `2024.04.05.0830`.

Change the Version generator to use the `yyyy.m.d.HMM` format (e.g. `2023.12.5.932`), incorporating hours and minutes instead of the GitHub run number. This change addresses an issue where the application workflow would fail due to an invalid prefix in dates with days and months below 10.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
