### PR TITLE
Introduce user avatars with Gravatar fallback and YARP for public sharing of private blobs

### DIFF
--- a/application/AppGateway/AppGateway.csproj
+++ b/application/AppGateway/AppGateway.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ContainerPort Include="8080" Type="tcp" />
+        <ContainerPort Include="8080" Type="tcp"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/application/AppGateway/AppGateway.csproj
+++ b/application/AppGateway/AppGateway.csproj
@@ -17,4 +17,8 @@
         <PackageReference Include="Yarp.ReverseProxy"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\shared-kernel\InfrastructureCore\InfrastructureCore.csproj"/>
+    </ItemGroup>
+
 </Project>

--- a/application/AppGateway/ClusterDestinationConfigFilter.cs
+++ b/application/AppGateway/ClusterDestinationConfigFilter.cs
@@ -8,8 +8,8 @@ public class ClusterDestinationConfigFilter : IProxyConfigFilter
     {
         return cluster.ClusterId switch
         {
-            "account-management" => ReplaceDestinationAddress(cluster, "ACCOUNT_MANAGEMENT_URL"),
-            "account-management-storage" => ReplaceDestinationAddress(cluster, "ACCOUNT_MANAGEMENT_STORAGE_URL"),
+            "account-management-api" => ReplaceDestinationAddress(cluster, "ACCOUNT_MANAGEMENT_API_URL"),
+            "avatars-storage" => ReplaceDestinationAddress(cluster, "AVATARS_STORAGE_URL"),
             _ => throw new InvalidOperationException($"Unknown Cluster ID {cluster.ClusterId}")
         };
     }

--- a/application/AppGateway/ManagedIdentityTransform.cs
+++ b/application/AppGateway/ManagedIdentityTransform.cs
@@ -1,0 +1,28 @@
+using Azure.Core;
+using Yarp.ReverseProxy.Transforms;
+
+namespace PlatformPlatform.AppGateway;
+
+public class ManagedIdentityTransform(TokenCredential credential)
+    : RequestHeaderTransform("Authorization", false)
+{
+    protected override string? GetValue(RequestTransformContext context)
+    {
+        if (!context.HttpContext.Request.Path.StartsWithSegments("/avatars")) return null;
+
+        var tokenRequestContext = new TokenRequestContext(["https://storage.azure.com/.default"]);
+        var token = credential.GetToken(tokenRequestContext, context.HttpContext.RequestAborted);
+        return $"Bearer {token.Token}";
+    }
+}
+
+public class ApiVersionHeaderTransform()
+    : RequestHeaderTransform("x-ms-version", false)
+{
+    protected override string? GetValue(RequestTransformContext context)
+    {
+        if (!context.HttpContext.Request.Path.StartsWithSegments("/avatars")) return null;
+
+        return "2023-11-03";
+    }
+}

--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -4,7 +4,7 @@ using PlatformPlatform.SharedKernel.InfrastructureCore;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSingleton<SharedAccessSignatureRequestTransform>();
-builder.Services.AddBlobStorage(builder, ("account-management-storage", "ACCOUNT_MANAGEMENT_STORAGE_URL"));
+builder.Services.AddNamedBlobStorages(builder, ("avatars-storage", "AVATARS_STORAGE_URL"));
 
 builder.Services
     .AddReverseProxy()

--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -4,7 +4,7 @@ using PlatformPlatform.SharedKernel.InfrastructureCore;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSingleton<SharedAccessSignatureRequestTransform>();
-builder.Services.AddBlobStorage(builder, "account-management-storage");
+builder.Services.AddBlobStorage(builder, ("account-management-storage", "ACCOUNT_MANAGEMENT_STORAGE_URL"));
 
 builder.Services
     .AddReverseProxy()

--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -1,11 +1,19 @@
 using PlatformPlatform.AppGateway;
+using PlatformPlatform.SharedKernel.InfrastructureCore;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<SharedAccessSignatureRequestTransform>();
+builder.Services.AddBlobStorage(builder, "account-management-storage");
 
 builder.Services
     .AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"))
-    .AddConfigFilter<ClusterDestinationConfigFilter>();
+    .AddConfigFilter<ClusterDestinationConfigFilter>()
+    .AddTransforms(context =>
+    {
+        context.RequestTransforms.Add(context.Services.GetRequiredService<SharedAccessSignatureRequestTransform>());
+    });
 
 builder.WebHost.UseKestrel(option => option.AddServerHeader = false);
 

--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -1,9 +1,20 @@
+using Azure.Core;
 using PlatformPlatform.AppGateway;
 using PlatformPlatform.SharedKernel.InfrastructureCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddSingleton<SharedAccessSignatureRequestTransform>();
+if (InfrastructureCoreConfiguration.IsRunningInAzure)
+{
+    builder.Services.AddSingleton<ManagedIdentityTransform>();
+    builder.Services.AddSingleton<ApiVersionHeaderTransform>();
+    builder.Services.AddSingleton<TokenCredential>(InfrastructureCoreConfiguration.GetDefaultAzureCredential());
+}
+else
+{
+    builder.Services.AddSingleton<SharedAccessSignatureRequestTransform>();
+}
+
 builder.Services.AddNamedBlobStorages(builder, ("avatars-storage", "AVATARS_STORAGE_URL"));
 
 builder.Services
@@ -12,7 +23,15 @@ builder.Services
     .AddConfigFilter<ClusterDestinationConfigFilter>()
     .AddTransforms(context =>
     {
-        context.RequestTransforms.Add(context.Services.GetRequiredService<SharedAccessSignatureRequestTransform>());
+        if (InfrastructureCoreConfiguration.IsRunningInAzure)
+        {
+            context.RequestTransforms.Add(context.Services.GetRequiredService<ManagedIdentityTransform>());
+            context.RequestTransforms.Add(context.Services.GetRequiredService<ApiVersionHeaderTransform>());
+        }
+        else
+        {
+            context.RequestTransforms.Add(context.Services.GetRequiredService<SharedAccessSignatureRequestTransform>());
+        }
     });
 
 builder.WebHost.UseKestrel(option => option.AddServerHeader = false);

--- a/application/AppGateway/SharedAccessSignatureRequestTransform.cs
+++ b/application/AppGateway/SharedAccessSignatureRequestTransform.cs
@@ -3,17 +3,15 @@ using Yarp.ReverseProxy.Transforms;
 
 namespace PlatformPlatform.AppGateway;
 
