### PR TITLE
Create email signature service for both production and development

### DIFF
--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -13,4 +13,8 @@ var accountManagementApi = builder.AddProject<Api>("account-management-api")
 builder.AddNpmApp("account-management-spa", "../account-management/WebApp", "dev")
     .WithReference(accountManagementApi);
 
+builder.AddContainer("email-test-server", "mailhog/mailhog")
+    .WithEndpoint(hostPort: 8025, containerPort: 8025, scheme: "http")
+    .WithEndpoint(hostPort: 1025, containerPort: 1025);
+
 builder.Build().Run();

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -27,6 +27,8 @@
     <PackageVersion Include="NSwag.MSBuild" Version="14.0.3" />
     <PackageVersion Include="NUlid" Version="1.7.1" />
     <!-- PlatformPlatform dependencies - Infrastructure -->
+    <PackageVersion Include="Azure.Communication.Email" Version="1.0.1" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EfCoreVersion)" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />
     <!-- PlatformPlatform dependencies - Tests -->

--- a/application/shared-kernel/ApplicationCore/Services/IEmailService.cs
+++ b/application/shared-kernel/ApplicationCore/Services/IEmailService.cs
@@ -1,0 +1,7 @@
+namespace PlatformPlatform.SharedKernel.ApplicationCore.Services;
+
+public interface IEmailService
+{
+    [UsedImplicitly]
+    Task SendAsync(string recipient, string subject, string htmlContent, CancellationToken cancellationToken);
+}

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
@@ -15,6 +15,8 @@
 
     <ItemGroup>
         <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer"/>
+        <PackageReference Include="Azure.Communication.Email"/>
+        <PackageReference Include="Azure.Security.KeyVault.Secrets"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -3,9 +3,11 @@ using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using PlatformPlatform.SharedKernel.ApplicationCore.Services;
 using PlatformPlatform.SharedKernel.DomainCore.DomainEvents;
 using PlatformPlatform.SharedKernel.DomainCore.Persistence;
 using PlatformPlatform.SharedKernel.InfrastructureCore.Persistence;
+using PlatformPlatform.SharedKernel.InfrastructureCore.Services;
 
 namespace PlatformPlatform.SharedKernel.InfrastructureCore;
 
@@ -36,6 +38,8 @@ public static class InfrastructureCoreConfiguration
             new DomainEventCollector(provider.GetRequiredService<T>()));
 
         services.RegisterRepositories(assembly);
+
+        services.AddTransient<IEmailService, DevelopmentEmailService>();
 
         return services;
     }

--- a/application/shared-kernel/InfrastructureCore/Services/AzureEmailService.cs
+++ b/application/shared-kernel/InfrastructureCore/Services/AzureEmailService.cs
@@ -1,0 +1,27 @@
+using Azure;
+using Azure.Communication.Email;
+using Azure.Security.KeyVault.Secrets;
+using PlatformPlatform.SharedKernel.ApplicationCore.Services;
+
+namespace PlatformPlatform.SharedKernel.InfrastructureCore.Services;
+
+public sealed class AzureEmailService(SecretClient secretClient) : IEmailService
+{
+    private const string SecretName = "communication-services-connection-string";
+
+    private static readonly string Sender = Environment.GetEnvironmentVariable("SENDER_EMAIL_ADDRESS")!;
+
+    public async Task SendAsync(
+        string recipient,
+        string subject,
+        string htmlContent,
+        CancellationToken cancellationToken
+    )
+    {
+        var connectionString = await secretClient.GetSecretAsync(SecretName, cancellationToken: cancellationToken);
+
+        var emailClient = new EmailClient(connectionString.Value.Value);
+        EmailMessage message = new(Sender, recipient, new EmailContent(subject) { Html = htmlContent });
+        await emailClient.SendAsync(WaitUntil.Completed, message, cancellationToken);
+    }
+}

--- a/application/shared-kernel/InfrastructureCore/Services/DevelopmentEmailService.cs
+++ b/application/shared-kernel/InfrastructureCore/Services/DevelopmentEmailService.cs
@@ -1,0 +1,21 @@
+using System.Net.Mail;
+using PlatformPlatform.SharedKernel.ApplicationCore.Services;
+
+namespace PlatformPlatform.SharedKernel.InfrastructureCore.Services;
+
+public sealed class DevelopmentEmailService : IEmailService
+{
+    private const string Sender = "no-reply@localhost";
+    private readonly SmtpClient _emailSender = new("localhost", 1025);
+
+    public Task SendAsync(
+        string recipient,
+        string subject,
+        string htmlContent,
+        CancellationToken cancellationToken
+    )
+    {
+        var mailMessage = new MailMessage(Sender, recipient, subject, htmlContent) { IsBodyHtml = true };
+        return _emailSender.SendMailAsync(mailMessage, cancellationToken);
+    }
+}


### PR DESCRIPTION
### Summary & Motivation

Create an `IEmailService` for sending emails from the platform.

Implement `AzureEmailService` to utilize the Email Communication Service when operating in Azure environments. This service should fetch the Azure Communication Service's connection string from Key Vault and retrieve the sender's email address from an environment variable.

For local development environments, establish a `DevelopmentEmailService`. Integrate a MailHog Email Docker Server into `AspireHost` to facilitate straightforward email testing. This service will capture all outgoing emails, making them accessible through an inbox viewable directly from the Aspire Dashboard.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
