### PR TITLE
Fix typo when calling an Azure CLI command

### DIFF
--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -436,10 +436,10 @@ public class ConfigureContinuousDeploymentsCommand : Command
         azureInfo.AppRegistrationId = RunAzureCliCommand(
             $"""ad app create --display-name "{azureInfo.AppRegistrationName}" --query appId -o tsv""").Trim();
 
-        azureInfo.ServicePrincipalId =
-            RunAzureCliCommand($"ad sp create --id {azureInfo.AppRegistrationId} --query appId -o tsv").Trim();
+        azureInfo.ServicePrincipalId = RunAzureCliCommand(
+            $"ad sp create --id {azureInfo.AppRegistrationId} --query appId -o tsv").Trim();
 
-        azureInfo.ServicePrincipalObjectId = ProcessHelper.StartProcess(
+        azureInfo.ServicePrincipalObjectId = RunAzureCliCommand(
             $"""ad sp list --filter "appId eq '{azureInfo.AppRegistrationId}'" --query "[].id" -o tsv""").Trim();
 
         AnsiConsole.MarkupLine(


### PR DESCRIPTION

### Summary & Motivation

This pull request fixes a previous error where we need to wrap the execution into the RunAzureCliCommand method which provides the `az` command for Azure CLI. 

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
