### PR TITLE
Fix connection to Azure KeyVault

### DIFF
--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -47,7 +47,10 @@ public static class InfrastructureCoreConfiguration
             services.AddSingleton<SecretClient>(_ =>
             {
                 var keyVaultUrl = Environment.GetEnvironmentVariable("KEYVAULT_URL")!;
-                return new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
+                var managedIdentityClientId = Environment.GetEnvironmentVariable("MANAGED_IDENTITY_CLIENT_ID")!;
+                var credentialOptions = new DefaultAzureCredentialOptions
+                    { ManagedIdentityClientId = managedIdentityClientId };
+                return new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential(credentialOptions));
             });
             services.AddTransient<IEmailService, AzureEmailService>();
         }

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -116,6 +116,10 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
               value: 'Server=tcp:${sqlServerName}${environment().suffixes.sqlServerHostname},1433;Initial Catalog=${sqlDatabaseName};User Id=${userAssignedIdentity.properties.clientId};Authentication=Active Directory Default;TrustServerCertificate=True;'
             }
             {
+              name: 'MANAGED_IDENTITY_CLIENT_ID'
+              value: userAssignedIdentity.properties.clientId
+            }
+            {
               name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
               value: applicationInsightsConnectionString
             }

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -174,20 +174,12 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
   dependsOn: [containerRegistryPermission]
 }
 
-resource keyVaultAccessPolicy 'Microsoft.KeyVault/vaults/accessPolicies@2021-10-01' = {
-  parent: keyVault
-  name: 'add'
+var keyVaultSecretsUserRoleDefinitionId = '4633458b-17de-408a-b874-0445c86b69e6' // Key Vault Secrets User role
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: guid(keyVault.name, name, keyVaultSecretsUserRoleDefinitionId)
+  scope: keyVault
   properties: {
-    accessPolicies: [
-      {
-        tenantId: subscription().tenantId
-        objectId: userAssignedIdentity.properties.principalId
-        permissions: {
-          secrets: [
-            'get'
-          ]
-        }
-      }
-    ]
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleDefinitionId)
+    principalId: userAssignedIdentity.properties.principalId
   }
 }

--- a/cloud-infrastructure/modules/key-vault.bicep
+++ b/cloud-infrastructure/modules/key-vault.bicep
@@ -26,13 +26,12 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
         }
       ]
     }
-    accessPolicies: []
     enabledForDeployment: false
     enabledForDiskEncryption: false
     enabledForTemplateDeployment: false
     enableSoftDelete: true
     softDeleteRetentionInDays: 7
-    enableRbacAuthorization: false
+    enableRbacAuthorization: true
     publicNetworkAccess: 'Enabled'
   }
 }


### PR DESCRIPTION
### Summary & Motivation

Fix the connection to KeyVault, which failed to use the managed identity of the Azure Container App. Add the ID of the Account Management Managed Identity ID as an environment variable (named `MANAGED_IDENTITY_CLIENT_ID`) to Azure Container Apps, and use this to explicitly specify the Identity when creating `DefaultAzureCredentialOptions`.

Change the KeyVault configuration to use Role-Based Access Control instead of the legacy Key Vault access policy. Grant the Account Management Managed Identity ID `Key Vault Secrets User role` permissions.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
