### PR TITLE
Upgrade .NET Aspire to preview 2 and upgrade NuGet packages

### DIFF
--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -6,7 +6,7 @@
     <AspNetCoreVersion>8.0.0</AspNetCoreVersion>
     <EfCoreVersion>8.0.0</EfCoreVersion>
     <RuntimeVersion>8.0.0</RuntimeVersion>
-    <AspireVersion>8.0.0-preview.1.23557.2</AspireVersion>
+    <AspireVersion>8.0.0-preview.2.23619.3</AspireVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- PlatformPlatform dependencies - Api -->

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -10,11 +10,11 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- PlatformPlatform dependencies - Api -->
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EfCoreVersion)" />
     <!-- PlatformPlatform dependencies - Application -->
-    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageVersion Include="Mapster" Version="7.4.0" />
     <PackageVersion Include="MediatR" Version="12.2.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.1" />

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -70,21 +70,21 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(RuntimeVersion)" />
     <!-- Open Telemetry -->
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0-beta.8" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0-alpha.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-alpha.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0-alpha.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EventCounters" Version="1.5.1-alpha.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.7" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />
     <!-- VS Test -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <!-- Miscellaneous -->
-    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="7.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="8.0.0" />
     <PackageVersion Include="Dapr.AspNetCore" Version="1.12.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageVersion Include="Yarp.ReverseProxy" Version="2.1.0-preview.1.23556.5" />
+    <PackageVersion Include="Yarp.ReverseProxy" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EfCoreVersion)" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />
     <!-- PlatformPlatform dependencies - Tests -->
-    <PackageVersion Include="Bogus" Version="34.0.2" />
+    <PackageVersion Include="Bogus" Version="35.0.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Meziantou.Xunit.ParallelTestFramework" Version="2.1.0" />
@@ -37,8 +37,8 @@
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="NJsonSchema" Version="10.9.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="xunit" Version="2.6.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageVersion Include="xunit" Version="2.6.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>
   <ItemGroup>
     <!-- Version together with Aspire -->

--- a/developer-cli/Installation/PrerequisitesChecker.cs
+++ b/developer-cli/Installation/PrerequisitesChecker.cs
@@ -12,7 +12,7 @@ public static class PrerequisitesChecker
         var checkAzureCli = CheckCommandLineTool("az", new Version(2, 55));
         var checkBun = CheckCommandLineTool("bun", new Version(1, 0));
         var docker = CheckCommandLineTool("docker", new Version(24, 0));
-        var aspire = CheckDotnetWorkload("aspire", """aspire\s*8\.0\.0-preview."""); // aspire 8.0.0-preview.1.23557
+        var aspire = CheckDotnetWorkload("aspire", """aspire\s*8\.0\.0-preview.2"""); // aspire 8.0.0-preview.2.23619.3
 
         if (!checkAzureCli || !checkBun || !docker || !aspire)
         {
@@ -98,8 +98,9 @@ public static class PrerequisitesChecker
 
         if (!output.Contains(workloadName))
         {
+            AnsiConsole.MarkupLine($"[red].NET '[bold]{workloadName}[/]' workload is not installed.[/]");
             AnsiConsole.MarkupLine(
-                $"[red].NET '[bold]{workloadName}[/]' workload is not installed. Please run '[bold]dotnet workload install {workloadName}[/]' to install.[/]");
+                $"[red]Please run '[bold]dotnet workload update[/]' and then '[bold]dotnet workload install {workloadName}[/]'.");
             return false;
         }
 
@@ -108,7 +109,7 @@ public static class PrerequisitesChecker
 
            Installed Workload Id      Manifest Version                     Installation Source
            -----------------------------------------------------------------------------------
-           aspire                     8.0.0-preview.1.23557.2/8.0.100      SDK 8.0.100
+           aspire                     8.0.0-preview.2.23619.3/8.0.100      SDK 8.0.100
 
            Use `dotnet workload search` to find additional workloads to install.
          */
@@ -118,7 +119,8 @@ public static class PrerequisitesChecker
         {
             // If the version could not be determined please change the logic here to check for the correct version
             AnsiConsole.MarkupLine(
-                $"[red]Dotnet '[bold]{workloadName}[/]' workload is installed but not in the expected version. Please upgrade the workflow or update the CLI to check for correct version.[/]");
+                $"[red].NET '[bold]{workloadName}[/]' workload is installed but not in the expected version.[/]");
+            AnsiConsole.MarkupLine("[red]Please run '[bold]dotnet workload update[/]'.[/]");
         }
 
         return match.Success;


### PR DESCRIPTION
### Summary & Motivation

Update .NET Aspire to preview 2. Update the CLI tool prerequisites checker to show a warning if the incorrect Aspire version is installed.

Simultaneously, update all NuGet packages to the latest version. This includes OpenTelemetry, ASP.NET HealthChecks, and Yarp.ReverseProxy used in .NET Aspire, as well as an upgrade to Application Insights NuGet packages and xUnit and Bogus NuGet packages used for testing.

Refine the change detection in the Developer CLI to solely evaluate files that are part of the Git repository. This avoids triggering changes if, for example, Rider configurations are changed.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
