### PR TITLE
Add API endpoints and logic for searching, sorting, and pagination

### DIFF
--- a/application/account-management/Api/AccountRegistrations/AccountRegistrationsEndpoints.cs
+++ b/application/account-management/Api/AccountRegistrations/AccountRegistrationsEndpoints.cs
@@ -12,8 +12,9 @@ public static class AccountRegistrationsEndpoints
     {
         var group = routes.MapGroup(RoutesPrefix);
 
-        group.MapGet("/is-subdomain-free", async Task<ApiResult<bool>> (string subdomain, ISender mediator)
-            => await mediator.Send(new IsSubdomainFreeQuery(subdomain)));
+        group.MapGet("/is-subdomain-free",
+            async Task<ApiResult<bool>> ([AsParameters] IsSubdomainFreeQuery query, ISender mediator)
+                => await mediator.Send(query));
 
         group.MapPost("/start", async Task<ApiResult> (StartAccountRegistrationCommand command, ISender mediator)
             => (await mediator.Send(command)).AddResourceUri(RoutesPrefix));

--- a/application/account-management/Api/Tenants/TenantEndpoints.cs
+++ b/application/account-management/Api/Tenants/TenantEndpoints.cs
@@ -11,13 +11,14 @@ public static class TenantEndpoints
     {
         var group = routes.MapGroup(RoutesPrefix);
 
-        group.MapGet("/{id}", async Task<ApiResult<TenantResponseDto>> (TenantId id, ISender mediator)
-            => await mediator.Send(new GetTenantQuery(id)));
+        group.MapGet("/{id}",
+            async Task<ApiResult<TenantResponseDto>> ([AsParameters] GetTenantQuery query, ISender mediator)
+                => await mediator.Send(query));
 
         group.MapPut("/{id}", async Task<ApiResult> (TenantId id, UpdateTenantCommand command, ISender mediator)
             => await mediator.Send(command with { Id = id }));
 
-        group.MapDelete("/{id}", async Task<ApiResult> (TenantId id, ISender mediator)
-            => await mediator.Send(new DeleteTenantCommand(id)));
+        group.MapDelete("/{id}", async Task<ApiResult> ([AsParameters] DeleteTenantCommand command, ISender mediator)
+            => await mediator.Send(command));
     }
 }

--- a/application/account-management/Api/Users/UserEndpoints.cs
+++ b/application/account-management/Api/Users/UserEndpoints.cs
@@ -12,7 +12,7 @@ public static class UserEndpoints
         var group = routes.MapGroup(RoutesPrefix);
 
         group.MapGet("/",
-            async Task<ApiResult<UserResponseDto[]>> ([AsParameters] GetUsersQuery query, ISender mediator)
+            async Task<ApiResult<SearchUsersDto>> ([AsParameters] GetUsersQuery query, ISender mediator)
                 => await mediator.Send(query));
 
         group.MapGet("/{id}", async Task<ApiResult<UserResponseDto>> (UserId id, ISender mediator)

--- a/application/account-management/Api/Users/UserEndpoints.cs
+++ b/application/account-management/Api/Users/UserEndpoints.cs
@@ -11,12 +11,12 @@ public static class UserEndpoints
     {
         var group = routes.MapGroup(RoutesPrefix);
 
-        group.MapGet("/",
-            async Task<ApiResult<SearchUsersDto>> ([AsParameters] GetUsersQuery query, ISender mediator)
-                => await mediator.Send(query));
+        group.MapGet("/", async Task<ApiResult<SearchUsersDto>> ([AsParameters] GetUsersQuery query, ISender mediator)
+            => await mediator.Send(query));
 
-        group.MapGet("/{id}", async Task<ApiResult<UserResponseDto>> (UserId id, ISender mediator)
-            => await mediator.Send(new GetUserQuery(id)));
+        group.MapGet("/{id}",
+            async Task<ApiResult<UserResponseDto>> ([AsParameters] GetUserQuery query, ISender mediator)
+                => await mediator.Send(query));
 
         group.MapPost("/", async Task<ApiResult> (CreateUserCommand command, ISender mediator)
             => (await mediator.Send(command)).AddResourceUri(RoutesPrefix));
@@ -24,7 +24,7 @@ public static class UserEndpoints
         group.MapPut("/{id}", async Task<ApiResult> (UserId id, UpdateUserCommand command, ISender mediator)
             => await mediator.Send(command with { Id = id }));
 
-        group.MapDelete("/{id}", async Task<ApiResult> (UserId id, ISender mediator)
-            => await mediator.Send(new DeleteUserCommand(id)));
+        group.MapDelete("/{id}", async Task<ApiResult> ([AsParameters] DeleteUserCommand command, ISender mediator)
+            => await mediator.Send(command));
     }
 }

--- a/application/account-management/Api/Users/UserEndpoints.cs
+++ b/application/account-management/Api/Users/UserEndpoints.cs
@@ -11,6 +11,10 @@ public static class UserEndpoints
     {
         var group = routes.MapGroup(RoutesPrefix);
 
+        group.MapGet("/",
+            async Task<ApiResult<UserResponseDto[]>> ([AsParameters] GetUsersQuery query, ISender mediator)
+                => await mediator.Send(query));
+
         group.MapGet("/{id}", async Task<ApiResult<UserResponseDto>> (UserId id, ISender mediator)
             => await mediator.Send(new GetUserQuery(id)));
 

--- a/application/account-management/Application/Tenants/DeleteTenant.cs
+++ b/application/account-management/Application/Tenants/DeleteTenant.cs
@@ -5,6 +5,7 @@ using PlatformPlatform.SharedKernel.ApplicationCore.TelemetryEvents;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants;
 
+[UsedImplicitly]
 public sealed record DeleteTenantCommand(TenantId Id) : ICommand, IRequest<Result>;
 
 [UsedImplicitly]

--- a/application/account-management/Application/Tenants/GetTenant.cs
+++ b/application/account-management/Application/Tenants/GetTenant.cs
@@ -3,6 +3,7 @@ using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Application.Tenants;
 
+[UsedImplicitly]
 public sealed record GetTenantQuery(TenantId Id) : IRequest<Result<TenantResponseDto>>;
 
 [UsedImplicitly]

--- a/application/account-management/Application/Users/DeleteUser.cs
+++ b/application/account-management/Application/Users/DeleteUser.cs
@@ -4,6 +4,7 @@ using PlatformPlatform.SharedKernel.ApplicationCore.TelemetryEvents;
 
 namespace PlatformPlatform.AccountManagement.Application.Users;
 
+[UsedImplicitly]
 public sealed record DeleteUserCommand(UserId Id) : ICommand, IRequest<Result>;
 
 [UsedImplicitly]

--- a/application/account-management/Application/Users/GetUser.cs
+++ b/application/account-management/Application/Users/GetUser.cs
@@ -3,6 +3,7 @@ using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Application.Users;
 
+[UsedImplicitly]
 public sealed record GetUserQuery(UserId Id) : IRequest<Result<UserResponseDto>>;
 
 [UsedImplicitly]

--- a/application/account-management/Application/Users/GetUsers.cs
+++ b/application/account-management/Application/Users/GetUsers.cs
@@ -1,0 +1,35 @@
+using Mapster;
+using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
+using PlatformPlatform.SharedKernel.DomainCore.Persistence;
+
+namespace PlatformPlatform.AccountManagement.Application.Users;
+
+[UsedImplicitly]
+public sealed record GetUsersQuery(
+    string? Search = null,
+    UserRole? UserRole = null,
+    SortableUserProperties OrderBy = SortableUserProperties.Name,
+    SortOrder SortOrder = SortOrder.Ascending,
+    int? PageSize = null,
+    int? PageOffset = null
+)
+    : IRequest<Result<UserResponseDto[]>>;
+
+[UsedImplicitly]
+public sealed class GetUsersHandler(IUserRepository userRepository)
+    : IRequestHandler<GetUsersQuery, Result<UserResponseDto[]>>
+{
+    public async Task<Result<UserResponseDto[]>> Handle(GetUsersQuery query, CancellationToken cancellationToken)
+    {
+        var users = await userRepository.Search(
+            query.Search,
+            query.UserRole,
+            query.OrderBy,
+            query.SortOrder,
+            query.PageSize,
+            query.PageOffset,
+            cancellationToken
+        );
+        return users.Select(u => u.Adapt<UserResponseDto>()).ToArray();
+    }
+}

--- a/application/account-management/Application/Users/GetUsersDto.cs
+++ b/application/account-management/Application/Users/GetUsersDto.cs
@@ -1,0 +1,4 @@
+namespace PlatformPlatform.AccountManagement.Application.Users;
+
+[UsedImplicitly]
+public sealed record SearchUsersDto(int TotalCount, int TotalPages, int CurrentPageOffset, UserResponseDto[] Users);

--- a/application/account-management/Domain/Users/IUserRepository.cs
+++ b/application/account-management/Domain/Users/IUserRepository.cs
@@ -1,3 +1,5 @@
+using PlatformPlatform.SharedKernel.DomainCore.Persistence;
+
 namespace PlatformPlatform.AccountManagement.Domain.Users;
 
 public interface IUserRepository
@@ -13,4 +15,14 @@ public interface IUserRepository
     Task<bool> IsEmailFreeAsync(TenantId tenantId, string email, CancellationToken cancellationToken);
 
     Task<int> CountTenantUsersAsync(TenantId tenantId, CancellationToken cancellationToken);
+
+    Task<User[]> Search(
+        string? search,
+        UserRole? userRole,
+        SortableUserProperties? orderBy,
+        SortOrder? sortOrder,
+        int? pageSize,
+        int? pageOffset,
+        CancellationToken cancellationToken
+    );
 }