-public class SharedAccessSignatureRequestTransform(
-    [FromKeyedServices("account-management-storage")] IBlobStorage blobStorage
-) : RequestTransform
+public class SharedAccessSignatureRequestTransform([FromKeyedServices("avatars-storage")] IBlobStorage blobStorage)
+    : RequestTransform
 {
     public override ValueTask ApplyAsync(RequestTransformContext context)
     {
-        if (context.Path.StartsWithSegments("/avatars"))
-        {
-            var sharedAccessSignature = blobStorage.GetSharedAccessSignature("avatars", TimeSpan.FromMinutes(10));
-            context.HttpContext.Request.QueryString = new QueryString(sharedAccessSignature);
-        }
+        if (!context.Path.StartsWithSegments("/avatars")) return ValueTask.CompletedTask;
+
+        var sharedAccessSignature = blobStorage.GetSharedAccessSignature("avatars", TimeSpan.FromMinutes(10));
+        context.HttpContext.Request.QueryString = new QueryString(sharedAccessSignature);
 
         return ValueTask.CompletedTask;
     }

--- a/application/AppGateway/SharedAccessSignatureRequestTransform.cs
+++ b/application/AppGateway/SharedAccessSignatureRequestTransform.cs
@@ -3,7 +3,9 @@ using Yarp.ReverseProxy.Transforms;
 
 namespace PlatformPlatform.AppGateway;
 
-public class SharedAccessSignatureRequestTransform(IBlobStorage blobStorage) : RequestTransform
+public class SharedAccessSignatureRequestTransform(
+    [FromKeyedServices("account-management-storage")] IBlobStorage blobStorage
+) : RequestTransform
 {
     public override ValueTask ApplyAsync(RequestTransformContext context)
     {

--- a/application/AppGateway/SharedAccessSignatureRequestTransform.cs
+++ b/application/AppGateway/SharedAccessSignatureRequestTransform.cs
@@ -1,0 +1,18 @@
+using PlatformPlatform.SharedKernel.ApplicationCore.Services;
+using Yarp.ReverseProxy.Transforms;
+
+namespace PlatformPlatform.AppGateway;
+
+public class SharedAccessSignatureRequestTransform(IBlobStorage blobStorage) : RequestTransform
+{
+    public override ValueTask ApplyAsync(RequestTransformContext context)
+    {
+        if (context.Path.StartsWithSegments("/avatars"))
+        {
+            var sharedAccessSignature = blobStorage.GetSharedAccessSignature("avatars", TimeSpan.FromMinutes(10));
+            context.HttpContext.Request.QueryString = new QueryString(sharedAccessSignature);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/application/AppGateway/appsettings.json
+++ b/application/AppGateway/appsettings.json
@@ -5,6 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "account-management-storage": "UseDevelopmentStorage=true"
+  },
   "AllowedHosts": "*",
   "ReverseProxy": {
     "Routes": {

--- a/application/AppGateway/appsettings.json
+++ b/application/AppGateway/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "account-management-storage": "UseDevelopmentStorage=true"
+    "blob-storage": "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"
   },
   "AllowedHosts": "*",
   "ReverseProxy": {

--- a/application/AppGateway/appsettings.json
+++ b/application/AppGateway/appsettings.json
@@ -25,6 +25,10 @@
         "Transforms": [
           {
             "PathPattern": "/avatars/{**catchall}"
+          },
+          {
+            "ResponseHeader": "Cache-Control",
+            "Set": "public, max-age=2592000, immutable"
           }
         ]
       }

--- a/application/AppGateway/appsettings.json
+++ b/application/AppGateway/appsettings.json
@@ -12,13 +12,13 @@
   "ReverseProxy": {
     "Routes": {
       "account-management-route": {
-        "ClusterId": "account-management",
+        "ClusterId": "account-management-api",
         "Match": {
           "Path": "/{**catch-all}"
         }
       },
       "avatars": {
-        "ClusterId": "account-management-storage",
+        "ClusterId": "avatars-storage",
         "Match": {
           "Path": "/avatars/{**catchall}"
         },
@@ -34,14 +34,14 @@
       }
     },
     "Clusters": {
-      "account-management": {
+      "account-management-api": {
         "Destinations": {
           "destination": {
             "Address": "https://localhost:9100"
           }
         }
       },
-      "account-management-storage": {
+      "avatars-storage": {
         "Destinations": {
           "destination": {
             "Address": "http://127.0.0.1:10000/devstoreaccount1"

--- a/application/AppHost/AppHost.csproj
+++ b/application/AppHost/AppHost.csproj
@@ -15,6 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Aspire.Azure.Storage.Blobs"/>
         <PackageReference Include="Aspire.Hosting.Azure"/>
         <PackageReference Include="Aspire.Hosting"/>
     </ItemGroup>

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -1,3 +1,5 @@
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
 using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -24,6 +26,8 @@ builder
 var accountManagementDatabase = sqlServer
     .AddDatabase("account-management-database", "account-management");
 
+CreateBlobContainer("avatars");
+
 var accountManagementApi = builder
     .AddProject<Api>("account-management-api")
     .WithReference(accountManagementDatabase)
@@ -39,3 +43,17 @@ builder
     .WithReference(accountManagementSpa);
 
 builder.Build().Run();
+
+return;
+
+void CreateBlobContainer(string containerName)
+{
+    var connectionString = builder.Configuration.GetConnectionString("account-management-storage");
+
+    new Task(() =>
+    {
+        var blobServiceClient = new BlobServiceClient(connectionString);
+        var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+        containerClient.CreateIfNotExists();
+    }).Start();
+}

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -48,7 +48,7 @@ return;
 
 void CreateBlobContainer(string containerName)
 {
-    var connectionString = builder.Configuration.GetConnectionString("account-management-storage");
+    var connectionString = builder.Configuration.GetConnectionString("blob-storage");
 
     new Task(() =>
     {

--- a/application/AppHost/appsettings.Development.json
+++ b/application/AppHost/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}

--- a/application/AppHost/appsettings.json
+++ b/application/AppHost/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "account-management-storage": "UseDevelopmentStorage=true"
   }
 }

--- a/application/AppHost/appsettings.json
+++ b/application/AppHost/appsettings.json
@@ -7,6 +7,6 @@
     }
   },
   "ConnectionStrings": {
-    "account-management-storage": "UseDevelopmentStorage=true"
+    "blob-storage": "UseDevelopmentStorage=true"
   }
 }

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -30,6 +30,7 @@
     <PackageVersion Include="NSwag.MSBuild" Version="14.0.7" />
     <PackageVersion Include="NUlid" Version="1.7.2" />
     <!-- PlatformPlatform dependencies - Infrastructure -->
+    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="$(AspireVersion)" />
     <PackageVersion Include="Azure.Communication.Email" Version="1.0.1" />
     <PackageVersion Include="Aspire.Hosting.Azure" Version="$(AspireVersion)" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />

--- a/application/account-management/Api/Api.csproj
+++ b/application/account-management/Api/Api.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ContainerPort Include="8080" Type="tcp" />
+        <ContainerPort Include="8080" Type="tcp"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/application/account-management/Api/Program.cs
+++ b/application/account-management/Api/Program.cs
@@ -10,9 +10,9 @@ var builder = WebApplication.CreateBuilder(args);
 // FluentValidation validators, Pipelines.
 builder.Services
     .AddApplicationServices()
-    .ConfigureStorage(builder)
     .AddInfrastructureServices()
     .AddApiCoreServices(builder, Assembly.GetExecutingAssembly(), DomainConfiguration.Assembly)
+    .ConfigureStorage(builder)
     .AddWebAppMiddleware();
 
 var app = builder.Build();

--- a/application/account-management/Api/Program.cs
+++ b/application/account-management/Api/Program.cs
@@ -10,7 +10,7 @@ var builder = WebApplication.CreateBuilder(args);
 // FluentValidation validators, Pipelines.
 builder.Services
     .AddApplicationServices()
-    .AddDatabaseContext(builder)
+    .ConfigureStorage(builder)
     .AddInfrastructureServices()
     .AddApiCoreServices(builder, Assembly.GetExecutingAssembly(), DomainConfiguration.Assembly)
     .AddWebAppMiddleware();

--- a/application/account-management/Api/Users/UserEndpoints.cs
+++ b/application/account-management/Api/Users/UserEndpoints.cs
@@ -13,8 +13,9 @@ public class UserEndpoints : IEndpoints
     {
         var group = routes.MapGroup(RoutesPrefix);
 
-        group.MapGet("/", async Task<ApiResult<SearchUsersDto>> ([AsParameters] GetUsersQuery query, ISender mediator)
-            => await mediator.Send(query));
+        group.MapGet("/",
+            async Task<ApiResult<GetUsersResponseDto>> ([AsParameters] GetUsersQuery query, ISender mediator)
+                => await mediator.Send(query));
 
         group.MapGet("/{id}",
             async Task<ApiResult<UserResponseDto>> ([AsParameters] GetUserQuery query, ISender mediator)

--- a/application/account-management/Api/Users/UserEndpoints.cs
+++ b/application/account-management/Api/Users/UserEndpoints.cs
@@ -29,5 +29,15 @@ public class UserEndpoints : IEndpoints
 
         group.MapDelete("/{id}", async Task<ApiResult> ([AsParameters] DeleteUserCommand command, ISender mediator)
             => await mediator.Send(command));
+
+        // Id should be inferred from the authenticated user
+        group.MapPost("/{id}/update-avatar", async Task<ApiResult> (UserId id, IFormFile file, ISender mediator)
+                => await mediator.Send(new UpdateAvatarCommand(id, file.OpenReadStream(), file.ContentType)))
+            .DisableAntiforgery(); // Disable antiforgery until we implement it
+
+        // Id should be inferred from the authenticated user
+        group.MapPost("/{id}/remove-avatar",
+            async Task<ApiResult> ([AsParameters] RemoveAvatarCommand command, ISender mediator)
+                => await mediator.Send(command));
     }
 }

--- a/application/account-management/Api/appsettings.development.json
+++ b/application/account-management/Api/appsettings.development.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Information"
     }
+  },
+  "ConnectionStrings": {
+    "account-management-storage": "UseDevelopmentStorage=true"
   }
 }

--- a/application/account-management/Api/appsettings.development.json
+++ b/application/account-management/Api/appsettings.development.json
@@ -7,6 +7,6 @@
     }
   },
   "ConnectionStrings": {
-    "account-management-storage": "UseDevelopmentStorage=true"
+    "blob-storage": "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"
   }
 }

--- a/application/account-management/Application/TelemetryEvents/TelemetryEvents.cs
+++ b/application/account-management/Application/TelemetryEvents/TelemetryEvents.cs
@@ -40,3 +40,9 @@ public sealed class UserDeleted()
 
 public sealed class UserUpdated()
     : TelemetryEvent(nameof(UserUpdated));
+
+public sealed class UserAvatarUpdated(string contentType, long size)
+    : TelemetryEvent(nameof(UserAvatarUpdated), ("ContentType", contentType), ("Size", size.ToString()));
+
+public sealed class UserAvatarRemoved()
+    : TelemetryEvent(nameof(UserAvatarUpdated));

--- a/application/account-management/Application/TelemetryEvents/TelemetryEvents.cs
+++ b/application/account-management/Application/TelemetryEvents/TelemetryEvents.cs
@@ -31,8 +31,9 @@ public sealed class TenantDeleted(TenantId tenantId, TenantState tenantState)
 public sealed class TenantUpdated(TenantId tenantId)
     : TelemetryEvent(nameof(TenantUpdated), ("TenantId", tenantId));
 
-public sealed class UserCreated(TenantId tenantId)
-    : TelemetryEvent(nameof(UserCreated), ("TenantId", tenantId));
+public sealed class UserCreated(TenantId tenantId, bool gravatarProfileFound)
+    : TelemetryEvent(nameof(UserCreated), ("TenantId", tenantId),
+        ("GravatarProfileFound", gravatarProfileFound.ToString()));
 
 public sealed class UserDeleted()
     : TelemetryEvent(nameof(UserDeleted));

--- a/application/account-management/Application/Users/CreateUser.cs
+++ b/application/account-management/Application/Users/CreateUser.cs
@@ -19,7 +19,7 @@ public sealed class CreateUserHandler(IUserRepository userRepository, ITelemetry
 {
     public async Task<Result<UserId>> Handle(CreateUserCommand command, CancellationToken cancellationToken)
     {
-        var user = User.Create(command.TenantId, command.Email, command.UserRole, command.EmailConfirmed);
+        var user = User.Create(command.TenantId, command.Email, command.UserRole, command.EmailConfirmed, null);
         await userRepository.AddAsync(user, cancellationToken);
 
         events.CollectEvent(new UserCreated(command.TenantId));

--- a/application/account-management/Application/Users/CreateUser.cs
+++ b/application/account-management/Application/Users/CreateUser.cs
@@ -1,3 +1,6 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
 using FluentValidation;
 using PlatformPlatform.AccountManagement.Application.TelemetryEvents;
 using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
@@ -5,26 +8,35 @@ using PlatformPlatform.SharedKernel.ApplicationCore.TelemetryEvents;
 
 namespace PlatformPlatform.AccountManagement.Application.Users;
 
-public sealed record CreateUserCommand(
-    TenantId TenantId,
-    string Email,
-    UserRole UserRole,
-    bool EmailConfirmed
-)
+public sealed record CreateUserCommand(TenantId TenantId, string Email, UserRole UserRole, bool EmailConfirmed)
     : ICommand, IUserValidation, IRequest<Result<UserId>>;
 
 [UsedImplicitly]
 public sealed class CreateUserHandler(IUserRepository userRepository, ITelemetryEventsCollector events)
     : IRequestHandler<CreateUserCommand, Result<UserId>>
 {
+    private static readonly HttpClient Client = new();
+
     public async Task<Result<UserId>> Handle(CreateUserCommand command, CancellationToken cancellationToken)
     {
-        var user = User.Create(command.TenantId, command.Email, command.UserRole, command.EmailConfirmed, null);
+        var gravatarUrl = await GetGravatarProfileUrlIfExists(command.Email);
+
+        var user = User.Create(command.TenantId, command.Email, command.UserRole, command.EmailConfirmed, gravatarUrl);
+
         await userRepository.AddAsync(user, cancellationToken);
 
-        events.CollectEvent(new UserCreated(command.TenantId));
+        events.CollectEvent(new UserCreated(command.TenantId, gravatarUrl is not null));
 
         return user.Id;
+    }
+
+    private async Task<string?> GetGravatarProfileUrlIfExists(string email)
+    {
+        var hash = Convert.ToHexString(MD5.HashData(Encoding.ASCII.GetBytes(email)));
+        var gravatarUrl = $"https://gravatar.com/avatar/{hash.ToLowerInvariant()}";
+        // The d=404 instructs Gravatar to return 404 the email has no Gravatar account
+        var httpResponseMessage = await Client.GetAsync($"{gravatarUrl}?d=404");
+        return httpResponseMessage.StatusCode == HttpStatusCode.OK ? gravatarUrl : null;
     }
 }
 

--- a/application/account-management/Application/Users/GetUsers.cs
+++ b/application/account-management/Application/Users/GetUsers.cs
@@ -13,13 +13,13 @@ public sealed record GetUsersQuery(
     int? PageSize = null,
     int? PageOffset = null
 )
-    : IRequest<Result<SearchUsersDto>>;
+    : IRequest<Result<GetUsersResponseDto>>;
 
 [UsedImplicitly]
 public sealed class GetUsersHandler(IUserRepository userRepository)
-    : IRequestHandler<GetUsersQuery, Result<SearchUsersDto>>
+    : IRequestHandler<GetUsersQuery, Result<GetUsersResponseDto>>
 {
-    public async Task<Result<SearchUsersDto>> Handle(GetUsersQuery query, CancellationToken cancellationToken)
+    public async Task<Result<GetUsersResponseDto>> Handle(GetUsersQuery query, CancellationToken cancellationToken)
     {
         var (users, count, totalPages) = await userRepository.Search(
             query.Search,
@@ -32,6 +32,6 @@ public sealed class GetUsersHandler(IUserRepository userRepository)
         );
 
         var userResponseDtos = users.Select(u => u.Adapt<UserResponseDto>()).ToArray();
-        return new SearchUsersDto(count, totalPages, query.PageOffset ?? 0, userResponseDtos);
+        return new GetUsersResponseDto(count, totalPages, query.PageOffset ?? 0, userResponseDtos);
     }
 }

--- a/application/account-management/Application/Users/GetUsers.cs
+++ b/application/account-management/Application/Users/GetUsers.cs
@@ -31,7 +31,7 @@ public sealed class GetUsersHandler(IUserRepository userRepository)
             cancellationToken
         );
 
-        var userResponseDtos = users.Select(u => u.Adapt<UserResponseDto>()).ToArray();
+        var userResponseDtos = users.Adapt<UserResponseDto[]>();
         return new GetUsersResponseDto(count, totalPages, query.PageOffset ?? 0, userResponseDtos);
     }
 }

--- a/application/account-management/Application/Users/GetUsersDto.cs
+++ b/application/account-management/Application/Users/GetUsersDto.cs
@@ -1,4 +1,0 @@
-namespace PlatformPlatform.AccountManagement.Application.Users;
-
-[UsedImplicitly]
-public sealed record SearchUsersDto(int TotalCount, int TotalPages, int CurrentPageOffset, UserResponseDto[] Users);

--- a/application/account-management/Application/Users/GetUsersResponseDto.cs
+++ b/application/account-management/Application/Users/GetUsersResponseDto.cs
@@ -1,0 +1,9 @@
+namespace PlatformPlatform.AccountManagement.Application.Users;
+
+[UsedImplicitly]
+public sealed record GetUsersResponseDto(
+    int TotalCount,
+    int TotalPages,
+    int CurrentPageOffset,
+    UserResponseDto[] Users
+);

--- a/application/account-management/Application/Users/RemoveAvatar.cs
+++ b/application/account-management/Application/Users/RemoveAvatar.cs
@@ -1,0 +1,29 @@
+using PlatformPlatform.AccountManagement.Application.TelemetryEvents;
+using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
+using PlatformPlatform.SharedKernel.ApplicationCore.TelemetryEvents;
+
+namespace PlatformPlatform.AccountManagement.Application.Users;
+
+[UsedImplicitly]
+public sealed record RemoveAvatarCommand(UserId Id) : ICommand, IRequest<Result>;
+
+[UsedImplicitly]
+public sealed class RemoveAvatarCommandHandler(
+    IUserRepository userRepository,
+    ITelemetryEventsCollector events
+)
+    : IRequestHandler<RemoveAvatarCommand, Result>
+{
+    public async Task<Result> Handle(RemoveAvatarCommand command, CancellationToken cancellationToken)
+    {
+        var user = await userRepository.GetByIdAsync(command.Id, cancellationToken);
+        if (user is null) return Result.NotFound($"User with id '{command.Id}' not found.");
+
+        user.RemoveAvatar();
+        userRepository.Update(user);
+
+        events.CollectEvent(new UserAvatarRemoved());
+
+        return Result.Success();
+    }
+}

--- a/application/account-management/Application/Users/UpdateAvatar.cs
+++ b/application/account-management/Application/Users/UpdateAvatar.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using Microsoft.Extensions.DependencyInjection;
 using PlatformPlatform.AccountManagement.Application.TelemetryEvents;
 using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
@@ -18,26 +19,32 @@ public sealed class UpdateAvatarHandler(
     : IRequestHandler<UpdateAvatarCommand, Result>
 {
     private const string ContainerName = "avatars";
-    private static readonly string PublicUrl = Environment.GetEnvironmentVariable("PUBLIC_URL")!;
 
     public async Task<Result> Handle(UpdateAvatarCommand command, CancellationToken cancellationToken)
     {
         var user = await userRepository.GetByIdAsync(command.Id, cancellationToken);
         if (user is null) return Result.NotFound($"User with id '{command.Id}' not found.");
 
-        var avatarVersion = user.Avatar.Version + 1;
-        var blobName = $"{user.Id}-{avatarVersion}.jpg";
+        var fileHash = await GetFileHash(command.FileSteam, cancellationToken);
+        var blobName = $"{user.TenantId}/{user.Id}/{fileHash}.jpg";
+        await blobStorage.UploadAsync(ContainerName, blobName, command.ContentType, command.FileSteam,
+            cancellationToken);
 
-        await blobStorage.UploadAsync(ContainerName, blobName, command.ContentType,
-            command.FileSteam, cancellationToken);
-
-        var avatarUrl = $"{PublicUrl}/{ContainerName}/{blobName}";
-        user.UpdateAvatar(avatarUrl, avatarVersion);
+        var avatarUrl = $"/{ContainerName}/{blobName}";
+        user.UpdateAvatar(avatarUrl);
 
         userRepository.Update(user);
 
         events.CollectEvent(new UserAvatarUpdated(command.ContentType, command.FileSteam.Length));
 
         return Result.Success();
+    }
+
+    private async Task<string> GetFileHash(Stream fileStream, CancellationToken cancellationToken)
+    {
+        var hashBytes = await SHA1.Create().ComputeHashAsync(fileStream, cancellationToken);
+        fileStream.Position = 0;
+        // This just need to be unique for one user, who likely will ever have one avatar, so 16 chars should be enough
+        return BitConverter.ToString(hashBytes).Replace("-", "")[..16].ToUpper();
     }
 }

--- a/application/account-management/Application/Users/UpdateAvatar.cs
+++ b/application/account-management/Application/Users/UpdateAvatar.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using PlatformPlatform.AccountManagement.Application.TelemetryEvents;
 using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
 using PlatformPlatform.SharedKernel.ApplicationCore.Services;
@@ -11,7 +12,7 @@ public sealed record UpdateAvatarCommand(UserId Id, Stream FileSteam, string Con
 [UsedImplicitly]
 public sealed class UpdateAvatarHandler(
     IUserRepository userRepository,
-    IBlobStorage blobStorage,
+    [FromKeyedServices("avatars-storage")] IBlobStorage blobStorage,
     ITelemetryEventsCollector events
 )
     : IRequestHandler<UpdateAvatarCommand, Result>

--- a/application/account-management/Application/Users/UpdateAvatar.cs
+++ b/application/account-management/Application/Users/UpdateAvatar.cs
@@ -1,0 +1,42 @@
+using PlatformPlatform.AccountManagement.Application.TelemetryEvents;
+using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
+using PlatformPlatform.SharedKernel.ApplicationCore.Services;
+using PlatformPlatform.SharedKernel.ApplicationCore.TelemetryEvents;
+
+namespace PlatformPlatform.AccountManagement.Application.Users;
+
+[UsedImplicitly]
+public sealed record UpdateAvatarCommand(UserId Id, Stream FileSteam, string ContentType) : ICommand, IRequest<Result>;
+
+[UsedImplicitly]
+public sealed class UpdateAvatarHandler(
+    IUserRepository userRepository,
+    IBlobStorage blobStorage,
+    ITelemetryEventsCollector events
+)
+    : IRequestHandler<UpdateAvatarCommand, Result>
+{
+    private const string ContainerName = "avatars";
+    private static readonly string PublicUrl = Environment.GetEnvironmentVariable("PUBLIC_URL")!;
+
+    public async Task<Result> Handle(UpdateAvatarCommand command, CancellationToken cancellationToken)
+    {
+        var user = await userRepository.GetByIdAsync(command.Id, cancellationToken);
+        if (user is null) return Result.NotFound($"User with id '{command.Id}' not found.");
+
+        var avatarVersion = user.Avatar.Version + 1;
+        var blobName = $"{user.Id}-{avatarVersion}.jpg";
+
+        await blobStorage.UploadAsync(ContainerName, blobName, command.ContentType,
+            command.FileSteam, cancellationToken);
+
+        var avatarUrl = $"{PublicUrl}/{ContainerName}/{blobName}";
+        user.UpdateAvatar(avatarUrl, avatarVersion);
+
+        userRepository.Update(user);
+
+        events.CollectEvent(new UserAvatarUpdated(command.ContentType, command.FileSteam.Length));
+
+        return Result.Success();
+    }
+}

--- a/application/account-management/Application/Users/UpdateAvatar.cs
+++ b/application/account-management/Application/Users/UpdateAvatar.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using PlatformPlatform.AccountManagement.Application.TelemetryEvents;
 using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
@@ -46,5 +47,20 @@ public sealed class UpdateAvatarHandler(
         fileStream.Position = 0;
         // This just need to be unique for one user, who likely will ever have one avatar, so 16 chars should be enough
         return BitConverter.ToString(hashBytes).Replace("-", "")[..16].ToUpper();
+    }
+}
+
+[UsedImplicitly]
+public sealed class UpdateAvatarValidator : AbstractValidator<UpdateAvatarCommand>
+{
+    public UpdateAvatarValidator()
+    {
+        RuleFor(x => x.ContentType)
+            .Must(x => x == "image/jpeg")
+            .WithMessage(_ => "Image must be of type Jpeg.");
+
+        RuleFor(x => x.FileSteam.Length)
+            .LessThanOrEqualTo(1024 * 1024)
+            .WithMessage(_ => "Image must be less than 1MB.");
     }
 }

--- a/application/account-management/Application/Users/UserResponseDto.cs
+++ b/application/account-management/Application/Users/UserResponseDto.cs
@@ -9,5 +9,6 @@ public sealed record UserResponseDto(
     UserRole UserRole,
     string FirstName,
     string LastName,
-    bool EmailConfirmed
+    bool EmailConfirmed,
+    string? AvatarUrl
 );

--- a/application/account-management/Domain/Users/User.cs
+++ b/application/account-management/Domain/Users/User.cs
@@ -28,9 +28,18 @@ public sealed class User : AggregateRoot<UserId>
     [UsedImplicitly]
     public bool EmailConfirmed { get; private set; }
 
-    public static User Create(TenantId tenantId, string email, UserRole userRole, bool emailConfirmed)
+    public Avatar Avatar { get; private set; } = default!;
+
+    public static User Create(
+        TenantId tenantId,
+        string email,
+        UserRole userRole,
+        bool emailConfirmed,
+        string? gravatarUrl
+    )
     {
-        return new User(tenantId, email, userRole, emailConfirmed);
+        var avatar = new Avatar(gravatarUrl, 0, gravatarUrl is not null);
+        return new User(tenantId, email, userRole, emailConfirmed) { Avatar = avatar };
     }
 
     public void Update(string email, UserRole userRole)
@@ -38,4 +47,17 @@ public sealed class User : AggregateRoot<UserId>
         Email = email;
         UserRole = userRole;
     }
+
+    public void UpdateAvatar(string avatarUrl, int version = 1, bool isGravatar = false)
+    {
+        Avatar = new Avatar(avatarUrl, version, isGravatar);
+    }
+
+    public void RemoveAvatar()
+    {
+        Avatar = new Avatar();
+    }
 }
+
+[UsedImplicitly]
+public sealed record Avatar(string? Url = null, int Version = 0, bool IsGravatar = false);

--- a/application/account-management/Domain/Users/User.cs
+++ b/application/account-management/Domain/Users/User.cs
@@ -48,9 +48,9 @@ public sealed class User : AggregateRoot<UserId>
         UserRole = userRole;
     }
 
-    public void UpdateAvatar(string avatarUrl, int version)
+    public void UpdateAvatar(string avatarUrl)
     {
-        Avatar = new Avatar(avatarUrl, version, false);
+        Avatar = new Avatar(avatarUrl, Avatar.Version + 1);
     }
 
     public void RemoveAvatar()

--- a/application/account-management/Domain/Users/User.cs
+++ b/application/account-management/Domain/Users/User.cs
@@ -38,7 +38,7 @@ public sealed class User : AggregateRoot<UserId>
         string? gravatarUrl
     )
     {
-        var avatar = new Avatar(gravatarUrl, 0, gravatarUrl is not null);
+        var avatar = new Avatar(gravatarUrl, IsGravatar: gravatarUrl is not null);
         return new User(tenantId, email, userRole, emailConfirmed) { Avatar = avatar };
     }
 
@@ -48,14 +48,14 @@ public sealed class User : AggregateRoot<UserId>
         UserRole = userRole;
     }
 
