### PR TITLE
Fix dependencies between Azure Container App and Communication Services

### DIFF
--- a/cloud-infrastructure/cluster/deploy-cluster.sh
+++ b/cloud-infrastructure/cluster/deploy-cluster.sh
@@ -56,6 +56,7 @@ ACTIVE_ACCOUNT_MANAGEMENT_VERSION=$(get_active_version account-management)
 ACCOUNT_MANAGEMENT_DOMAIN_CONFIGURED=$(is_domain_configured "account-management" "$RESOURCE_GROUP_NAME")
 
 az extension add --name application-insights
+az extension add --name application-insights --allow-preview true
 APPLICATION_INSIGHTS_CONNECTION_STRING=$(az monitor app-insights component show --app $ENVIRONMENT-application-insights --resource-group $ENVIRONMENT --query connectionString --output tsv)
 
 DEPLOYMENT_COMMAND="az deployment sub create"

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -201,7 +201,7 @@ module accountManagement '../modules/container-app.bicep' = {
     applicationInsightsConnectionString: applicationInsightsConnectionString
     keyVaultName: keyVault.outputs.name
   }
-  dependsOn: [accountManagementDatabase]
+  dependsOn: [accountManagementDatabase, communicationService]
 }
 
 output accountManagementIdentityClientId string = accountManagementIdentity.outputs.clientId


### PR DESCRIPTION
### Summary & Motivation

Fix first-time deployment of Azure Container App when Azure Communication Services is not fully provisioned. The Container App attempts to read the email address for sending emails, which is not available.

Remove warning from az application-insights extension.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
