### PR TITLE
Use Aspire's AddSqlServerDbContext in order to set up the DbContext a…

### DIFF
--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -3,14 +3,14 @@ using Projects;
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sqlServerPassword = Environment.GetEnvironmentVariable("SQL_SERVER_PASSWORD");
-var database = builder.AddSqlServerContainer("Default", sqlServerPassword)
+var database = builder.AddSqlServerContainer("account-management-db", sqlServerPassword)
     .WithVolumeMount("sql-server-data", "/var/opt/mssql", VolumeMountType.Named)
     .AddDatabase("account-management");
 
 var accountManagementApi = builder.AddProject<PlatformPlatform_AccountManagement_Api>("account-management-api")
     .WithReference(database);
 
-builder.AddNpmApp("frontend", "../account-management/WebApp", "dev")
+builder.AddNpmApp("account-management-spa", "../account-management/WebApp", "dev")
     .WithReference(accountManagementApi);
 
 builder.Build().Run();

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -3,7 +3,7 @@ using Projects;
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sqlServerPassword = Environment.GetEnvironmentVariable("SQL_SERVER_PASSWORD");
-var database = builder.AddSqlServerContainer("Default", sqlServerPassword, 1433)
+var database = builder.AddSqlServerContainer("Default", sqlServerPassword)
     .WithVolumeMount("sql-server-data", "/var/opt/mssql", VolumeMountType.Named)
     .AddDatabase("account-management");
 

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- PlatformPlatform dependencies - Api -->
+    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-preview.2.23619.3" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EfCoreVersion)" />

--- a/application/account-management/Api/Program.cs
+++ b/application/account-management/Api/Program.cs
@@ -11,7 +11,8 @@ var builder = WebApplication.CreateBuilder(args);
 // FluentValidation validators, Pipelines.
 builder.Services
     .AddApplicationServices()
-    .AddInfrastructureServices(builder.Configuration)
+    .AddDatabaseContext(builder)
+    .AddInfrastructureServices()
     .AddApiCoreServices(builder);
 
 var app = builder.Build();

--- a/application/account-management/Api/appsettings.development.json
+++ b/application/account-management/Api/appsettings.development.json
@@ -5,8 +5,5 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Information"
     }
-  },
-  "ConnectionStrings": {
-    "Default": "Server=${SQL_SERVER_NAME};Database=account-management;User Id=sa;Password=${SQL_SERVER_PASSWORD};Encrypt=False;TrustServerCertificate=True"
   }
 }

--- a/application/account-management/Infrastructure/InfrastructureConfiguration.cs
+++ b/application/account-management/Infrastructure/InfrastructureConfiguration.cs
@@ -1,5 +1,5 @@
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using PlatformPlatform.SharedKernel.InfrastructureCore;
 
 namespace PlatformPlatform.AccountManagement.Infrastructure;