-    public void UpdateAvatar(string avatarUrl, int version = 1, bool isGravatar = false)
+    public void UpdateAvatar(string avatarUrl, int version)
     {
-        Avatar = new Avatar(avatarUrl, version, isGravatar);
+        Avatar = new Avatar(avatarUrl, version, false);
     }
 
     public void RemoveAvatar()
     {
-        Avatar = new Avatar();
+        Avatar = new Avatar(Version: Avatar.Version);
     }
 }
 

--- a/application/account-management/Infrastructure/AccountManagementDbContext.cs
+++ b/application/account-management/Infrastructure/AccountManagementDbContext.cs
@@ -28,6 +28,7 @@ public sealed class AccountManagementDbContext(DbContextOptions<AccountManagemen
         modelBuilder.MapStronglyTypedUuid<User, UserId>(u => u.Id);
         modelBuilder.MapStronglyTypedId<User, TenantId, string>(u => u.TenantId);
         modelBuilder.Entity<User>()
+            .OwnsOne(e => e.Avatar, b => b.ToJson())
             .HasOne<Tenant>()
             .WithMany()
             .HasForeignKey(u => u.TenantId)

--- a/application/account-management/Infrastructure/InfrastructureConfiguration.cs
+++ b/application/account-management/Infrastructure/InfrastructureConfiguration.cs
@@ -12,7 +12,7 @@ public static class InfrastructureConfiguration
     {
         // Storage is configured separately from other Infrastructure services to allow mocking in tests
         services.ConfigureDatabaseContext<AccountManagementDbContext>(builder, "account-management-database");
-        services.AddBlobStorage(builder, "account-management-storage");
+        services.AddBlobStorage(builder, ("account-management-storage", "ACCOUNT_MANAGEMENT_STORAGE_URL"));
 
         return services;
     }

--- a/application/account-management/Infrastructure/InfrastructureConfiguration.cs
+++ b/application/account-management/Infrastructure/InfrastructureConfiguration.cs
@@ -12,7 +12,8 @@ public static class InfrastructureConfiguration
     {
         // Storage is configured separately from other Infrastructure services to allow mocking in tests
         services.ConfigureDatabaseContext<AccountManagementDbContext>(builder, "account-management-database");
-        services.AddBlobStorage(builder, ("account-management-storage", "ACCOUNT_MANAGEMENT_STORAGE_URL"));
+        services.AddDefaultBlobStorage(builder);
+        services.AddNamedBlobStorages(builder, ("avatars-storage", "BLOB_STORAGE_URL"));
 
         return services;
     }

--- a/application/account-management/Infrastructure/InfrastructureConfiguration.cs
+++ b/application/account-management/Infrastructure/InfrastructureConfiguration.cs
@@ -8,12 +8,11 @@ public static class InfrastructureConfiguration
 {
     public static Assembly Assembly => Assembly.GetExecutingAssembly();
 
-    public static IServiceCollection AddDatabaseContext(
-        this IServiceCollection services,
-        IHostApplicationBuilder builder
-    )
+    public static IServiceCollection ConfigureStorage(this IServiceCollection services, IHostApplicationBuilder builder)
     {
+        // Storage is configured separately from other Infrastructure services to allow mocking in tests
         services.ConfigureDatabaseContext<AccountManagementDbContext>(builder, "account-management-database");
+        services.AddBlobStorage(builder, "account-management-storage");
 
         return services;
     }

--- a/application/account-management/Infrastructure/Migrations/20240307000000_Initial.Designer.cs
+++ b/application/account-management/Infrastructure/Migrations/20240307000000_Initial.Designer.cs
@@ -20,7 +20,7 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "8.0.2")
+                .HasAnnotation("ProductVersion", "8.0.3")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -123,19 +123,15 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
                         .IsRequired()
                         .HasColumnType("bit");
 
+                    b.Property<string>("Avatar")
+                        .IsRequired()
+                        .HasColumnType("varchar(200)");
+
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
                     b.ToTable("Users");
-                });
-
-            modelBuilder.Entity("PlatformPlatform.AccountManagement.Domain.Users.User", b =>
-                {
-                    b.HasOne("PlatformPlatform.AccountManagement.Domain.Tenants.Tenant", null)
-                        .WithMany()
-                        .HasForeignKey("TenantId")
-                        .IsRequired();
                 });
 #pragma warning restore 612, 618
         }

