### PR TITLE
Set App gateway using YARP as reverse proxy for routing traffic between services

### DIFF
--- a/application/AppGateway/AppGateway.csproj
+++ b/application/AppGateway/AppGateway.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <AssemblyName>PlatformPlatform.AppGateway</AssemblyName>
+        <RootNamespace>PlatformPlatform.AppGateway</RootNamespace>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+</Project>

--- a/application/AppGateway/AppGateway.csproj
+++ b/application/AppGateway/AppGateway.csproj
@@ -8,4 +8,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
+    <ItemGroup>
+        <PackageReference Include="Yarp.ReverseProxy"/>
+    </ItemGroup>
+
 </Project>

--- a/application/AppGateway/ClusterDestinationConfigFilter.cs
+++ b/application/AppGateway/ClusterDestinationConfigFilter.cs
@@ -1,0 +1,42 @@
+using Yarp.ReverseProxy.Configuration;
+
+namespace PlatformPlatform.AppGateway;
+
+public class ClusterDestinationConfigFilter : IProxyConfigFilter
+{
+    public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel)
+    {
+        return cluster.ClusterId switch
+        {
+            "account-management" => ReplaceDestinationAddress(cluster, "ACCOUNT_MANAGEMENT_URL"),
+            "account-management-storage" => ReplaceDestinationAddress(cluster, "ACCOUNT_MANAGEMENT_STORAGE_URL"),
+            _ => throw new InvalidOperationException($"Unknown Cluster ID {cluster.ClusterId}")
+        };
+    }
+
+    public ValueTask<RouteConfig> ConfigureRouteAsync(
+        RouteConfig route,
+        ClusterConfig? cluster,
+        CancellationToken cancel
+    )
+    {
+        return new ValueTask<RouteConfig>(route);
+    }
+
+    private static ValueTask<ClusterConfig> ReplaceDestinationAddress(ClusterConfig cluster, string environmentVariable)
+    {
+        var destinationAddress = Environment.GetEnvironmentVariable(environmentVariable);
+        if (destinationAddress is null) return new ValueTask<ClusterConfig>(cluster);
+
+        // Each cluster has a dictionary with one and only one destination
+        var destination = cluster.Destinations!.Single();
+
+        // This is read-only, so we'll create a new one with our updates
+        var newDestinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
+        {
+            { destination.Key, destination.Value with { Address = destinationAddress } }
+        };
+
+        return new ValueTask<ClusterConfig>(cluster with { Destinations = newDestinations });
+    }
+}

--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -1,6 +1,13 @@
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services
+    .AddReverseProxy()
+    .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
+
 var app = builder.Build();
 
-app.MapGet("/", () => "Hello World!");
+app.UseHttpsRedirection();
+
+app.MapReverseProxy();
 
 app.Run();

--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -7,6 +7,8 @@ builder.Services
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"))
     .AddConfigFilter<ClusterDestinationConfigFilter>();
 
+builder.WebHost.UseKestrel(option => option.AddServerHeader = false);
+
 var app = builder.Build();
 
 app.UseHttpsRedirection();

--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -1,8 +1,11 @@
+using PlatformPlatform.AppGateway;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services
     .AddReverseProxy()
-    .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
+    .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"))
+    .AddConfigFilter<ClusterDestinationConfigFilter>();
 
 var app = builder.Build();
 

--- a/application/AppGateway/Properties/launchSettings.json
+++ b/application/AppGateway/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+﻿{
+  "profiles": {
+    "Api": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "",
+      "applicationUrl": "https://localhost:8002"
+    }
+  }
+}

--- a/application/AppGateway/Properties/launchSettings.json
+++ b/application/AppGateway/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "",
-      "applicationUrl": "https://localhost:8002"
+      "applicationUrl": "https://localhost:9000"
     }
   }
 }

--- a/application/AppGateway/appsettings.json
+++ b/application/AppGateway/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/application/AppGateway/appsettings.json
+++ b/application/AppGateway/appsettings.json
@@ -4,5 +4,43 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "AllowedHosts": "*",
+  "ReverseProxy": {
+    "Routes": {
+      "account-management-route": {
+        "ClusterId": "account-management",
+        "Match": {
+          "Path": "/{**catch-all}"
+        }
+      },
+      "avatars": {
+        "ClusterId": "account-management-storage",
+        "Match": {
+          "Path": "/avatars/{**catchall}"
+        },
+        "Transforms": [
+          {
+            "PathPattern": "/avatars/{**catchall}"
+          }
+        ]
+      }
+    },
+    "Clusters": {
+      "account-management": {
+        "Destinations": {
+          "destination": {
+            "Address": "https://localhost:8443"
+          }
+        }
+      },
+      "account-management-storage": {
+        "Destinations": {
+          "destination": {
+            "Address": "http://127.0.0.1:10000/devstoreaccount1"
+          }
+        }
+      }
+    }
   }
 }

