### PR TITLE
Add WebApp dependency to Aspire AppHost after upgrading Microsoft.VisualStudio.JavaScript.SDK

### DIFF
--- a/application/AppHost/AppHost.csproj
+++ b/application/AppHost/AppHost.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
         <ProjectReference Include="../account-management/Api/Api.csproj"/>
+        <ProjectReference Include="../account-management/WebApp/WebApp.esproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/application/PlatformPlatform.sln
+++ b/application/PlatformPlatform.sln
@@ -30,9 +30,6 @@ EndProject
 Project("{54A90642-561A-4BB1-A94E-469ADEE60C69}") = "WebApp", "account-management\WebApp\WebApp.esproj", "{8292F35B-F0F6-4DB1-90E2-4707DB8C7104}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppHost", "AppHost\AppHost.csproj", "{2D6D4E5B-983A-4AAB-A91E-5492F7FD52E8}"
-	ProjectSection(ProjectDependencies) = postProject
-		{8292F35B-F0F6-4DB1-90E2-4707DB8C7104} = {8292F35B-F0F6-4DB1-90E2-4707DB8C7104}
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/application/account-management/WebApp/WebApp.esproj
+++ b/application/account-management/WebApp/WebApp.esproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/0.5.302517-alpha">
+<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/1.0.751930">
 
     <PropertyGroup>
         <StartupCommand>set BROWSER=none;yarn dev</StartupCommand>


### PR DESCRIPTION
### Summary & Motivation

Upgrade `Microsoft.VisualStudio.JavaScript.SDK` to the final version and add the `WebApp` dependency back to the Aspire AppHost project.

This change allows for the removal of the configuration where the WebApp was added as a dependency in the `PlatformPlatform.sln` file. Consequently, it is now possible to run `pp run` without first needing to build the entire solution, as `pp run` was just running AppHost but did not build the WebApp.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
