### PR TITLE
Set up emulator for storage for local development

### DIFF
--- a/application/AppHost/AppHost.csproj
+++ b/application/AppHost/AppHost.csproj
@@ -14,6 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Aspire.Hosting.Azure"/>
         <PackageReference Include="Aspire.Hosting"/>
     </ItemGroup>
 

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -3,14 +3,23 @@ using Projects;
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sqlServerPassword = Environment.GetEnvironmentVariable("SQL_SERVER_PASSWORD");
-var database = builder.AddSqlServer("account-management-db", sqlServerPassword, 8433)
+var database = builder
+    .AddSqlServer("account-management-db", sqlServerPassword, 8433)
     .WithVolumeMount("sql-server-data", "/var/opt/mssql")
     .AddDatabase("account-management");
 
-var accountManagementApi = builder.AddProject<Api>("account-management-api")
-    .WithReference(database);
+var accountManagementStorage = builder
+    .AddAzureStorage("account-management-storage")
+    .RunAsEmulator()
+    .AddBlobs("blobs");
 
-builder.AddNpmApp("account-management-spa", "../account-management/WebApp", "dev")
+var accountManagementApi = builder
+    .AddProject<Api>("account-management-api")
+    .WithReference(database)
+    .WithReference(accountManagementStorage);
+
+builder
+    .AddNpmApp("account-management-spa", "../account-management/WebApp", "dev")
     .WithReference(accountManagementApi);
 
 builder.AddContainer("email-test-server", "mailhog/mailhog")

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -10,7 +10,11 @@ var database = builder
 
 var accountManagementStorage = builder
     .AddAzureStorage("account-management-storage")
-    .RunAsEmulator()
+    .RunAsEmulator(resourceBuilder =>
+    {
+        resourceBuilder.WithVolumeMount("account-management-storage", "/var/opt/blobstorage");
+        resourceBuilder.UseBlobPort(10000);
+    })
     .AddBlobs("blobs");
 
 var accountManagementApi = builder

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -31,6 +31,7 @@
     <PackageVersion Include="NUlid" Version="1.7.2" />
     <!-- PlatformPlatform dependencies - Infrastructure -->
     <PackageVersion Include="Azure.Communication.Email" Version="1.0.1" />
+    <PackageVersion Include="Aspire.Hosting.Azure" Version="$(AspireVersion)" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />


### PR DESCRIPTION
### Summary & Motivation

Use .NET Aspire's `AddAzureStorage` and `RunAsEmulator` to configure the Azure storage emulator for localhost development. Behind the scenes, Aspire utilizes the `azure-storage/azurite` Docker container to emulate Blob, Queue, and Table Storage. When the Aspire AppHost is started, the storage emulator automatically starts.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