--- a/application/account-management/Infrastructure/Migrations/20240307000000_Initial.cs
+++ b/application/account-management/Infrastructure/Migrations/20240307000000_Initial.cs
@@ -59,7 +59,8 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
                     FirstName = table.Column<string>(type: "nvarchar(30)", nullable: true),
                     LastName = table.Column<string>(type: "nvarchar(30)", nullable: true),
                     UserRole = table.Column<string>(type: "varchar(20)", nullable: false),
-                    EmailConfirmed = table.Column<bool>(type: "bit", nullable: false)
+                    EmailConfirmed = table.Column<bool>(type: "bit", nullable: false),
+                    Avatar = table.Column<string>(type: "varchar(200)", nullable: false),
                 },
                 constraints: table =>
                 {

--- a/application/account-management/Infrastructure/Migrations/AccountManagementDbContextModelSnapshot.cs
+++ b/application/account-management/Infrastructure/Migrations/AccountManagementDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "8.0.2")
+                .HasAnnotation("ProductVersion", "8.0.3")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -120,19 +120,15 @@ namespace PlatformPlatform.AccountManagement.Infrastructure.Migrations
                         .IsRequired()
                         .HasColumnType("bit");
 
+                    b.Property<string>("Avatar")
+                        .IsRequired()
+                        .HasColumnType("varchar(200)");
+
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
                     b.ToTable("Users");
