### PR TITLE
Add blob storage infrastructure to Account Management and create avatars container

### DIFF
--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -197,7 +197,7 @@ module accountManagementStorageAccount '../modules/storage-account.bicep' = {
 }
 
 module accountManagement '../modules/container-app.bicep' = {
-  name: 'account-management'
+  name: 'account-management-container-app'
   scope: clusterResourceGroup
   params: {
     name: 'account-management'

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -216,6 +216,7 @@ module accountManagement '../modules/container-app.bicep' = {
     emailServicesName: clusterUniqueName
     sqlServerName: clusterUniqueName
     sqlDatabaseName: 'account-management'
+    storageAccountName: accountManagementStorageAccountName
     userAssignedIdentityName: accountManagementIdentityName
     domainName: domainName == '' ? '' : 'account-management.${domainName}'
     domainConfigured: domainName != '' && accountManagementDomainConfigured

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -176,6 +176,26 @@ module accountManagementDatabase '../modules/microsoft-sql-database.bicep' = {
   dependsOn: [microsoftSqlServer]
 }
 
+var accountManagementStorageAccountName = '${clusterUniqueName}acctmgmt'
+module accountManagementStorageAccount '../modules/storage-account.bicep' = {
+  scope: clusterResourceGroup
+  name: 'account-management-storage-account'
+  params: {
+    location: location
+    name: accountManagementStorageAccountName
+    tags: tags
+    sku: 'Standard_GRS'
+    userAssignedIdentityName: accountManagementIdentityName
+    containers: [
+      {
+        name: 'avatars'
+        publicAccess: 'None'
+      }
+    ]
+  }
+  dependsOn: [accountManagementIdentity]
+}
+
 module accountManagement '../modules/container-app.bicep' = {
   name: 'account-management'
   scope: clusterResourceGroup
@@ -202,7 +222,7 @@ module accountManagement '../modules/container-app.bicep' = {
     applicationInsightsConnectionString: applicationInsightsConnectionString
     keyVaultName: keyVault.outputs.name
   }
-  dependsOn: [accountManagementDatabase, communicationService]
+  dependsOn: [accountManagementDatabase, accountManagementIdentity, communicationService]
 }
 
 output accountManagementIdentityClientId string = accountManagementIdentity.outputs.clientId

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -18,6 +18,17 @@ param mailSenderDisplayName string = 'PlatformPlatform'
 var tags = { environment: environment, 'managed-by': 'bicep' }
 var diagnosticStorageAccountName = '${clusterUniqueName}diagnostic'
 
+resource clusterResourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+  name: resourceGroupName
+  location: location
+  tags: tags
+}
+
+resource existingLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
+  scope: resourceGroup('${environment}')
+  name: '${environment}-log-analytics-workspace'
+}
+
 // Manually construct virtual network subnetId to avoid dependent Bicep resources to be ignored. See https://github.com/Azure/arm-template-whatif/issues/157#issuecomment-1336139303
 var virtualNetworkName = '${locationPrefix}-virtual-network'
 var subnetId = resourceId(
@@ -28,25 +39,14 @@ var subnetId = resourceId(
   'subnet'
 )
 
-resource existingLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
-  scope: resourceGroup('${environment}')
-  name: '${environment}-log-analytics-workspace'
-}
-
-resource clusterResourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
-  name: resourceGroupName
-  location: location
-  tags: tags
-}
-
 module diagnosticStorageAccount '../modules/storage-account.bicep' = {
   scope: clusterResourceGroup
   name: 'diagnostic-storage-account'
   params: {
     location: location
     name: diagnosticStorageAccountName
-    sku: 'Standard_GRS'
     tags: tags
+    sku: 'Standard_GRS'
   }
 }
 
@@ -60,31 +60,16 @@ module virtualNetwork '../modules/virtual-network.bicep' = {
   }
 }
 
