### PR TITLE
Configure AntiForgery in WebApp

### DIFF
--- a/application/account-management/WebApp/global.d.ts
+++ b/application/account-management/WebApp/global.d.ts
@@ -16,6 +16,8 @@ export declare global {
     APPLICATION_VERSION: string;
     /* User locale */
     LOCALE: string;
+    /* AntiForgery token */
+    XSRF_TOKEN: string;
   }
 
   /**

--- a/application/account-management/WebApp/src/lib/api/client.ts
+++ b/application/account-management/WebApp/src/lib/api/client.ts
@@ -2,4 +2,4 @@ import createClient from "openapi-fetch";
 import type { paths } from "./api.generated";
 
 const baseUrl = import.meta.env.PUBLIC_URL;
-export const accountManagementApi = createClient<paths>({ baseUrl });
+export const accountManagementApi = createClient<paths>({ baseUrl, headers: { "X-XSRF-TOKEN": import.meta.env.XSRF_TOKEN } });

--- a/application/account-management/WebApp/src/ui/AntiForgeryToken.tsx
+++ b/application/account-management/WebApp/src/ui/AntiForgeryToken.tsx
@@ -1,0 +1,8 @@
+/**
+ * AntiForgeryToken Hidden Form Element
+ */
+export function AntiForgeryToken() {
+  return (
+    <input type="hidden" name="__RequestVerificationToken" value={import.meta.env.XSRF_TOKEN} />
+  );
+}

--- a/application/account-management/WebApp/src/ui/AntiForgeryToken.tsx
+++ b/application/account-management/WebApp/src/ui/AntiForgeryToken.tsx
@@ -1,8 +1,0 @@
-/**
- * AntiForgeryToken Hidden Form Element
- */
-export function AntiForgeryToken() {
-  return (
-    <input type="hidden" name="__RequestVerificationToken" value={import.meta.env.XSRF_TOKEN} />
-  );
-}

--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -74,6 +74,13 @@ public static class ApiCoreConfiguration
             options.KnownProxies.Clear();
         });
 
+        // Enable support for CSRF tokens and configure the header and form field names
+        services.AddAntiforgery(options =>
+        {
+            options.HeaderName = "X-XSRF-TOKEN";
+            options.FormFieldName = "__RequestVerificationToken";
+        });
+
         builder.AddServiceDefaults();
 
         if (builder.Environment.IsDevelopment())
@@ -134,6 +141,9 @@ public static class ApiCoreConfiguration
         app.MapTestEndpoints();
 
         app.Services.ApplyMigrations<TDbContext>();
+
+        // Enable support for CSRF tokens
+        app.UseAntiforgery();
 
         return app;
     }

--- a/application/shared-kernel/ApiCore/Endpoints/TrackEndpoints.cs
+++ b/application/shared-kernel/ApiCore/Endpoints/TrackEndpoints.cs
@@ -20,7 +20,7 @@ public static class TrackEndpoints
     // </summary>
     public static void MapTrackEndpoints(this IEndpointRouteBuilder routes)
     {
-        routes.MapPost("/api/track", Track);
+        routes.MapPost("/api/track", Track).DisableAntiforgery();
     }
 
     [OpenApiIgnore]


### PR DESCRIPTION
### Summary & Motivation

We want to prevent cross-site request forgery (XSRF/CSRF) attacks.

This pull-request adds token exchange via runtime environment allowing the api client to send the token in headers.

We also add and configure the anti forgery middleware.

### Checklist

- [x] I have added a Label to the pull-request
- [ ] I have added tests, and done manual regression tests
- [ ] I have updated the documentation, if necessary
