### PR TITLE
Add client ip in OpenTelemetry tracking

### DIFF
--- a/application/shared-kernel/ApiCore/Aspire/ServiceDefaultsExtensions.cs
+++ b/application/shared-kernel/ApiCore/Aspire/ServiceDefaultsExtensions.cs
@@ -47,6 +47,14 @@ public static class ServiceDefaultsExtensions
                 var requestPath = httpContext.Request.Path.ToString();
                 return !Array.Exists(excludedPaths, requestPath.StartsWith);
             };
+
+            options.EnrichWithHttpRequest = (activity, request) =>
+            {
+                var context = request.HttpContext;
+
+                // Add the client IP address to the trace
+                activity.AddTag(SemanticConventions.AttributeHttpClientIp, context.Connection.RemoteIpAddress);
+            };
         });
 
         builder.Logging.AddOpenTelemetry(logging =>
@@ -119,5 +127,15 @@ public static class ServiceDefaultsExtensions
         app.MapHealthChecks("/alive", new HealthCheckOptions { Predicate = r => r.Tags.Contains("live") });
 
         return app;
+    }
+
+    /// <summary>
+    ///     Constants for semantic attribute names outlined by the OpenTelemetry specifications.
+    ///     <see
+    ///         href="https://github.com/open-telemetry/opentelemetry-dotnet/blob/d0620e6f0f24bc4aa89143aaeddfac7a4fffb2aa/src/Shared/SemanticConventions.cs" />
+    /// </summary>
+    private static class SemanticConventions
+    {
+        public const string AttributeHttpClientIp = "http.client_ip";
     }
 }


### PR DESCRIPTION
### Summary & Motivation

Enrich OpenTelemetry data adding Client IP for user location

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
