### PR TITLE
Fix failing Entity Framework migrations

### DIFF
--- a/application/account-management/Api/appsettings.json
+++ b/application/account-management/Api/appsettings.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "account-management": "Server=.;Database=account-management;Trusted_Connection=True"
   }
 }

--- a/application/account-management/Directory.Build.props
+++ b/application/account-management/Directory.Build.props
@@ -1,7 +1,4 @@
 <Project>
-    <PropertyGroup>
-        <UseArtifactsOutput>true</UseArtifactsOutput>
-    </PropertyGroup>
     <ItemGroup>
         <Using Include="JetBrains.Annotations"/>
         <Using Include="MediatR"/>

--- a/application/shared-kernel/Directory.Build.props
+++ b/application/shared-kernel/Directory.Build.props
@@ -1,7 +1,4 @@
 <Project>
-    <PropertyGroup>
-        <UseArtifactsOutput>true</UseArtifactsOutput>
-    </PropertyGroup>
     <ItemGroup>
         <Using Include="JetBrains.Annotations"/>
         <Using Include="MediatR"/>


### PR DESCRIPTION
### Summary & Motivation

Reverts the `<UseArtifactsOutput>` setting in .NET 8 projects, which resolves an issue preventing Entity Framework migrations from being executed. Additionally, a development connection string has been added to facilitate Entity Framework migration processes. 

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
