### PR TITLE
Refine the dynamic SQL Server connection string construction in Bicep

### DIFF
--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -103,7 +103,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
           env: [
             {
               name: 'ConnectionStrings__${sqlDatabaseName}'
-              value: 'Server=tcp:${sqlServerName}.${environment().sqlManagement},1433;Initial Catalog=${sqlDatabaseName};User Id=${userAssignedIdentity.properties.clientId};Authentication=Active Directory Default;TrustServerCertificate=True;'
+              value: 'Server=tcp:${sqlServerName}${environment().suffixes.sqlServerHostname},1433;Initial Catalog=${sqlDatabaseName};User Id=${userAssignedIdentity.properties.clientId};Authentication=Active Directory Default;TrustServerCertificate=True;'
             }
             {
               name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'


### PR DESCRIPTION
### Summary & Motivation

Modify the dynamic construction of the SQL Server connection string in Bicep. Replace the use of `environment().sqlManagement` with `environment().suffixes.sqlServerHostname`. This change ensures the connection string correctly uses `.database.windows.net`, aligning with standard SQL Server hostname conventions, instead of the previously returned `https://management.core.windows.net:8443/`.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
