### PR TITLE
Update vs code github extension branch naming

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,7 @@
   },
   "files.associations": {
     "*.css": "tailwindcss"
-  }
+  },
+  "githubIssues.issueBranchTitle": "${issueNumber}-${sanitizedIssueTitle}",
+  "githubPullRequests.assignCreated": "${user}"
 }


### PR DESCRIPTION
### Summary & Motivation

When using the VS Code Github extension workflows to start working on issues the branch name was formatted:
```js
"${user}/issue-${issueNumber}"
```

When using github.com to create a branch the name was formatted:
```js
"${issueNumber}-${sanitizedIssueTitle}"
```

This pr aligns the GitHub extension with github.com

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
