### PR TITLE
Streamline Open API Documentation generation with built-in OpenApiGenerateDocumentsOnBuild property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -383,6 +383,7 @@ FodyWeavers.xsd
 **/*.generated.d.ts
 **/*.generated.ts
 **/Api/swagger.json
+**/lib/api/Api.json
 
 # Frontend builds
 .swc/

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -72,6 +72,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(AspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="$(AspNetCoreVersion)">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <!-- Version together with EF -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(EfCoreVersion)" />

--- a/application/account-management/Api/Api.csproj
+++ b/application/account-management/Api/Api.csproj
@@ -6,6 +6,9 @@
         <RootNamespace>PlatformPlatform.AccountManagement.Api</RootNamespace>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/../WebApp/lib/api/</OpenApiDocumentsDirectory>
+        <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>
+        <OpenApiGenerateDocumentsOnBuild>true</OpenApiGenerateDocumentsOnBuild>
     </PropertyGroup>
 
     <ItemGroup>
@@ -22,6 +25,10 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.Extensions.ApiDescription.Server">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="NSwag.MSBuild">
             <PrivateAssets>all</PrivateAssets>
@@ -40,14 +47,4 @@
         <None Remove="publish\**"/>
     </ItemGroup>
 
-    <PropertyGroup>
-        <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-    </PropertyGroup>
-
-    <Target Name="NSwag" AfterTargets="PostBuildEvent">
-        <Exec
-            EnvironmentVariables="ASPNETCORE_ENVIRONMENT=Development;SWAGGER_GENERATOR=true;PUBLIC_URL=https://localhost:8443"
-            Command="$(NSwagExe_Net80) aspnetcore2openapi /Project:Api.csproj /Output:swagger.json /DocumentName:v1 /NoBuild:true /TargetFramework:net8.0 /Configuration:$(Configuration) /NewLineBehavior:LF"
-        />
-    </Target>
 </Project>

--- a/application/account-management/Api/appsettings.json
+++ b/application/account-management/Api/appsettings.json
@@ -4,8 +4,5 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  },
-  "ConnectionStrings": {
-    "account-management": "Server=.;Database=account-management;Trusted_Connection=True"
   }
 }

--- a/application/account-management/WebApp/eslint.config.js
+++ b/application/account-management/WebApp/eslint.config.js
@@ -62,5 +62,6 @@ module.exports = antfu({
     "**/.swc/*",
     "**/dist/*",
     "**/locale/*.d.ts",
+    "**/lib/api/Api.json",
   ],
 });

--- a/application/account-management/WebApp/package.json
+++ b/application/account-management/WebApp/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "typechecking": "tsc --noEmit",
     "msbuild": "yarn run msbuild:swagger && yarn run build",
-    "msbuild:swagger": "npx openapi-typescript ../Api/swagger.json -o lib/api/api.generated.d.ts && npx prettier lib/api/api.generated.d.ts --write",
+    "msbuild:swagger": "npx openapi-typescript lib/api/Api.json -o lib/api/api.generated.d.ts && npx prettier lib/api/api.generated.d.ts --write",
     "postinstall": "yarn run lingui:extract && yarn run lingui:compile"
   },
   "dependencies": {

--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddlewareConfiguration.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddlewareConfiguration.cs
@@ -36,7 +36,7 @@ public class WebAppMiddlewareConfiguration
         VerifyRuntimeEnvironment(StaticRuntimeEnvironment);
 
         BuildRootPath = GetWebAppDistRoot("WebApp", "dist");
-        HtmlTemplate = ReadHtmlTemplate(Path.Combine(BuildRootPath, "index.html"), isDevelopment);
+        HtmlTemplate = ReadHtmlTemplate(GetHtmlTemplatePath(), isDevelopment);
 
         PermissionPolicies = GetPermissionsPolicies();
         ContentSecurityPolicies = GetContentSecurityPolicies(isDevelopment);
@@ -72,6 +72,12 @@ public class WebAppMiddlewareConfiguration
         }
 
         return Path.Join(directoryInfo!.FullName, webAppProjectName, webAppDistRootName);
+    }
+
+    public static string GetHtmlTemplatePath()
+    {
+        var buildRootPath = GetWebAppDistRoot("WebApp", "dist");
+        return Path.Combine(buildRootPath, "index.html");
     }
 
     private string ReadHtmlTemplate(string htmlTemplatePath, bool isDevelopment)

--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddlewareExtensions.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddlewareExtensions.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
-using PlatformPlatform.SharedKernel.InfrastructureCore;
 
 namespace PlatformPlatform.SharedKernel.ApiCore.Middleware;
 
@@ -14,8 +13,6 @@ public static class WebAppMiddlewareExtensions
     [UsedImplicitly]
     public static IServiceCollection AddWebAppMiddleware(this IServiceCollection services)
     {
-        if (InfrastructureCoreConfiguration.SwaggerGenerator) return services;
-
         return services.AddSingleton<WebAppMiddlewareConfiguration>(serviceProvider =>
             {
                 var jsonOptions = serviceProvider.GetRequiredService<IOptions<JsonOptions>>();
@@ -28,7 +25,7 @@ public static class WebAppMiddlewareExtensions
     [UsedImplicitly]
     public static IApplicationBuilder UseWebAppMiddleware(this IApplicationBuilder builder)
     {
-        if (InfrastructureCoreConfiguration.SwaggerGenerator) return builder;
+        if (!Path.Exists(WebAppMiddlewareConfiguration.GetHtmlTemplatePath())) return builder;
 
         var webAppConfiguration = builder.ApplicationServices.GetRequiredService<WebAppMiddlewareConfiguration>();
 


### PR DESCRIPTION
### Summary & Motivation

Replace the custom Post Build Event used to generate the Open API JSON file with NSwag by leveraging .NET's built-in but undocumented `OpenApiGenerateDocumentsOnBuild` property. Although NSwag is still utilized behind the scenes, this adjustment eliminates the need for the custom event, making the implementation much cleaner.

When generating the Open API file, the .NET API process still needs to be started. However, this change ensures that any .NET exceptions in the startup are displayed directly in the output. Previously, with the custom post-build event, the output was cluttered with information about the NSwag configuration, obscuring the root cause.

Previously, the `SWAGGER_GENERATOR` environment variable was passed to .NET during Open API generation to avoid running Database Migrations and running the SPA configuration. With the shift to the built-in `OpenApiGenerateDocumentsOnBuild` property, this approach is no longer feasible. Instead, Database Migration and SPA Configuration are now skipped by detecting a missing connection string and the absence of the `index.html` file.

Finally, the generated file is moved from `/Api/swagger.json` to `WebApp/lib/api/Api.json`, where it belongs.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