--- a/application/AppGateway/appsettings.json
+++ b/application/AppGateway/appsettings.json
@@ -30,7 +30,7 @@
       "account-management": {
         "Destinations": {
           "destination": {
-            "Address": "https://localhost:8443"
+            "Address": "https://localhost:9100"
           }
         }
       },

--- a/application/AppHost/AppHost.csproj
+++ b/application/AppHost/AppHost.csproj
@@ -9,8 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="../account-management/Api/Api.csproj"/>
-        <ProjectReference Include="../account-management/WebApp/WebApp.esproj"/>
+        <ProjectReference Include="..\account-management\Api\Api.csproj"/>
+        <ProjectReference Include="..\account-management\WebApp\WebApp.esproj"/>
+        <ProjectReference Include="..\AppGateway\AppGateway.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -22,12 +22,17 @@ var accountManagementApi = builder
     .WithReference(database)
     .WithReference(accountManagementStorage);
 
-builder
+var accountManagementSpa = builder
     .AddNpmApp("account-management-spa", "../account-management/WebApp", "dev")
     .WithReference(accountManagementApi);
 
 builder.AddContainer("email-test-server", "mailhog/mailhog")
     .WithEndpoint(hostPort: 8025, containerPort: 8025, scheme: "http")
     .WithEndpoint(hostPort: 1025, containerPort: 1025);
+
+builder
+    .AddProject<AppGateway>("app-gateway")
+    .WithReference(accountManagementApi)
+    .WithReference(accountManagementSpa);
 
 builder.Build().Run();

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -4,7 +4,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var sqlServerPassword = Environment.GetEnvironmentVariable("SQL_SERVER_PASSWORD");
 var sqlServer = builder
-    .AddSqlServer("sql-server", sqlServerPassword, 8433)
+    .AddSqlServer("sql-server", sqlServerPassword, 9002)
     .WithVolumeMount("sql-server-data", "/var/opt/mssql");
 
 var azureStorage = builder
@@ -18,8 +18,8 @@ var azureStorage = builder
 
 builder
     .AddContainer("mail-server", "mailhog/mailhog")
-    .WithEndpoint(hostPort: 8025, containerPort: 8025, scheme: "http")
-    .WithEndpoint(hostPort: 1025, containerPort: 1025);
+    .WithEndpoint(hostPort: 9003, containerPort: 8025, scheme: "http")
+    .WithEndpoint(hostPort: 9004, containerPort: 1025);
 
 var accountManagementDatabase = sqlServer
     .AddDatabase("account-management-database", "account-management");

--- a/application/AppHost/Properties/launchSettings.json
+++ b/application/AppHost/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:8001",
+      "applicationUrl": "https://localhost:9001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",

--- a/application/PlatformPlatform.sln
+++ b/application/PlatformPlatform.sln
@@ -31,6 +31,8 @@ Project("{54A90642-561A-4BB1-A94E-469ADEE60C69}") = "WebApp", "account-managemen
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppHost", "AppHost\AppHost.csproj", "{2D6D4E5B-983A-4AAB-A91E-5492F7FD52E8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppGateway", "AppGateway\AppGateway.csproj", "{8A9E566E-2DE4-4A60-9030-615C939BC05C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -87,6 +89,10 @@ Global
 		{2D6D4E5B-983A-4AAB-A91E-5492F7FD52E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D6D4E5B-983A-4AAB-A91E-5492F7FD52E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D6D4E5B-983A-4AAB-A91E-5492F7FD52E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A9E566E-2DE4-4A60-9030-615C939BC05C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A9E566E-2DE4-4A60-9030-615C939BC05C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A9E566E-2DE4-4A60-9030-615C939BC05C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A9E566E-2DE4-4A60-9030-615C939BC05C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{836ABCEF-C16B-4331-B8D5-0EA75E4101FE} = {F01E4DC8-2A8B-4CB9-893A-B3B8FF2EFE22}

--- a/application/account-management/Api/Properties/launchSettings.json
+++ b/application/account-management/Api/Properties/launchSettings.json
@@ -6,10 +6,10 @@
       "launchUrl": "",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",
-        "PUBLIC_URL": "https://localhost:8002",
-        "CDN_URL": "https://localhost:8444"
+        "PUBLIC_URL": "https://localhost:9000",
+        "CDN_URL": "https://localhost:9099"
       },
-      "applicationUrl": "https://localhost:8443"
+      "applicationUrl": "https://localhost:9100"
     }
   }
 }

--- a/application/account-management/Api/Properties/launchSettings.json
+++ b/application/account-management/Api/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "launchUrl": "",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",
-        "PUBLIC_URL": "https://localhost:8443",
+        "PUBLIC_URL": "https://localhost:8002",
         "CDN_URL": "https://localhost:8444"
       },
       "applicationUrl": "https://localhost:8443"