-                });
-
-            modelBuilder.Entity("PlatformPlatform.AccountManagement.Domain.Users.User", b =>
-                {
-                    b.HasOne("PlatformPlatform.AccountManagement.Domain.Tenants.Tenant", null)
-                        .WithMany()
-                        .HasForeignKey("TenantId")
-                        .IsRequired();
                 });
 #pragma warning restore 612, 618
         }

--- a/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
@@ -34,8 +34,9 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
                     'email': {'type': 'string', 'maxLength': 100},
                     'firstName': {'type': ['null', 'string'], 'maxLength': 30},
                     'lastName': {'type': ['null', 'string'], 'maxLength': 30},
-                    'userRole': {'type': 'string', 'minLength': 1, 'maxLength':20},
-                    'emailConfirmed': {'type': 'boolean'}
+                    'userRole': {'type': 'string', 'minLength': 1, 'maxLength': 20},
+                    'emailConfirmed': {'type': 'boolean'},
+                    'avatarUrl': {'type': ['null', 'string'], 'maxLength': 100},
                 },
                 'required': ['id', 'createdAt', 'modifiedAt', 'email', 'userRole'],
                 'additionalProperties': false

--- a/application/account-management/Tests/DatabaseSeeder.cs
+++ b/application/account-management/Tests/DatabaseSeeder.cs
@@ -27,7 +27,7 @@ public sealed class DatabaseSeeder
         Tenant1 = Tenant.Create(new TenantId(_faker.Subdomain()), _faker.Internet.Email());
         accountManagementDbContext.Tenants.AddRange(Tenant1);
 
