### PR TITLE
Reintroduce Dockerfile for building containers to get smaller and safer images

### DIFF
--- a/.github/workflows/_publish-container.yml
+++ b/.github/workflows/_publish-container.yml
@@ -15,7 +15,10 @@ on:
       version:
         required: true
         type: string
-      project_file:
+      docker_context:
+        required: true
+        type: string
+      docker_file:
         required: true
         type: string
 
@@ -43,5 +46,18 @@ jobs:
       - name: Login to ACR
         run: az acr login --name ${{ vars.CONTAINER_REGISTRY_NAME }}
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push container image
-        run: dotnet publish ${{ inputs.project_file }} -t:PublishContainer -p ContainerRegistry=${{ vars.CONTAINER_REGISTRY_NAME }}.azurecr.io -p ContainerImageTags='"${{ inputs.version }};latest"' -p ContainerRepository=${{ inputs.image_name }}
+        working-directory: ${{ inputs.docker_context }}
+        run: |
+          docker buildx create --use
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg VERSION=${{ inputs.version }} \
+            -t ${{ vars.CONTAINER_REGISTRY_NAME }}.azurecr.io/${{ inputs.image_name }}:${{ inputs.version }} \
+            -t ${{ vars.CONTAINER_REGISTRY_NAME }}.azurecr.io/${{ inputs.image_name }}:latest \
+            -f ${{ inputs.docker_file }} \
+            --push .
+          docker buildx rm

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -182,7 +182,8 @@ jobs:
       artifacts_path: application/account-management/Api/publish
       image_name: account-management-api
       version: ${{ needs.build-and-test.outputs.version }}
-      project_file: application/account-management/Api/Api.csproj
+      docker_context: ./application/account-management
+      docker_file: ./Api/Dockerfile
 
   account-management-deploy:
     name: Account Management API Deploy
@@ -204,7 +205,8 @@ jobs:
       artifacts_path: application/AppGateway/publish
       image_name: app-gateway
       version: ${{ needs.build-and-test.outputs.version }}
-      project_file: application/AppGateway/AppGateway.csproj
+      docker_context: ./application
+      docker_file: ./AppGateway/Dockerfile
 
   app-gateway-deploy:
     name: App Gateway Deploy

--- a/application/AppGateway/AppGateway.csproj
+++ b/application/AppGateway/AppGateway.csproj
@@ -6,12 +6,7 @@
         <RootNamespace>PlatformPlatform.AppGateway</RootNamespace>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <ContainerFamily>alpine</ContainerFamily>
     </PropertyGroup>
-
-    <ItemGroup>
-        <ContainerPort Include="8080" Type="tcp"/>
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Yarp.ReverseProxy"/>

--- a/application/AppGateway/Dockerfile
+++ b/application/AppGateway/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+
+WORKDIR /app
+COPY ./AppGateway/publish .
+
+USER app
+
+ENTRYPOINT ["dotnet", "PlatformPlatform.AppGateway.dll"]

--- a/application/account-management/Api/Api.csproj
+++ b/application/account-management/Api/Api.csproj
@@ -9,12 +9,7 @@
         <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/../WebApp/lib/api/</OpenApiDocumentsDirectory>
         <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>
         <OpenApiGenerateDocumentsOnBuild>true</OpenApiGenerateDocumentsOnBuild>
-        <ContainerFamily>jammy-chiseled-extra</ContainerFamily>
     </PropertyGroup>
-
-    <ItemGroup>
-        <ContainerPort Include="8080" Type="tcp"/>
-    </ItemGroup>
 
     <ItemGroup>
         <InternalsVisibleTo Include="PlatformPlatform.AccountManagement.Tests"/>

--- a/application/account-management/Api/Dockerfile
+++ b/application/account-management/Api/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+
+RUN apk add --no-cache icu-libs
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+
+WORKDIR /app
+COPY ./Api/publish .
+
+USER app
+
+ENTRYPOINT ["dotnet", "PlatformPlatform.AccountManagement.Api.dll"]


### PR DESCRIPTION
### Summary & Motivation

Reintroduce Dockerfile for building to create smaller and safer images than those generated with `8.0-jammy-chiseled-extra`, which was found to have several open CVEs. The initial switch to `jammy-chiseled-extra` was solely for the installation of `icu-libs` and to set `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT` to false, a requirement dictated by SQLClient.

Additionally, this change fixes a problem where the frontend build files are correctly incorporated into the images.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
