### PR TITLE
Exclude tracking of live metrics health and track endpoints

### DIFF
--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -39,6 +39,7 @@ public static class ApiCoreConfiguration
         };
 
         services.AddApplicationInsightsTelemetry(applicationInsightsServiceOptions);
+        services.AddApplicationInsightsTelemetryProcessor<EndpointTelemetryFilter>();
 
         services.AddSwaggerGen(c =>
         {

--- a/application/shared-kernel/ApiCore/Filters/EndpointTelemetryFilter.cs
+++ b/application/shared-kernel/ApiCore/Filters/EndpointTelemetryFilter.cs
@@ -1,0 +1,29 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace PlatformPlatform.SharedKernel.ApiCore.Filters;
+
+/// <summary>
+///     Filter out telemetry from requests matching excluded paths
+/// </summary>
+[UsedImplicitly]
+public class EndpointTelemetryFilter(ITelemetryProcessor telemetryProcessor) : ITelemetryProcessor
+{
+    private readonly string[] _excludedPaths = { "/swagger", "/health", "/alive", "/track" };
+
+    public void Process(ITelemetry item)
+    {
+        if (item is RequestTelemetry requestTelemetry && IsExcludedPath(requestTelemetry))
+        {
+            return;
+        }
+
+        telemetryProcessor.Process(item);
+    }
+
+    private bool IsExcludedPath(RequestTelemetry requestTelemetry)
+    {
+        return Array.Exists(_excludedPaths, excludePath => requestTelemetry.Url.AbsolutePath.StartsWith(excludePath));
+    }
+}

--- a/application/shared-kernel/ApiCore/Filters/EndpointTelemetryFilter.cs
+++ b/application/shared-kernel/ApiCore/Filters/EndpointTelemetryFilter.cs
@@ -10,7 +10,7 @@ namespace PlatformPlatform.SharedKernel.ApiCore.Filters;
 [UsedImplicitly]
 public class EndpointTelemetryFilter(ITelemetryProcessor telemetryProcessor) : ITelemetryProcessor
 {
-    private readonly string[] _excludedPaths = { "/swagger", "/health", "/alive", "/track" };
+    private readonly string[] _excludedPaths = { "/swagger", "/health", "/alive", "/api/track" };
 
     public void Process(ITelemetry item)
     {


### PR DESCRIPTION
### Summary & Motivation

We don't want to track calls for internal infrastructure endpoints. This pr adds an Endpoint Telemetry Filter

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