@@ -8,12 +8,20 @@ public static class InfrastructureConfiguration
 {
     public static Assembly Assembly => Assembly.GetExecutingAssembly();
 
-    public static IServiceCollection AddInfrastructureServices(
+
+    public static IServiceCollection AddDatabaseContext(
         this IServiceCollection services,
-        IConfiguration configuration
+        IHostApplicationBuilder builder
     )
     {
-        services.ConfigureInfrastructureCoreServices<AccountManagementDbContext>(configuration, Assembly);
+        services.ConfigureDatabaseContext<AccountManagementDbContext>(builder, "account-management");
+
+        return services;
+    }
+
+    public static IServiceCollection AddInfrastructureServices(this IServiceCollection services)
+    {
+        services.ConfigureInfrastructureCoreServices<AccountManagementDbContext>(Assembly);
 
         return services;
     }

--- a/application/account-management/Tests/BaseTest.cs
+++ b/application/account-management/Tests/BaseTest.cs
@@ -6,7 +6,6 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -42,10 +41,9 @@ public abstract class BaseTest<TContext> : IDisposable where TContext : DbContex
         Connection.Open();
         Services.AddDbContext<TContext>(options => { options.UseSqlite(Connection); });
 
-        var configuration = new ConfigurationBuilder().AddEnvironmentVariables().Build();
         Services
             .AddApplicationServices()
-            .AddInfrastructureServices(configuration);
+            .AddInfrastructureServices();
 
         TelemetryEventsCollectorSpy = new TelemetryEventsCollectorSpy(new TelemetryEventsCollector());
         Services.AddScoped<ITelemetryEventsCollector>(_ => TelemetryEventsCollectorSpy);

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
@@ -14,6 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -1,8 +1,8 @@
 using System.Net.Sockets;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using PlatformPlatform.SharedKernel.DomainCore.DomainEvents;
 using PlatformPlatform.SharedKernel.DomainCore.Persistence;
 using PlatformPlatform.SharedKernel.InfrastructureCore.Persistence;
@@ -11,75 +11,35 @@ namespace PlatformPlatform.SharedKernel.InfrastructureCore;
 
 public static class InfrastructureCoreConfiguration
 {
-    private static string? _cachedConnectionString;
-
     public static readonly bool SwaggerGenerator = Environment.GetEnvironmentVariable("SWAGGER_GENERATOR") == "true";
+
+    [UsedImplicitly]
+    public static IServiceCollection ConfigureDatabaseContext<T>(
+        this IServiceCollection services,
+        IHostApplicationBuilder builder,
+        string connectionName
+    ) where T : DbContext
+    {
+        builder.AddSqlServerDbContext<T>(connectionName, static settings => settings.DbContextPooling = false);
+
+        return services;
+    }
 
     [UsedImplicitly]
     public static IServiceCollection ConfigureInfrastructureCoreServices<T>(
         this IServiceCollection services,
-        IConfiguration configuration,
         Assembly assembly
     ) where T : DbContext
     {
-        services.ConfigureDatabaseContext<T>(configuration);
+        services.AddScoped<IUnitOfWork, UnitOfWork>(provider => new UnitOfWork(provider.GetRequiredService<T>()));
+        services.AddScoped<IDomainEventCollector, DomainEventCollector>(provider =>
+            new DomainEventCollector(provider.GetRequiredService<T>()));
 
         services.RegisterRepositories(assembly);
 
         return services;
     }
 
-    [UsedImplicitly]
-    private static IServiceCollection ConfigureDatabaseContext<T>(
-        this IServiceCollection services,
-        IConfiguration configuration
-    ) where T : DbContext
-    {
-        services.AddDbContext<T>((_, options) => options.UseSqlServer(GetConnectionString(configuration)));
-
-        services.AddScoped<IUnitOfWork, UnitOfWork>(provider => new UnitOfWork(provider.GetRequiredService<T>()));
-        services.AddScoped<IDomainEventCollector, DomainEventCollector>(provider =>
-            new DomainEventCollector(provider.GetRequiredService<T>()));
-
-        return services;
-    }
-
-    private static string GetConnectionString(IConfiguration configuration)
-    {
-        if (_cachedConnectionString is not null) return _cachedConnectionString;
-
-        var serverName = Environment.GetEnvironmentVariable("AZURE_SQL_SERVER_NAME");
-        var databaseName = Environment.GetEnvironmentVariable("AZURE_SQL_DATABASE_NAME");
-        var managedIdentityId = Environment.GetEnvironmentVariable("MANAGED_IDENTITY_CLIENT_ID");
-
-        var isRunningInAzure = serverName is not null && databaseName is not null && managedIdentityId is not null;
-        if (isRunningInAzure)
-        {
-            _cachedConnectionString = $"""
-                                       Server=tcp:{serverName}.database.windows.net,1433;
-                                       Initial Catalog={databaseName};
-                                       User Id={managedIdentityId};
-                                       Authentication=Active Directory Default;TrustServerCertificate=True;
-                                       """;
-        }
-        else
-        {
-            var connectionString = configuration.GetConnectionString("Default")
-                                   ?? throw new InvalidOperationException("Missing ConnectionString configuration.");
-
-            var password = Environment.GetEnvironmentVariable("SQL_SERVER_PASSWORD")
-                           ?? throw new InvalidOperationException("Missing SQL_SERVER_PASSWORD environment variable.");
-
-            // When running in Docker (on localhost) the SQL Sever name is configured in the docker-compose.yml
-            var sqlServerName = Environment.GetEnvironmentVariable("SQL_SERVER_NAME") ?? "localhost";
-
-            _cachedConnectionString = connectionString
-                .Replace("${SQL_SERVER_NAME}", sqlServerName)
-                .Replace("${SQL_SERVER_PASSWORD}", password);
-        }
-
-        return _cachedConnectionString;
-    }
 
     [UsedImplicitly]
     private static IServiceCollection RegisterRepositories(this IServiceCollection services, Assembly assembly)

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -102,16 +102,8 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
           }
           env: [
             {
-              name: 'AZURE_SQL_SERVER_NAME'
-              value: sqlServerName
-            }
-            {
-              name: 'AZURE_SQL_DATABASE_NAME'
-              value: sqlDatabaseName
-            }
-            {
-              name: 'MANAGED_IDENTITY_CLIENT_ID'
-              value: userAssignedIdentity.properties.clientId
+              name: 'ConnectionStrings__${sqlDatabaseName}'
+              value: 'Server=tcp:${sqlServerName}.${environment().sqlManagement},1433;Initial Catalog=${sqlDatabaseName};User Id=${userAssignedIdentity.properties.clientId};Authentication=Active Directory Default;TrustServerCertificate=True;'
             }
             {
               name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'


### PR DESCRIPTION
### Summary & Motivation

When working with local environment, Aspire will create the SQL database container on a unique port. We need to use Aspire in the areas where the connection string is generated and therefore we avoid setting up the connection string manually and we use Aspire's methods instead.

This pull request will also change the name of the applications as shown in the Aspire dashboard. The SQL database will be renamed to `account-management-db` and the frontend application will be renamed to `account-management-spa`.

The infrastructure has been updated to use the new connection string.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
