### PR TITLE
Upgrade GitHub actions to latest versions for Node.js compatibility

### DIFF
--- a/.github/workflows/_publish-container.yml
+++ b/.github/workflows/_publish-container.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifacts_name }}
           path: ${{ inputs.artifacts_path }}
@@ -47,7 +47,7 @@ jobs:
         run: az acr login --name ${{ vars.CONTAINER_REGISTRY_NAME }}
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push container image
         working-directory: ${{ inputs.docker_context }}

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -27,7 +27,7 @@ jobs:
       version: ${{ steps.generate_version.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate version
         id: generate_version
@@ -47,7 +47,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 
@@ -62,7 +62,7 @@ jobs:
         run: dotnet restore
 
       - name: Setup-java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "microsoft"
           java-version: "17"
@@ -89,7 +89,7 @@ jobs:
           dotnet publish ./Api/Api.csproj --no-restore --configuration Release --output ./Api/publish --version-suffix ${{ steps.generate_version.outputs.version }}
 
       - name: Save Account Management artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: account-management
           path: application/account-management/Api/publish/**/*
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
@@ -111,7 +111,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/cloud-infrastructure.yml
+++ b/.github/workflows/cloud-infrastructure.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Bicep CLI
         run: |
@@ -78,7 +78,7 @@ jobs:
     environment: "shared" ## Force a manual approval
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Bicep CLI
         run: |
@@ -107,7 +107,7 @@ jobs:
     environment: "staging" ## Force a manual approval
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Bicep CLI
         run: |
@@ -167,7 +167,7 @@ jobs:
     environment: "production" ## Force a manual approval
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Bicep CLI
         run: |


### PR DESCRIPTION
### Summary & Motivation

All GitHub Actions used in the project are updated to their latest versions, a move primarily motivated by the deprecation of Node.js version 16. The updates include transitioning from:

- actions/checkout@v3 to actions/checkout@v4
- actions/download-artifact@v3 to actions/download-artifact@v4
- actions/upload-artifact@v3 to actions/upload-artifact@v4
- docker/setup-buildx-action@v2 to docker/setup-buildx-action@v3
- actions/setup-dotnet@v3 to actions/setup-dotnet@v4
- actions/setup-java@v3 to actions/setup-java@v4

However, azure/login@v1 remains unchanged as it awaits an update for Node.js 20 compatibility, as discussed in https://github.com/Azure/login/issues/357.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