-        User1 = User.Create(Tenant1.Id, _faker.Internet.Email(), UserRole.TenantOwner, true);
+        User1 = User.Create(Tenant1.Id, _faker.Internet.Email(), UserRole.TenantOwner, true, null);
         accountManagementDbContext.Users.AddRange(User1);
 
         accountManagementDbContext.SaveChanges();

--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -117,7 +117,6 @@ public static class ApiCoreConfiguration
         }
         else
         {
-            // When running inside a Docker container running as non-root we need to use a port higher than 1024
             builder.WebHost.ConfigureKestrel(options => { options.AddServerHeader = false; });
         }
 

--- a/application/shared-kernel/ApplicationCore/Services/IBlobStorage.cs
+++ b/application/shared-kernel/ApplicationCore/Services/IBlobStorage.cs
@@ -1,0 +1,15 @@
+namespace PlatformPlatform.SharedKernel.ApplicationCore.Services;
+
+public interface IBlobStorage
+{
+    Task UploadAsync(
+        string containerName,
+        string blobName,
+        string contentType,
+        Stream stream,
+        CancellationToken cancellationToken
+    );
+
+    [UsedImplicitly]
+    string GetBlobUrl(string container, string blobName);
+}

--- a/application/shared-kernel/ApplicationCore/Services/IBlobStorage.cs
+++ b/application/shared-kernel/ApplicationCore/Services/IBlobStorage.cs
@@ -12,4 +12,6 @@ public interface IBlobStorage
 
     [UsedImplicitly]
     string GetBlobUrl(string container, string blobName);