--- a/application/account-management/Infrastructure/InfrastructureConfiguration.cs
+++ b/application/account-management/Infrastructure/InfrastructureConfiguration.cs
@@ -13,7 +13,7 @@ public static class InfrastructureConfiguration
         IHostApplicationBuilder builder
     )
     {
-        services.ConfigureDatabaseContext<AccountManagementDbContext>(builder, "account-management");
+        services.ConfigureDatabaseContext<AccountManagementDbContext>(builder, "account-management-database");
 
         return services;
     }

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -20,8 +20,8 @@ public abstract class BaseApiTests<TContext> : BaseTest<TContext> where TContext
 
     protected BaseApiTests()
     {
-        Environment.SetEnvironmentVariable(WebAppMiddlewareConfiguration.PublicUrlKey, "https://localhost:8444");
-        Environment.SetEnvironmentVariable(WebAppMiddlewareConfiguration.CdnUrlKey, "https://localhost:8444");
+        Environment.SetEnvironmentVariable(WebAppMiddlewareConfiguration.PublicUrlKey, "https://localhost:9000");
+        Environment.SetEnvironmentVariable(WebAppMiddlewareConfiguration.CdnUrlKey, "https://localhost:9099");
 
         _webApplicationFactory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
         {

--- a/application/account-management/WebApp/rspack.config.ts
+++ b/application/account-management/WebApp/rspack.config.ts
@@ -146,7 +146,7 @@ const configuration: Configuration = {
     headers: {
       "Access-Control-Allow-Origin": "*",
     },
-    port: 8444,
+    port: 9099,
     server: {
       type: "https",
       options: {

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -25,7 +25,7 @@ public static class InfrastructureCoreConfiguration
         string connectionName
     ) where T : DbContext
     {
-        var connectionString = builder.Configuration.GetConnectionString("account-management");
+        var connectionString = builder.Configuration.GetConnectionString(connectionName);
         builder.Services.AddSqlServer<T>(connectionString, optionsBuilder => { optionsBuilder.UseAzureSqlDefaults(); });
         builder.EnrichSqlServerDbContext<T>();
 

--- a/application/shared-kernel/InfrastructureCore/Services/DevelopmentEmailService.cs
+++ b/application/shared-kernel/InfrastructureCore/Services/DevelopmentEmailService.cs
@@ -6,7 +6,7 @@ namespace PlatformPlatform.SharedKernel.InfrastructureCore.Services;
 public sealed class DevelopmentEmailService : IEmailService
 {
     private const string Sender = "no-reply@localhost";
-    private readonly SmtpClient _emailSender = new("localhost", 1025);
+    private readonly SmtpClient _emailSender = new("localhost", 9004);
 
     public Task SendAsync(
         string recipient,

--- a/developer-cli/Commands/RunCommand.cs
+++ b/developer-cli/Commands/RunCommand.cs
@@ -24,9 +24,9 @@ public class RunCommand : Command
         Task.Run(async () =>
         {
             // Start a background task that monitors the websites and opens the browser when ready
-            const int aspireDashboardPort = 9000;
+            const int aspireDashboardPort = 9001;
             await StartBrowserWhenSiteIsReady(aspireDashboardPort);
-            const int appPort = 9001;
+            const int appPort = 9000;
             await StartBrowserWhenSiteIsReady(appPort);
         });
 

--- a/developer-cli/Commands/RunCommand.cs
+++ b/developer-cli/Commands/RunCommand.cs
@@ -24,10 +24,10 @@ public class RunCommand : Command
         Task.Run(async () =>
         {
             // Start a background task that monitors the websites and opens the browser when ready
-            const int aspireDashboardPort = 8001;
+            const int aspireDashboardPort = 9000;
             await StartBrowserWhenSiteIsReady(aspireDashboardPort);
-            const int accountManagementPort = 8443;
-            await StartBrowserWhenSiteIsReady(accountManagementPort);
+            const int appPort = 9001;
+            await StartBrowserWhenSiteIsReady(appPort);
         });
 
         ProcessHelper.StartProcess("dotnet run", workingDirectory);


### PR DESCRIPTION
### Summary & Motivation

Create a new AppGateway project utilizing YARP to configure traffic routing to the Account Management API. Implement YARP routing to direct all traffic on `/` to the Account Management API, but all traffic on `/avatars/**` to the new `avatars` container within Account Management blob storage. This effectively makes the blob storage available on the main domain.

On localhost, YARP is configured to direct all traffic to the correct container. On production, the routing is updated based on environment variables, to use the correct blob storage and Azure Container App URLs.

Refactor Aspire AppHost for enhanced clarity and logical project ordering, with more descriptive names. For instance, rename `account-management-db` to `sql-server` and `account-management-storage` to `azure-storage-data` to highlight their global roles.

Adjust port assignments to distinguish "global" services and Account Management services more clearly. Global services now use port 90xx, while Account Management services use port 91xx. For example, AppGateway is accessible at https://localhost:9000, and the Aspire Dashboard at https://localhost:9001.

The Developer CLI `pp run` command is updated to start the gateway at https://localhost:9000.


### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