-module keyVault '../modules/key-vault.bicep' = {
+module containerAppsEnvironment '../modules/container-apps-environment.bicep' = {
   scope: clusterResourceGroup
-  name: 'key-vault'
+  name: 'container-apps-environment'
   params: {
     location: location
-    name: clusterUniqueName
+    name: '${locationPrefix}-container-apps-environment'
     tags: tags
-    tenantId: subscription().tenantId
     subnetId: subnetId
-    storageAccountId: diagnosticStorageAccount.outputs.storageAccountId
-    workspaceId: existingLogAnalyticsWorkspace.id
   }
   dependsOn: [virtualNetwork]
-}
-
-module serviceBus '../modules/service-bus.bicep' = {
-  scope: clusterResourceGroup
-  name: 'service-bus'
-  params: {
-    location: location
-    name: clusterUniqueName
-    tags: tags
-    storageAccountId: diagnosticStorageAccount.outputs.storageAccountId
-    workspaceId: existingLogAnalyticsWorkspace.id
-  }
 }
 
 module microsoftSqlServer '../modules/microsoft-sql-server.bicep' = {
@@ -141,6 +126,44 @@ module communicationService '../modules/communication-services.bicep' = {
   }
 }
 
+module keyVault '../modules/key-vault.bicep' = {
+  scope: clusterResourceGroup
+  name: 'key-vault'
+  params: {
+    location: location
+    name: clusterUniqueName
+    tags: tags
+    tenantId: subscription().tenantId
+    subnetId: subnetId
+    storageAccountId: diagnosticStorageAccount.outputs.storageAccountId
+    workspaceId: existingLogAnalyticsWorkspace.id
+  }
+  dependsOn: [virtualNetwork]
+}
+
+module serviceBus '../modules/service-bus.bicep' = {
+  scope: clusterResourceGroup
+  name: 'service-bus'
+  params: {
+    location: location
+    name: clusterUniqueName
+    tags: tags
+    storageAccountId: diagnosticStorageAccount.outputs.storageAccountId
+    workspaceId: existingLogAnalyticsWorkspace.id
+  }
+}
+
+var accountManagementIdentityName = 'account-management-${resourceGroupName}'
+module accountManagementIdentity '../modules/user-assigned-managed-identity.bicep' = {
+  name: 'account-management-managed-identity'
+  scope: clusterResourceGroup
+  params: {
+    name: accountManagementIdentityName
+    location: location
+    tags: tags
+  }
+}
+
 module accountManagementDatabase '../modules/microsoft-sql-database.bicep' = {
   name: 'account-management-database'
   scope: clusterResourceGroup
@@ -151,28 +174,6 @@ module accountManagementDatabase '../modules/microsoft-sql-database.bicep' = {
     tags: tags
   }
   dependsOn: [microsoftSqlServer]
-}
-
-module containerAppsEnvironment '../modules/container-apps-environment.bicep' = {
-  scope: clusterResourceGroup
-  name: 'container-apps-environment'
-  params: {
-    location: location
-    name: '${locationPrefix}-container-apps-environment'
-    tags: tags
-    subnetId: subnetId
-  }
-  dependsOn: [virtualNetwork]
-}
-
-module accountManagementIdentity '../modules/user-assigned-managed-identity.bicep' = {
-  name: 'account-management-managed-identity'
-  scope: clusterResourceGroup
-  params: {
-    name: 'account-management-${resourceGroupName}'
-    location: location
-    tags: tags
-  }
 }
 
 module accountManagement '../modules/container-app.bicep' = {
@@ -195,7 +196,7 @@ module accountManagement '../modules/container-app.bicep' = {
     emailServicesName: clusterUniqueName
     sqlServerName: clusterUniqueName
     sqlDatabaseName: 'account-management'
-    userAssignedIdentityName: 'account-management-${resourceGroupName}'
+    userAssignedIdentityName: accountManagementIdentityName
     domainName: domainName == '' ? '' : 'account-management.${domainName}'
     domainConfigured: domainName != '' && accountManagementDomainConfigured
     applicationInsightsConnectionString: applicationInsightsConnectionString

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -14,6 +14,7 @@ param maxReplicas int = 3
 param emailServicesName string
 param sqlServerName string
 param sqlDatabaseName string
+param storageAccountName string
 param userAssignedIdentityName string
 param domainName string
 param domainConfigured bool
@@ -112,10 +113,6 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
           }
           env: [
             {
-              name: 'ConnectionStrings__${sqlDatabaseName}'
-              value: 'Server=tcp:${sqlServerName}${environment().suffixes.sqlServerHostname},1433;Initial Catalog=${sqlDatabaseName};User Id=${userAssignedIdentity.properties.clientId};Authentication=Active Directory Default;TrustServerCertificate=True;'
-            }
-            {
               name: 'MANAGED_IDENTITY_CLIENT_ID'
               value: userAssignedIdentity.properties.clientId
             }
@@ -124,16 +121,24 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
               value: applicationInsightsConnectionString
             }
             {
+              name: 'DATABASE_CONNECTION_STRING'
+              value: 'Server=tcp:${sqlServerName}${environment().suffixes.sqlServerHostname},1433;Initial Catalog=${sqlDatabaseName};User Id=${userAssignedIdentity.properties.clientId};Authentication=Active Directory Default;TrustServerCertificate=True;'
+            }
+            {
+              name: 'STORAGE_ACCOUNT_URL'
+              value: 'https://${storageAccountName}.blob.${environment().suffixes.storage}'
+            }
+            {
+              name: 'KEYVAULT_URL'
+              value: keyVault.properties.vaultUri
+            }
+            {
               name: 'PUBLIC_URL'
               value: publicUrl
             }
             {
               name: 'CDN_URL'
               value: cdnUrl
-            }
-            {
-              name: 'KEYVAULT_URL'
-              value: keyVault.properties.vaultUri
             }
             {
               name: 'SENDER_EMAIL_ADDRESS'

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -34,12 +34,12 @@ resource azureManagedDomainEmailServices 'Microsoft.Communication/emailServices/
 }
 
 var containerRegistryResourceGroupName = 'shared'
-module containerRegistryPermission './container-registry-permission.bicep' = {
+module containerRegistryPermission './role-assignments-container-registry-acr-pull.bicep' = {
   name: 'container-registry-permission'
   scope: resourceGroup(subscription().subscriptionId, containerRegistryResourceGroupName)
   params: {
     containerRegistryName: containerRegistryName
-    identityPrincipalId: userAssignedIdentity.properties.principalId
+    principalId: userAssignedIdentity.properties.principalId
   }
 }
 
@@ -175,7 +175,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
 }
 
 var keyVaultSecretsUserRoleDefinitionId = '4633458b-17de-408a-b874-0445c86b69e6' // Key Vault Secrets User role
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(keyVault.name, name, keyVaultSecretsUserRoleDefinitionId)
   scope: keyVault
   properties: {

--- a/cloud-infrastructure/modules/role-assignments-container-registry-acr-pull.bicep
+++ b/cloud-infrastructure/modules/role-assignments-container-registry-acr-pull.bicep
@@ -1,5 +1,5 @@
 param containerRegistryName string
-param identityPrincipalId string
+param principalId string
 
 resource containerRegistryResource 'Microsoft.ContainerRegistry/registries@2023-08-01-preview' existing = {
   name: containerRegistryName
@@ -7,13 +7,12 @@ resource containerRegistryResource 'Microsoft.ContainerRegistry/registries@2023-
 
 var containerRegistryPullDefinitionId = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(identityPrincipalId)
+  name: guid(principalId)
   properties: {
-    principalId: identityPrincipalId
+    principalId: principalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', containerRegistryPullDefinitionId)
   }
   scope: containerRegistryResource
 }
 
-output loginServer string = containerRegistryResource.properties.loginServer

--- a/cloud-infrastructure/modules/role-assignments-storage-blob-data-contributor.bicep
+++ b/cloud-infrastructure/modules/role-assignments-storage-blob-data-contributor.bicep
@@ -1,0 +1,24 @@
+param storageAccountName string
+param userAssignedIdentityName string = ''
+param principalId string = ''
+
+resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = if(userAssignedIdentityName != '') {
+  scope: resourceGroup()
+  name: userAssignedIdentityName ?? principalId
+}
+
+resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
+  scope: resourceGroup()
+  name: storageAccountName
+}
+
+var storageBlobDataContributorRoleDefinitionId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(existingStorageAccount.id, userAssignedIdentityName, storageBlobDataContributorRoleDefinitionId)
+  properties: {
+    principalId: userAssignedIdentityName == '' ? principalId : userAssignedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleDefinitionId)
+  }
+  scope: existingStorageAccount
+}