+
+    string GetSharedAccessSignature(string container, TimeSpan expiresIn);
 }

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCore.csproj
@@ -14,6 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Aspire.Azure.Storage.Blobs"/>
         <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer"/>
         <PackageReference Include="Azure.Communication.Email"/>
         <PackageReference Include="Azure.Security.KeyVault.Secrets"/>

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -17,7 +17,7 @@ namespace PlatformPlatform.SharedKernel.InfrastructureCore;
 
 public static class InfrastructureCoreConfiguration
 {
-    private static readonly bool IsRunningInAzure = Environment.GetEnvironmentVariable("KEYVAULT_URL") is not null;
+    private static readonly bool IsRunningInAzure = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID") is not null;
 
     [UsedImplicitly]
     public static IServiceCollection ConfigureDatabaseContext<T>(
@@ -93,7 +93,8 @@ public static class InfrastructureCoreConfiguration
 
     private static DefaultAzureCredential GetDefaultAzureCredential()
     {
-        var managedIdentityClientId = Environment.GetEnvironmentVariable("MANAGED_IDENTITY_CLIENT_ID")!;
+        // Hack. Remove trailing whitespace from the environment variable, Bicep of bug in Bicep
+        var managedIdentityClientId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID")!.Trim();
         var credentialOptions = new DefaultAzureCredentialOptions { ManagedIdentityClientId = managedIdentityClientId };
         return new DefaultAzureCredential(credentialOptions);
     }

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -32,6 +32,17 @@ public static class InfrastructureCoreConfiguration
         return services;
     }
 
+    public static IServiceCollection AddBlobStorage(
+        this IServiceCollection services,
+        IHostApplicationBuilder builder,
+        string connectionName
+    )
+    {
+        builder.AddAzureBlobService(connectionName);
+        services.AddTransient<IBlobStorage, BlobStorage>();
+        return services;
+    }
+
     [UsedImplicitly]
     public static IServiceCollection ConfigureInfrastructureCoreServices<T>(
         this IServiceCollection services,

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -17,7 +17,7 @@ namespace PlatformPlatform.SharedKernel.InfrastructureCore;
 
 public static class InfrastructureCoreConfiguration
 {
-    private static readonly bool IsRunningInAzure = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID") is not null;
+    public static readonly bool IsRunningInAzure = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID") is not null;
 
     [UsedImplicitly]
     public static IServiceCollection ConfigureDatabaseContext<T>(
@@ -114,7 +114,7 @@ public static class InfrastructureCoreConfiguration
         return services;
     }
 
-    private static DefaultAzureCredential GetDefaultAzureCredential()
+    public static DefaultAzureCredential GetDefaultAzureCredential()
     {
         // Hack. Remove trailing whitespace from the environment variable, Bicep of bug in Bicep
         var managedIdentityClientId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID")!.Trim();

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -57,14 +57,9 @@ public static class InfrastructureCoreConfiguration
 
         if (IsRunningInAzure)
         {
-            services.AddSingleton<SecretClient>(_ =>
-            {
-                var keyVaultUrl = Environment.GetEnvironmentVariable("KEYVAULT_URL")!;
-                var managedIdentityClientId = Environment.GetEnvironmentVariable("MANAGED_IDENTITY_CLIENT_ID")!;
-                var credentialOptions = new DefaultAzureCredentialOptions
-                    { ManagedIdentityClientId = managedIdentityClientId };
-                return new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential(credentialOptions));
-            });
+            var keyVaultUri = new Uri(Environment.GetEnvironmentVariable("KEYVAULT_URL")!);
+            services.AddSingleton(_ => new SecretClient(keyVaultUri, GetDefaultAzureCredential()));
+
             services.AddTransient<IEmailService, AzureEmailService>();
         }
         else
@@ -73,6 +68,13 @@ public static class InfrastructureCoreConfiguration
         }
 
         return services;
+    }
+
+    private static DefaultAzureCredential GetDefaultAzureCredential()
+    {
+        var managedIdentityClientId = Environment.GetEnvironmentVariable("MANAGED_IDENTITY_CLIENT_ID")!;
+        var credentialOptions = new DefaultAzureCredentialOptions { ManagedIdentityClientId = managedIdentityClientId };
+        return new DefaultAzureCredential(credentialOptions);
     }
 
     [UsedImplicitly]

--- a/application/shared-kernel/InfrastructureCore/Services/BlobStorage.cs
+++ b/application/shared-kernel/InfrastructureCore/Services/BlobStorage.cs
@@ -1,5 +1,6 @@
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
 using PlatformPlatform.SharedKernel.ApplicationCore.Services;
 
 namespace PlatformPlatform.SharedKernel.InfrastructureCore.Services;
@@ -23,5 +24,13 @@ public class BlobStorage(BlobServiceClient blobServiceClient) : IBlobStorage
     public string GetBlobUrl(string container, string blobName)
     {
         return $"{blobServiceClient.Uri}/{container}/{blobName}";
+    }
+
+    public string GetSharedAccessSignature(string container, TimeSpan expiresIn)
+    {
+        var blobContainerClient = blobServiceClient.GetBlobContainerClient(container);
+        var dateTimeOffset = DateTimeOffset.UtcNow.Add(expiresIn);
+        var generateSasUri = blobContainerClient.GenerateSasUri(BlobContainerSasPermissions.Read, dateTimeOffset);
+        return generateSasUri.Query;
     }
 }

