### PR TITLE
Fix change detection in CLI when publish folder contains space

### DIFF
--- a/developer-cli/Installation/ChangeDetection.cs
+++ b/developer-cli/Installation/ChangeDetection.cs
@@ -72,7 +72,7 @@ public static class ChangeDetection
             }
 
             // Call "dotnet publish" to create a new executable
-            ProcessHelper.StartProcess($"dotnet publish DeveloperCli.csproj -o {Configuration.PublishFolder}",
+            ProcessHelper.StartProcess($"dotnet publish DeveloperCli.csproj -o \"{Configuration.PublishFolder}\"",
                 Configuration.GetSourceCodeFolder());
 
             var configurationSetting = Configuration.GetConfigurationSetting();


### PR DESCRIPTION
### Summary & Motivation

On Windows, the publish folder for the CLI may contain spaces (due to a user account name with spaces), MSBuild will split the path using space and create multiple switches, resulting in the build error MSB1008. Example path: C:\Users\Martin Rosén-Lidholm\AppData\Local\PlatformPlatform. The fix is to put quotes around the path.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary