### PR TITLE
Update Swagger contract generation to correctly treat strongly typed IDs as plain text

### DIFF
--- a/application/account-management/Api/Program.cs
+++ b/application/account-management/Api/Program.cs
@@ -2,6 +2,7 @@ using PlatformPlatform.AccountManagement.Api.AccountRegistrations;
 using PlatformPlatform.AccountManagement.Api.Tenants;
 using PlatformPlatform.AccountManagement.Api.Users;
 using PlatformPlatform.AccountManagement.Application;
+using PlatformPlatform.AccountManagement.Domain;
 using PlatformPlatform.AccountManagement.Infrastructure;
 using PlatformPlatform.SharedKernel.ApiCore;
 using PlatformPlatform.SharedKernel.ApiCore.Middleware;
@@ -14,7 +15,7 @@ builder.Services
     .AddApplicationServices()
     .AddDatabaseContext(builder)
     .AddInfrastructureServices()
-    .AddApiCoreServices(builder)
+    .AddApiCoreServices(builder, DomainConfiguration.Assembly)
     .AddWebAppMiddleware();
 
 var app = builder.Build();

--- a/application/account-management/Domain/AccountRegistrations/AccountRegistration.cs
+++ b/application/account-management/Domain/AccountRegistrations/AccountRegistration.cs
@@ -57,7 +57,7 @@ public sealed class AccountRegistration : AggregateRoot<AccountRegistrationId>
     }
 }
 
-[TypeConverter(typeof(UserIdTypeConverter))]
+[TypeConverter(typeof(StronglyTypedIdTypeConverter<string, AccountRegistrationId>))]
 [UsedImplicitly]
 public sealed record AccountRegistrationId(string Value) : StronglyTypedUlid<AccountRegistrationId>(Value)
 {

--- a/application/account-management/Domain/Tenants/TenantTypes.cs
+++ b/application/account-management/Domain/Tenants/TenantTypes.cs
@@ -2,7 +2,7 @@ using PlatformPlatform.SharedKernel.DomainCore.Identity;
 
 namespace PlatformPlatform.AccountManagement.Domain.Tenants;
 
-[TypeConverter(typeof(TenantIdTypeConverter))]
+[TypeConverter(typeof(StronglyTypedIdTypeConverter<string, TenantId>))]
 public sealed record TenantId(string Value) : StronglyTypedId<string, TenantId>(Value)
 {
     public override string ToString()
@@ -23,8 +23,6 @@ public sealed record TenantId(string Value) : StronglyTypedId<string, TenantId>(
         return false;
     }
 }
-
-public sealed class TenantIdTypeConverter : StronglyTypedIdTypeConverter<string, TenantId>;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
 [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/application/account-management/Domain/Users/UserTypes.cs
+++ b/application/account-management/Domain/Users/UserTypes.cs
@@ -2,7 +2,7 @@ using PlatformPlatform.SharedKernel.DomainCore.Identity;
 
 namespace PlatformPlatform.AccountManagement.Domain.Users;
 
-[TypeConverter(typeof(UserIdTypeConverter))]
+[TypeConverter(typeof(StronglyTypedIdTypeConverter<string, UserId>))]
 [UsedImplicitly]
 public sealed record UserId(string Value) : StronglyTypedUlid<UserId>(Value)
 {
@@ -12,9 +12,6 @@ public sealed record UserId(string Value) : StronglyTypedUlid<UserId>(Value)
     }
 }
 
-public sealed class UserIdTypeConverter : StronglyTypedIdTypeConverter<string, UserId>;
-
-[UsedImplicitly(ImplicitUseTargetFlags.Members)]
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum UserRole
 {

--- a/application/account-management/WebApp/app/register/components/actions.ts
+++ b/application/account-management/WebApp/app/register/components/actions.ts
@@ -93,8 +93,6 @@ export async function completeAccountRegistration(_: State, formData: FormData):
     const result = await accountManagementApi.POST("/api/account-registrations/{id}/complete", {
       params: {
         path: {
-          // eslint-disable-next-line ts/ban-ts-comment
-          // @ts-expect-error
           id: accountRegistrationId,
         },
       },

--- a/application/shared-kernel/DomainCore/Identity/StronglyTypedId.cs
+++ b/application/shared-kernel/DomainCore/Identity/StronglyTypedId.cs
@@ -7,7 +7,10 @@ namespace PlatformPlatform.SharedKernel.DomainCore.Identity;
 ///     better type safety than AddToOrder(long customerId, long orderId, long productId, int quantity).
 ///     When used with Entity Framework, make sure to register the type in the OnModelCreating method in the DbContext.
 /// </summary>
-public abstract record StronglyTypedId<TValue, T>(TValue Value) : IComparable<StronglyTypedId<TValue, T>>
+public interface IStronglyTypedId;
+
+public abstract record StronglyTypedId<TValue, T>(TValue Value)
+    : IStronglyTypedId, IComparable<StronglyTypedId<TValue, T>>
     where T : StronglyTypedId<TValue, T> where TValue : IComparable<TValue>
 {
     public int CompareTo(StronglyTypedId<TValue, T>? other)

--- a/application/shared-kernel/DomainCore/Persistence/SortOrder.cs
+++ b/application/shared-kernel/DomainCore/Persistence/SortOrder.cs
@@ -1,7 +1,8 @@
 namespace PlatformPlatform.SharedKernel.DomainCore.Persistence;
 
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
 public enum SortOrder
 {
     Ascending,
-    [UsedImplicitly] Descending
+    Descending
 }


### PR DESCRIPTION
### Summary & Motivation

After upgrading from Swashbuckle to NSwag, the Swagger UI displayed strongly typed IDs, such as `TenantId` and `UserId`, as complex objects `{ "value": "string" }` instead of simply a `string`. This issue affected only the UI and TypeScript definitions, necessitating the suppression of a warning.

The solution involves loading all strongly typed IDs and overriding the default in the `AddOpenApiDocument` configuration's `settings.PostProcess()`.

Additionally, the convention for creating strongly typed IDs has been updated to avoid creating a TypeConverter class for each strongly typed ID.


### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
