### PR TITLE
Change CLI to use System.CommandLine package and add first command for JetBrains code inspection

### DIFF
--- a/application/dotnet-tools.json
+++ b/application/dotnet-tools.json
@@ -11,7 +11,7 @@
       "commands": ["dotnet-dotcover"]
     },
     "jetbrains.resharper.globaltools": {
-      "version": "2023.3.0-eap08",
+      "version": "2023.3.0",
       "commands": ["jb"]
     },
     "swashbuckle.aspnetcore.cli": {

--- a/developer-cli/Commands/JetBrainsCodeInspections.cs
+++ b/developer-cli/Commands/JetBrainsCodeInspections.cs
@@ -1,0 +1,40 @@
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using PlatformPlatform.DeveloperCli.Installation;
+using PlatformPlatform.DeveloperCli.Utilities;
+using Spectre.Console;
+
+namespace PlatformPlatform.DeveloperCli.Commands;
+
+public class JetBrainsCodeInspections : Command
+{
+    public JetBrainsCodeInspections() :
+        base("jetbrains-code-inspections", "Run JetBrains Code Inspections")
+    {
+        Handler = CommandHandler.Create(new Func<int>(Execute));
+    }
+
+    private int Execute()
+    {
+        var workingDirectory = Path.Combine(AliasRegistration.SolutionFolder, "..", "application");
+
+        ProcessHelpers.StartProcess("dotnet", "tool restore", workingDirectory);
+        ProcessHelpers.StartProcess(
+            "dotnet",
+            "jb inspectcode PlatformPlatform.sln --build --output=result.xml --severity=SUGGESTION",
+            workingDirectory
+        );
+
+        var resultXml = File.ReadAllText(Path.Combine(workingDirectory, "result.xml"));
+        if (resultXml.Contains("<Issues />"))
+        {
+            AnsiConsole.MarkupLine("[green]No issues found![/]");
+        }
+        else
+        {
+            ProcessHelpers.StartProcess("code", "result.xml", workingDirectory);
+        }
+
+        return 0;
+    }
+}

--- a/developer-cli/DeveloperCli.csproj
+++ b/developer-cli/DeveloperCli.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <AssemblyName>PlatformPlatform.DeveloperCli</AssemblyName>
+        <AssemblyName>pp</AssemblyName>
         <RootNamespace>PlatformPlatform.DeveloperCli</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/developer-cli/DeveloperCli.csproj
+++ b/developer-cli/DeveloperCli.csproj
@@ -11,6 +11,8 @@
 
     <ItemGroup>
         <PackageReference Include="Spectre.Console" Version="0.48.0"/>
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
+        <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/developer-cli/Installation/AliasRegistration.cs
+++ b/developer-cli/Installation/AliasRegistration.cs
@@ -7,9 +7,9 @@ public static class AliasRegistration
 {
     private const string Intro =
         """
-        To get the full benefit of PlatformPlatform, you can register a command-line alias for this CLI tool.
-        This will allow you to run PlatformPlatform commands from anywhere on your machine.
-        The alias defaults to [bold][grey]pp[/][/], but if you have multiple projects, you can customize it to something else.
+        [green]Welcome to:[/]
+        To get the full benefit of PlatformPlatform, allow this tool to register an alias on your machine.
+        This will allow you to run PlatformPlatform commands from anywhere on your machine by typing [green]pp[/].
 
         [green]The CLI can be used to:[/]
         * Set up secure passwordless continuous deployments between GitHub and Azure
@@ -43,38 +43,18 @@ public static class AliasRegistration
     {
         if (IsAliasRegistered()) return;
 
-        var figletText = new FigletText("PlatformPlatform")
-            .Color(Color.Green)
-            .Centered();
+        var figletText = new FigletText("PlatformPlatform").Color(Color.Green);
+        AnsiConsole.Write(figletText);
+        AnsiConsole.Write(new Markup(Intro));
+        AnsiConsole.WriteLine();
+        if (AnsiConsole.Confirm("This will register the alias [green]pp[/], so it will be available everywhere."))
+        {
+            AnsiConsole.WriteLine();
 
-        AnsiConsole.Write(new Panel(figletText)
-            .Expand()
-            .SquareBorder()
-            .BorderColor(Color.Green)
-            .Padding(1, 1, 1, 1)
-            .Header("[bold green] Welcome to... [/]")
-        );
+            RegisterAlias("pp");
+        }
 
-        AnsiConsole.Write(new Panel(new Markup(Intro).Centered())
-            .Expand()
-            .SquareBorder()
-            .BorderColor(Color.Green)
-            .Padding(1, 1, 1, 1)
-        );
-
-        var aliasName = AnsiConsole.Prompt(
-            new TextPrompt<string>("Enter the command line alias you want to use for calling this CLI tool:")
-                .PromptStyle("green")
-                .DefaultValue("pp")
-                .Validate(result => result.Length >= 2 && result.All(char.IsLetter)
-                    ? ValidationResult.Success()
-                    : ValidationResult.Error("The alias must be at least two characters and only contain letters."))
-                .AllowEmpty()
-        );
-
-        RegisterAlias(aliasName);
-
-        // Kill the current process 
+        // Kill the current process
         Environment.Exit(0);
     }
 
@@ -89,10 +69,12 @@ public static class AliasRegistration
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             AnsiConsole.MarkupLine("[red]Windows is not supported yet[/]");
+            Environment.Exit(0);
             return false;
         }
 
         AnsiConsole.MarkupLine($"[red]Your OS [bold]{Environment.OSVersion.Platform}[/] is not supported.[/]");
+        Environment.Exit(0);
         return false;
     }
 
@@ -143,15 +125,6 @@ public static class AliasRegistration
                 return;
             }
 
-            var lines = File.ReadAllLines(shellInfo.ProfilePath);
-            if (lines.Any(line => line.Contains($"alias {aliasName}=")))
-            {
-                AnsiConsole.MarkupLine(
-                    $"Alias [red]{aliasName}[/] already exist in [red]{shellInfo.ProfileName}[/].");
-                return;
-            }
-
-            AnsiConsole.MarkupLine($"Registering alias [green]{aliasName}[/] in [green]{shellInfo.ProfileName}[/].");
             File.AppendAllText(shellInfo.ProfilePath, $"alias {aliasName}='{cliExecutable}'{Environment.NewLine}");
             AnsiConsole.MarkupLine($"Please restart your terminal or run [green]source ~/{shellInfo.ProfileName}[/]");
         }

--- a/developer-cli/Installation/PrerequisitesChecker.cs
+++ b/developer-cli/Installation/PrerequisitesChecker.cs
@@ -15,7 +15,7 @@ public static class PrerequisitesChecker
         }
 
         var checkAzureCli = CheckCommandLineTool("az", successMessage: "Your CLI is up-to-date.");
-        var checkBun = CheckCommandLineTool("bun", new Version(1, 0), null);
+        var checkBun = CheckCommandLineTool("bun", new Version(1, 0));
 
         if (checkAzureCli == false || checkBun == false)
         {
@@ -54,9 +54,9 @@ public static class PrerequisitesChecker
             UseShellExecute = false,
             CreateNoWindow = true
         });
-        
+
         var output = process!.StandardOutput.ReadToEnd();
-        
+
         // Check if the version is greater than the minimum required version
         if (minVersion is not null)
         {
@@ -67,7 +67,7 @@ public static class PrerequisitesChecker
                 return false;
             }
         }
-        
+
         // Some tools don't have the version easily readable in the output, so we check for a special success message
         if (successMessage is not null && !output.Contains(successMessage))
         {

--- a/developer-cli/README.md
+++ b/developer-cli/README.md
@@ -1,6 +1,7 @@
 ## Developer CLI
 
-PlatformPlatform comes with a command line interface (CLI) to get up and running and help you with daily tasks. The CLI is a .NET console application that can be run on Windows and macOS.
+PlatformPlatform comes with a command line interface (CLI) to get up and running and help you with daily tasks. The CLI
+is a .NET console application that can be run on Windows and macOS.
 
 ### Installation
 
@@ -10,14 +11,17 @@ Just run the following command to install the CLI:
 dotnet run
 ```
 
-This will show a prompt to register an alias for the CLI. The default is `pp`, but you can choose any alias you like. After that, the CLI is ready to use.
+This will register `pp` as an alias for the CLI. That you can call from anywhere on your system.
 
 ![PlatformPlatform CLI](https://platformplatformgithub.blob.core.windows.net/$root/PlatformPlatformCli.png)
 
 ## Self updating
 
-Since the CLI is compiled from source, it can update itself. When you run the CLI, it will detect any changes in the source code and compile itself. This means that you will always have the latest version of the CLI, and you don't have to inform teammates to update the CLI. This is awesome for teams to share new improvements to the CLI.
+Since the CLI is compiled from source, it can update itself. When you run the CLI, it will detect any changes in the
+source code and compile itself. This means that you will always have the latest version of the CLI, and you don't have
+to inform teammates to update the CLI. This is awesome for teams to share new improvements to the CLI.
 
 ## Prerequisites
 
-The CLI will check for the Prerequisites described in the [main README](../README.md) and will prompt you to install them if they are not installed or not up to date.
+The CLI will check for the Prerequisites described in the [main README](../README.md) and will prompt you to install
+them if they are not installed or not up to date.

--- a/developer-cli/Utilities/ProcessHelpers.cs
+++ b/developer-cli/Utilities/ProcessHelpers.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics;
+using Spectre.Console;
+
+namespace PlatformPlatform.DeveloperCli.Utilities;
+
+public static class ProcessHelpers
+{
+    public static void StartProcess(string command, string arguments, string workingDirectory)
+    {
+        AnsiConsole.MarkupLine($"[cyan]{command} {arguments}[/]");
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = command,
+                Arguments = arguments,
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = false
+            }
+        };
+
+        process.OutputDataReceived += (_, e) => { Console.WriteLine(e.Data); };
+        process.ErrorDataReceived += (_, e) => { Console.WriteLine(e.Data); };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.WaitForExit();
+    }
+}


### PR DESCRIPTION
### Summary & Motivation

Update the Developer CLI to use the System.CommandLine library, enhancing its capabilities with commonly required features for command-line applications like parsing command-line input and displaying help text.

Remove the option to have aliases configurable, and hardcode `pp`. This alias can be easily modified directly in the code if needed.

Add the first command enabling the execution of JetBrains code inspections, running `dotnet jb inspectcode PlatformPlatform.sln --build --output=result.xml --severity=SUGGESTION`. Open `results.xml` in VS Code if any issues are found.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