--- a/cloud-infrastructure/modules/storage-account.bicep
+++ b/cloud-infrastructure/modules/storage-account.bicep
@@ -3,6 +3,13 @@ param location string
 param tags object
 param sku string
 param userAssignedIdentityName string = ''
+@description('Array of containers to be created')
+param containers array = [
+  {
+    name: 'default'
+    publicAccess: 'None'
+  }
+]
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   name: name
@@ -38,6 +45,14 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
     accessTier: 'Hot'
   }
 }
+
+resource blobContainers 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = [for container in containers: {
+  name: '${name}/default/${container.name}'
+  properties: {
+    publicAccess: container.publicAccess
+  }
+  dependsOn: [storageAccount]
+}]
 
 module storageBlobDataContributorRoleAssignment 'role-assignments-storage-blob-data-contributor.bicep' = if (userAssignedIdentityName != '') {
   name: '${name}-blob-contributer-role-assignment'

--- a/cloud-infrastructure/modules/storage-account.bicep
+++ b/cloud-infrastructure/modules/storage-account.bicep
@@ -2,6 +2,7 @@ param name string
 param location string
 param tags object
 param sku string
+param userAssignedIdentityName string = ''
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   name: name
@@ -35,6 +36,14 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
       keySource: 'Microsoft.Storage'
     }
     accessTier: 'Hot'
+  }
+}
+
+module storageBlobDataContributorRoleAssignment 'role-assignments-storage-blob-data-contributor.bicep' = if (userAssignedIdentityName != '') {
+  name: '${name}-blob-contributer-role-assignment'
+  params: {
+    storageAccountName: name
+    userAssignedIdentityName: userAssignedIdentityName
   }
 }
 


### PR DESCRIPTION
### Summary & Motivation

Add a new Azure Blob Storage Container to the Account Management self-contained system for storing user profile avatars.

Introduce the `STORAGE_ACCOUNT_URL` environment variable to the container app and switch to using `DATABASE_CONNECTION_STRING` for the database, moving away from the `ConnectionStrings__${sqlDatabaseName}` format.

Update the storage account Bicep module to include the option of creating default containers as part of the infrastructure deployment, and add an `Avatars` container.

Reorganize Bicep resources to position the Container App Environment at the top and consolidate all Account Management SCS resources at the bottom.

Refactor the role-assignment module for Blob Data Contributor for clarity and consistency, and rename the existing ACR Pull role assignment module accordingly.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