--- a/application/shared-kernel/InfrastructureCore/Services/BlobStorage.cs
+++ b/application/shared-kernel/InfrastructureCore/Services/BlobStorage.cs
@@ -1,0 +1,27 @@
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using PlatformPlatform.SharedKernel.ApplicationCore.Services;
+
+namespace PlatformPlatform.SharedKernel.InfrastructureCore.Services;
+
+public class BlobStorage(BlobServiceClient blobServiceClient) : IBlobStorage
+{
+    public async Task UploadAsync(
+        string containerName,
+        string blobName,
+        string contentType,
+        Stream stream,
+        CancellationToken cancellationToken
+    )
+    {
+        var blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
+        var blobClient = blobContainerClient.GetBlobClient(blobName);
+        var blobHttpHeaders = new BlobHttpHeaders { ContentType = contentType };
+        await blobClient.UploadAsync(stream, blobHttpHeaders, cancellationToken: cancellationToken);
+    }
+
+    public string GetBlobUrl(string container, string blobName)
+    {
+        return $"{blobServiceClient.Uri}/{container}/{blobName}";
+    }
+}


### PR DESCRIPTION
### Summary & Motivation

Add option for uploading an avatar image for the user. The avatars are saved in Azure Blob storage with the name `/avatars/{TenantId}/{UserId}/{FileHash}.jpg`. The use of `TenantId` and `UserId` ensures that the Avatar can be deleted along with the user/tenant. The `FileHash` ensures that if a user uploads the same image multiple times, it will only be stored once in Blob Storage. Avatars must be JPEGs and less than 1MB in size.

When creating a new user, a check is made to Gravatar.com to see if the email has a Gravatar profile, and if so, the URL to the Gravatar is used as the profile image. As long as the user does not upload an avatar image manually, any updates to the Gravatar profile will be reflected. Importantly, when checking Gravatar.com, an MD5 hash is used, ensuring that no PII data is leaked.

Avatars can be accessed using URLs like `https://tenantid.sassproduct.com/avatars/{TenantId}/{UserId}/{FileHash}.jpg`. The AppGateway is configured to proxy all traffic on `/avatars/**` to the blob storage (using YARP). In Azure, the request is transformed using the User-Assigned Managed Identity of the AppGateway, which has read access to the Account Management blob storage, keeping URLs clean even though the blob storage is not publicly available. On localhost, where Managed Identities are not available, the transformation is done by dynamically adding a Shared Access Signature (SAS) link. Because the URLs are simple without any query string, the result can be cached permanently in browsers, avoiding the need to reload avatars every time a user list is shown. This caching is configured in YARP (currently for 30 days).

When Aspire AppHost starts, the `avatars` blob container is created (this is already part of the Bicep Infrastructure).

When updating and removing avatars, `UserAvatarUpdated` and `UserAvatarRemoved` telemetric events are tracked.

A new `User.Avatar` property is created on the Domain object. This property is a complex type (using a C# record) with a `Url`, `Version`, and `IsGravatar` property. Entity Framework 8's new feature for seamlessly storing complex objects as Json in databases is used. Mapster is utilized for mapping from `User.Avatar.Url` to `UserDto.AvatarUrl` by convention. Both these techniques make the code very clean and readable.

The IBlobStorage in Shared Kernel has been updated to allow a self-contained system to register multiple services using IBlobStorage with different blob storage accounts, utilizing .NET 8's Keyed Services dependency injection.

Logic to detect if the service is running in Azure now uses the `AZURE_CLIENT_ID` environment variable, which should always be configured.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
