### PR TITLE
Ensure uploaded avatars are persisted between Aspire sessions

### DIFF
--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -13,7 +13,7 @@ var azureStorage = builder
     .AddAzureStorage("azure-storage")
     .RunAsEmulator(resourceBuilder =>
     {
-        resourceBuilder.WithVolumeMount("azure-storage-data", "/var/opt/azurestorage");
+        resourceBuilder.WithVolumeMount("azure-storage-data", "/data");
         resourceBuilder.UseBlobPort(10000);
     })
     .AddBlobs("blobs");


### PR DESCRIPTION
### Summary & Motivation

Update the path configuration for Azurite, ensuring that uploaded avatars are correctly persisted between Aspire sessions. 

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
