### PR TITLE
Specify a specific port for the SQL server container

### DIFF
--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -3,7 +3,7 @@ using Projects;
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sqlServerPassword = Environment.GetEnvironmentVariable("SQL_SERVER_PASSWORD");
-var database = builder.AddSqlServerContainer("account-management-db", sqlServerPassword)
+var database = builder.AddSqlServerContainer("account-management-db", sqlServerPassword, 8433)
     .WithVolumeMount("sql-server-data", "/var/opt/mssql", VolumeMountType.Named)
     .AddDatabase("account-management");
 


### PR DESCRIPTION
### Summary & Motivation

With this pull request, we specify the port of the SQL Server container, so that it becomes easier to query our database when we are outside of docker.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
