### PR TITLE
Enable support for proxy headers

### DIFF
--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -3,6 +3,7 @@ using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Json;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -77,6 +78,12 @@ public static class ApiCoreConfiguration
         where TDbContext : DbContext
     {
         app.MapDefaultEndpoints();
+
+        app.UseForwardedHeaders(new ForwardedHeadersOptions
+        {
+            // Enable support for proxy headers such as X-Forwarded-For and X-Forwarded-Proto
+            ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+        });
 
         // Enable Swagger UI
         app.UseSwagger();


### PR DESCRIPTION
### Summary & Motivation

Our service is served behind a proxy both locally and in the cloud. We need to enable support for for proxy headers such as X-Forwarded-For and X-Forwarded-Proto to resolve the request client ip correctly.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
