### PR TITLE
Add endpoint for subdomain availability check

### DIFF
--- a/application/account-management/Api/AccountRegistrations/AccountRegistrationsEndpoints.cs
+++ b/application/account-management/Api/AccountRegistrations/AccountRegistrationsEndpoints.cs
@@ -15,6 +15,9 @@ public static class AccountRegistrationsEndpoints
         group.MapPost("/start", async Task<ApiResult> (StartAccountRegistrationCommand command, ISender mediator)
             => (await mediator.Send(command)).AddResourceUri(RoutesPrefix));
 
+        group.MapGet("/is-subdomain-free", async Task<ApiResult<bool>> (string subdomain, ISender mediator)
+            => await mediator.Send(new IsSubdomainFreeQuery(subdomain)));
+
         group.MapPost("{id}/complete", async Task<ApiResult> (
                 AccountRegistrationId id,
                 CompleteAccountRegistrationCommand command,

--- a/application/account-management/Api/AccountRegistrations/AccountRegistrationsEndpoints.cs
+++ b/application/account-management/Api/AccountRegistrations/AccountRegistrationsEndpoints.cs
@@ -12,11 +12,11 @@ public static class AccountRegistrationsEndpoints
     {
         var group = routes.MapGroup(RoutesPrefix);
 
-        group.MapPost("/start", async Task<ApiResult> (StartAccountRegistrationCommand command, ISender mediator)
-            => (await mediator.Send(command)).AddResourceUri(RoutesPrefix));
-
         group.MapGet("/is-subdomain-free", async Task<ApiResult<bool>> (string subdomain, ISender mediator)
             => await mediator.Send(new IsSubdomainFreeQuery(subdomain)));
+
+        group.MapPost("/start", async Task<ApiResult> (StartAccountRegistrationCommand command, ISender mediator)
+            => (await mediator.Send(command)).AddResourceUri(RoutesPrefix));
 
         group.MapPost("{id}/complete", async Task<ApiResult> (
                 AccountRegistrationId id,

--- a/application/account-management/Application/AccountRegistrations/IsSubdomainFree.cs
+++ b/application/account-management/Application/AccountRegistrations/IsSubdomainFree.cs
@@ -1,0 +1,16 @@
+using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
+
+namespace PlatformPlatform.AccountManagement.Application.AccountRegistrations;
+
+[UsedImplicitly]
+public sealed record IsSubdomainFreeQuery(string Subdomain) : IRequest<Result<bool>>;
+
+[UsedImplicitly]
+public sealed class IsSubdomainFreeHandler(ITenantRepository tenantRepository)
+    : IRequestHandler<IsSubdomainFreeQuery, Result<bool>>
+{
+    public async Task<Result<bool>> Handle(IsSubdomainFreeQuery request, CancellationToken cancellationToken)
+    {
+        return await tenantRepository.IsSubdomainFreeAsync(request.Subdomain, cancellationToken);
+    }
+}


### PR DESCRIPTION
### Summary & Motivation

Introduce a lightweight endpoint dedicated to verifying subdomain availability during the account registration process. Include tests.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
