### PR TITLE
Convert branch naming in GitHub VS Code extension to lowercase

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,6 @@
   "files.associations": {
     "*.css": "tailwindcss"
   },
-  "githubIssues.issueBranchTitle": "${issueNumber}-${sanitizedIssueTitle}",
+  "githubIssues.issueBranchTitle": "${issueNumber}-${sanitizedLowercaseIssueTitle}",
   "githubPullRequests.assignCreated": "${user}"
 }


### PR DESCRIPTION
### Summary & Motivation

Modify the VS Code GitHub extensions configuration to create branch names in lowercase. This aligns with GitHub's default naming convention of `{issue number}-{issue-title-in-lower-case-spinal}` when branches are created from the issue page on github.com.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
