### PR TITLE
Change API container image to use jammy-chiseled-extra container image which includes ICU libraries

### DIFF
--- a/application/account-management/Api/Api.csproj
+++ b/application/account-management/Api/Api.csproj
@@ -9,7 +9,7 @@
         <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/../WebApp/lib/api/</OpenApiDocumentsDirectory>
         <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>
         <OpenApiGenerateDocumentsOnBuild>true</OpenApiGenerateDocumentsOnBuild>
-        <ContainerFamily>alpine</ContainerFamily>
+        <ContainerFamily>jammy-chiseled-extra</ContainerFamily>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Summary & Motivation

The Alpine container image used to deploy the API failed when running Entity Framework queries, with a `CultureNotFoundException` (see this GitHub Issue: https://github.com/dotnet/SqlClient/issues/2239).

The root cause is that the SqlClient doesn't support invariant globalization.

The solution requires that the docker container has ICU libraries installed. Using a Dockerfile, this would be simple, but since we are using `dotnet publish -t:PublishContainer ...` we change the container image from `alpine` to `jammy-chiseled-extra`. Not a perfect solution as this image is bigger, and hence also has a bigger attack surface.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
