### PR TITLE
Configure Scrutor to only register the repository classes within the Assembly

### DIFF
--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -72,7 +72,10 @@ public static class InfrastructureCoreConfiguration
         // and register them as a service in the container.
         services.Scan(scan => scan
             .FromAssemblies(assembly)
-            .AddClasses(classes => classes.Where(type => type.IsClass && (type.IsNotPublic || type.IsPublic)))
+            .AddClasses(classes => classes.Where(type =>
+                type.IsClass && (type.IsNotPublic || type.IsPublic)
+                             && type.BaseType is { IsGenericType: true } &&
+                             type.BaseType.GetGenericTypeDefinition() == typeof(RepositoryBase<,>)))
             .AsImplementedInterfaces()
             .WithScopedLifetime());
 


### PR DESCRIPTION
### Summary & Motivation

This Pull request will only register the Repository classes in the DI container. This way we avoid the registration of classes that are inside the same assembly.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