--- a/application/account-management/Domain/Users/IUserRepository.cs
+++ b/application/account-management/Domain/Users/IUserRepository.cs
@@ -16,7 +16,7 @@ public interface IUserRepository
 
     Task<int> CountTenantUsersAsync(TenantId tenantId, CancellationToken cancellationToken);
 
-    Task<User[]> Search(
+    Task<(User[] Users, int TotalItems, int TotalPages)> Search(
         string? search,
         UserRole? userRole,
         SortableUserProperties? orderBy,

--- a/application/account-management/Domain/Users/UserTypes.cs
+++ b/application/account-management/Domain/Users/UserTypes.cs
@@ -22,3 +22,12 @@ public enum UserRole
     TenantAdmin,
     TenantOwner
 }
+
+public enum SortableUserProperties
+{
+    CreatedAt,
+    ModifiedAt,
+    Name,
+    Email,
+    UserRole
+}

--- a/application/account-management/Infrastructure/Users/UserRepository.cs
+++ b/application/account-management/Infrastructure/Users/UserRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using PlatformPlatform.SharedKernel.DomainCore.Persistence;
 using PlatformPlatform.SharedKernel.InfrastructureCore.Persistence;
 
 namespace PlatformPlatform.AccountManagement.Infrastructure.Users;
@@ -15,5 +16,54 @@ internal sealed class UserRepository(AccountManagementDbContext accountManagemen
     public Task<int> CountTenantUsersAsync(TenantId tenantId, CancellationToken cancellationToken)
     {
         return DbSet.CountAsync(u => u.TenantId == tenantId, cancellationToken);
+    }
+
+    public async Task<User[]> Search(
+        string? search,
+        UserRole? userRole,
+        SortableUserProperties? orderBy,
+        SortOrder? sortOrder,
+        int? pageSize,
+        int? pageOffset,
+        CancellationToken cancellationToken
+    )
+    {
+        IQueryable<User> users = DbSet;
+
+        if (search is not null)
+        {
+            // We use the null-forgiving (!) operator here because the SQL LIKE operator handles NULL values gracefully
+            users = users.Where(u =>
+                u.Email.Contains(search) || u.FirstName!.Contains(search) || u.LastName!.Contains(search));
+        }
+
+        if (userRole is not null)
+        {
+            users = users.Where(u => u.UserRole == userRole);
+        }
+
+        users = orderBy switch
+        {
+            SortableUserProperties.CreatedAt => sortOrder == SortOrder.Ascending
+                ? users.OrderBy(u => u.CreatedAt)
+                : users.OrderByDescending(u => u.CreatedAt),
+            SortableUserProperties.ModifiedAt => sortOrder == SortOrder.Ascending
+                ? users.OrderBy(u => u.ModifiedAt)
+                : users.OrderByDescending(u => u.ModifiedAt),
+            SortableUserProperties.Name => sortOrder == SortOrder.Ascending
+                ? users.OrderBy(u => u.FirstName).ThenBy(u => u.LastName)
+                : users.OrderByDescending(u => u.FirstName).ThenByDescending(u => u.LastName),
+            SortableUserProperties.Email => sortOrder == SortOrder.Ascending
+                ? users.OrderBy(u => u.Email)
+                : users.OrderByDescending(u => u.Email),
+            SortableUserProperties.UserRole => sortOrder == SortOrder.Ascending
+                ? users.OrderBy(u => u.UserRole)
+                : users.OrderByDescending(u => u.UserRole),
+            _ => users
+        };
+
+        pageSize ??= 50;
+        var itemOffset = (pageOffset ?? 0) * pageSize.Value;
+        return await users.Skip(itemOffset).Take(pageSize.Value).ToArrayAsync(cancellationToken);
     }
 }

--- a/application/account-management/Infrastructure/Users/UserRepository.cs
+++ b/application/account-management/Infrastructure/Users/UserRepository.cs
@@ -18,7 +18,7 @@ internal sealed class UserRepository(AccountManagementDbContext accountManagemen
         return DbSet.CountAsync(u => u.TenantId == tenantId, cancellationToken);
     }
 
-    public async Task<User[]> Search(
+    public async Task<(User[] Users, int TotalItems, int TotalPages)> Search(
         string? search,
         UserRole? userRole,
         SortableUserProperties? orderBy,
@@ -64,6 +64,11 @@ internal sealed class UserRepository(AccountManagementDbContext accountManagemen
 
         pageSize ??= 50;
         var itemOffset = (pageOffset ?? 0) * pageSize.Value;
-        return await users.Skip(itemOffset).Take(pageSize.Value).ToArrayAsync(cancellationToken);
+        var result = await users.Skip(itemOffset).Take(pageSize.Value).ToArrayAsync(cancellationToken);
+
+        var totalItems = await users.CountAsync(cancellationToken);
+
+        var totalPages = (totalItems - 1) / pageSize.Value + 1;
+        return (result, totalItems, totalPages);
     }
 }

--- a/application/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
@@ -73,7 +73,7 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         await EnsureErrorStatusCode(
             response,
             HttpStatusCode.BadRequest,
-            $"""Failed to bind parameter "TenantId id" from "{invalidTenantId}"."""
+            $"""Failed to bind parameter "TenantId Id" from "{invalidTenantId}"."""
         );
     }
 

--- a/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
@@ -70,7 +70,7 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
 
         // Assert
         await EnsureErrorStatusCode(response, HttpStatusCode.BadRequest,
-            $"""Failed to bind parameter "UserId id" from "{invalidUserId}".""");
+            $"""Failed to bind parameter "UserId Id" from "{invalidUserId}".""");
     }
 
     [Fact]

