### PR TITLE
:bug: bug fix for MSBUILD error MSB1008 when the publish folder contains space(s)

### DIFF
--- a/developer-cli/Installation/ChangeDetection.cs
+++ b/developer-cli/Installation/ChangeDetection.cs
@@ -72,7 +72,7 @@ public static class ChangeDetection
             }
 
             // Call "dotnet publish" to create a new executable
-            ProcessHelper.StartProcess($"dotnet publish DeveloperCli.csproj -o {Configuration.PublishFolder}",
+            ProcessHelper.StartProcess($"dotnet publish DeveloperCli.csproj -o \"{Configuration.PublishFolder}\"",
                 Configuration.GetSourceCodeFolder());
 
             var configurationSetting = Configuration.GetConfigurationSetting();


### PR DESCRIPTION
### Summary & Motivation

On Windows for publish folders containing space(s) (due to a user account name with space(s)), MSBuild will split the path using space and create multiple switches resulting in the build error MSB1008.

Example path: C:\Users\Martin Rosén-Lidholm\AppData\Local\PlatformPlatform

The fix is to put quotes around the path.