--- a/application/shared-kernel/DomainCore/Persistence/SortOrder.cs
+++ b/application/shared-kernel/DomainCore/Persistence/SortOrder.cs
@@ -3,5 +3,5 @@ namespace PlatformPlatform.SharedKernel.DomainCore.Persistence;
 public enum SortOrder
 {
     Ascending,
-    Descending
+    [UsedImplicitly] Descending
 }

--- a/application/shared-kernel/DomainCore/Persistence/SortOrder.cs
+++ b/application/shared-kernel/DomainCore/Persistence/SortOrder.cs
@@ -1,0 +1,7 @@
+namespace PlatformPlatform.SharedKernel.DomainCore.Persistence;
+
+public enum SortOrder
+{
+    Ascending,
+    Descending
+}


### PR DESCRIPTION
### Summary & Motivation

Add API endpoints to allow searching, sorting, and pagination of users. The result includes a list of `UserDto`s, total found rows, and total pages. This enables the frontend to display pagination information like "Showing 50 users, Page 2 out of 12 pages."

Update the API endpoint to use `[AsParameters]`, enabling the addition of `GetUsersQuery` as an API contract. In the OpenAPI contract, this will show all the possible query string parameters.

Here is an example showing the possibilities:

`/api/users?search=john&userRole=TenantOwner&pageSize=10&pageOffset=0&orderBy=Email&sortOrder=Descending`

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
