### PR TITLE
Update to .NET Aspire preview 5

### DIFF
--- a/application/AppHost/AppHost.csproj
+++ b/application/AppHost/AppHost.csproj
@@ -16,8 +16,10 @@
 
     <ItemGroup>
         <PackageReference Include="Aspire.Azure.Storage.Blobs"/>
-        <PackageReference Include="Aspire.Hosting.Azure"/>
-        <PackageReference Include="Aspire.Hosting"/>
+        <PackageReference Include="Aspire.Hosting.AppHost"/>
+        <PackageReference Include="Aspire.Hosting.Azure.Storage"/>
+        <PackageReference Include="Aspire.Hosting.NodeJs"/>
+        <PackageReference Include="Aspire.Hosting.SqlServer"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/application/AppHost/AppHost.csproj
+++ b/application/AppHost/AppHost.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsAspireHost>true</IsAspireHost>
+        <UserSecretsId>f817f2a1-ac57-4756-aef2-a57ca864bbd3</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
@@ -20,6 +21,8 @@
         <PackageReference Include="Aspire.Hosting.Azure.Storage"/>
         <PackageReference Include="Aspire.Hosting.NodeJs"/>
         <PackageReference Include="Aspire.Hosting.SqlServer"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -1,11 +1,13 @@
+using AppHost;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var sqlServer = builder
-    .AddSqlServer("sql-server", port: 9002)
+var sqlPassword = builder.CreateStablePassword("sql-server-password");
+Console.WriteLine($"Use the following password for the SQL Server: {sqlPassword.Resource.Value}");
+var sqlServer = builder.AddSqlServer("sql-server", sqlPassword, 9002)
     .WithVolume("sql-server-data", "/var/opt/mssql");
 
 var azureStorage = builder

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -4,24 +4,23 @@ using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var sqlServerPassword = Environment.GetEnvironmentVariable("SQL_SERVER_PASSWORD");
 var sqlServer = builder
-    .AddSqlServer("sql-server", sqlServerPassword, 9002)
-    .WithVolumeMount("sql-server-data", "/var/opt/mssql");
+    .AddSqlServer("sql-server", port: 9002)
+    .WithVolume("sql-server-data", "/var/opt/mssql");
 
 var azureStorage = builder
     .AddAzureStorage("azure-storage")
     .RunAsEmulator(resourceBuilder =>
     {
-        resourceBuilder.WithVolumeMount("azure-storage-data", "/data");
+        resourceBuilder.WithVolume("azure-storage-data", "/data");
         resourceBuilder.UseBlobPort(10000);
     })
     .AddBlobs("blobs");
 
 builder
     .AddContainer("mail-server", "mailhog/mailhog")
-    .WithEndpoint(hostPort: 9003, containerPort: 8025, scheme: "http")
-    .WithEndpoint(hostPort: 9004, containerPort: 1025);
+    .WithHttpEndpoint(9003, 8025)
+    .WithEndpoint(9004, 1025);
 
 var accountManagementDatabase = sqlServer
     .AddDatabase("account-management-database", "account-management");

--- a/application/AppHost/Properties/launchSettings.json
+++ b/application/AppHost/Properties/launchSettings.json
@@ -9,7 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:8317"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:9097",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:9098"
       }
     }
   }

--- a/application/AppHost/SecretManagerHelper.cs
+++ b/application/AppHost/SecretManagerHelper.cs
@@ -1,0 +1,51 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.UserSecrets;
+
+namespace AppHost;
+
+public static class SecretManagerHelper
+{
+    private static string UserSecretsId =>
+        Assembly.GetEntryAssembly()!.GetCustomAttribute<UserSecretsIdAttribute>()!.UserSecretsId;
+
+    public static IResourceBuilder<ParameterResource> CreateStablePassword(
+        this IDistributedApplicationBuilder builder,
+        string secretName
+    )
+    {
+        var config = new ConfigurationBuilder().AddUserSecrets(UserSecretsId).Build();
+
+        var password = config[secretName];
+
+        if (string.IsNullOrEmpty(password))
+        {
+            var passwordGenerator = new GenerateParameterDefault
+            {
+                MinLower = 5,
+                MinUpper = 5,
+                MinNumeric = 3,
+                MinSpecial = 3
+            };
+            password = passwordGenerator.GetDefaultValue();
+            SavePasswordToUserSecrets(secretName, password);
+        }
+
+        return builder.CreateResourceBuilder(new ParameterResource(secretName, _ => password, true));
+    }
+
+    private static void SavePasswordToUserSecrets(string key, string value)
+    {
+        var args = $"user-secrets set {key} {value} --id {UserSecretsId}";
+        var startInfo = new ProcessStartInfo("dotnet", args)
+        {
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(startInfo)!;
+        process.WaitForExit();
+    }
+}

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -5,7 +5,7 @@
     <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
     <AspNetCoreVersion>8.0.4</AspNetCoreVersion>
     <EfCoreVersion>8.0.4</EfCoreVersion>
-    <AspireVersion>8.0.0-preview.4.24156.9</AspireVersion>
+    <AspireVersion>8.0.0-preview.5.24201.12</AspireVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- PlatformPlatform dependencies - Api -->
@@ -58,11 +58,12 @@
   <ItemGroup>
     <!-- Version together with Aspire -->
     <PackageVersion Include="Aspire.Hosting" Version="$(AspireVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Dapr" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Hosting.NodeJs" Version="$(AspireVersion)" />  
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="$(AspireVersion)" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Abstractions" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="$(AspireVersion)" />
     <!-- Version together with ASP.NET -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetCoreVersion)" />

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -15,7 +15,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <!-- PlatformPlatform dependencies - Application -->
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="$(AspNetCoreVersion)">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
+      <!-- PlatformPlatform dependencies - Application -->
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageVersion Include="Mapster" Version="7.4.0" />
     <PackageVersion Include="MediatR" Version="12.2.0" />
@@ -65,21 +69,6 @@
     <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="$(AspireVersion)" />
-    <!-- Version together with ASP.NET -->
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="$(AspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(AspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="$(AspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(AspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(AspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(AspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="$(AspNetCoreVersion)">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageVersion>
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <!-- Version together with EF -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(EfCoreVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EfCoreVersion)" />
@@ -96,10 +85,8 @@
     <!-- Open Telemetry -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.EventCounters" Version="1.5.1-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
@@ -107,7 +94,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <!-- Miscellaneous -->
     <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="8.0.0" />
-    <PackageVersion Include="Dapr.AspNetCore" Version="1.12.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-      <!-- PlatformPlatform dependencies - Application -->
+    <!-- PlatformPlatform dependencies - Application -->
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageVersion Include="Mapster" Version="7.4.0" />
     <PackageVersion Include="MediatR" Version="12.2.0" />
@@ -28,7 +28,7 @@
     <PackageVersion Include="IdGen" Version="3.0.5" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="8.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.0.7" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.0.7" />
@@ -64,7 +64,7 @@
     <PackageVersion Include="Aspire.Hosting" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="$(AspireVersion)" />
-    <PackageVersion Include="Aspire.Hosting.NodeJs" Version="$(AspireVersion)" />  
+    <PackageVersion Include="Aspire.Hosting.NodeJs" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)" />
@@ -80,15 +80,15 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <!-- Open Telemetry -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
     <!-- VS Test -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -39,6 +39,8 @@
     <PackageVersion Include="Aspire.Hosting.Azure" Version="$(AspireVersion)" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EfCoreVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />
     <!-- PlatformPlatform dependencies - Tests -->
     <PackageVersion Include="Bogus" Version="35.5.0" />

--- a/application/shared-kernel/ApiCore/Aspire/ServiceDefaultsExtensions.cs
+++ b/application/shared-kernel/ApiCore/Aspire/ServiceDefaultsExtensions.cs
@@ -26,7 +26,7 @@ public static class ServiceDefaultsExtensions
             http.AddStandardResilienceHandler();
 
             // Turn on service discovery by default
-            http.UseServiceDiscovery();
+            http.AddServiceDiscovery();
         });
 
         return builder;
@@ -54,7 +54,12 @@ public static class ServiceDefaultsExtensions
         });
 
         builder.Services.AddOpenTelemetry()
-            .WithMetrics(metrics => { metrics.AddRuntimeInstrumentation().AddBuiltInMeters(); })
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
             .WithTracing(tracing =>
             {
                 // We want to view all traces in development
@@ -66,15 +71,6 @@ public static class ServiceDefaultsExtensions
         builder.AddOpenTelemetryExporters();
 
         return builder;
-    }
-
-    [UsedImplicitly]
-    private static MeterProviderBuilder AddBuiltInMeters(this MeterProviderBuilder meterProviderBuilder)
-    {
-        return meterProviderBuilder.AddMeter(
-            "Microsoft.AspNetCore.Hosting",
-            "Microsoft.AspNetCore.Server.Kestrel",
-            "System.Net.Http");
     }
 
     [UsedImplicitly]

--- a/developer-cli/Commands/ConfigureDeveloperEnvironmentCommand.cs
+++ b/developer-cli/Commands/ConfigureDeveloperEnvironmentCommand.cs
@@ -17,7 +17,7 @@ public class ConfigureDeveloperEnvironmentCommand : Command
 
     public ConfigureDeveloperEnvironmentCommand() : base(
         CommandName,
-        "Generate CERTIFICATE_PASSWORD and SQL_SERVER_PASSWORD, create developer certificate for localhost with known password, and store passwords in environment variables"
+        "Generate a developer certificate for localhost with known password, and store passwords it environment variables"
     )
     {
         Handler = CommandHandler.Create(Execute);
@@ -28,9 +28,8 @@ public class ConfigureDeveloperEnvironmentCommand : Command
         PrerequisitesChecker.Check("docker", "aspire", "node", "yarn");
 
         var certificateCreated = EnsureValidCertificateForLocalhostWithKnownPasswordIsConfigured();
-        var sqlServerPasswordCreated = CreateSqlServerPasswordIfNotExists();
 
-        if (certificateCreated || sqlServerPasswordCreated)
+        if (certificateCreated)
         {
             AnsiConsole.MarkupLine("[green]Please restart your terminal.[/]");
         }
@@ -41,23 +40,7 @@ public class ConfigureDeveloperEnvironmentCommand : Command
 
         return 0;
     }
-
-    private bool CreateSqlServerPasswordIfNotExists()
-    {
-        var certificatePassword = Environment.GetEnvironmentVariable("SQL_SERVER_PASSWORD");
-
-        if (certificatePassword is not null)
-        {
-            AnsiConsole.MarkupLine("[green]SQL_SERVER_PASSWORD environment variable already exist.[/]");
-            return false;
-        }
-
-        certificatePassword = GenerateRandomPassword(16);
-        AddEnvironmentVariable("SQL_SERVER_PASSWORD", certificatePassword);
-        AnsiConsole.MarkupLine("[green]SQL_SERVER_PASSWORD environment variable created.[/]");
-        return true;
-    }
-
+    
     private static bool EnsureValidCertificateForLocalhostWithKnownPasswordIsConfigured()
     {
         var certificatePassword = Environment.GetEnvironmentVariable("CERTIFICATE_PASSWORD");

--- a/developer-cli/Commands/InstallCommand.cs
+++ b/developer-cli/Commands/InstallCommand.cs
@@ -65,7 +65,7 @@ public class InstallCommand : Command
         }
 
         if (AnsiConsole.Confirm(
-                "PlatformPlatform requires a self-signed certificate and a SQL Server password. Do you want to create them now?"))
+                "PlatformPlatform requires a self-signed certificate with a known password. Do you want to create it now?"))
         {
             AnsiConsole.WriteLine();
             var command = new ConfigureDeveloperEnvironmentCommand();

--- a/developer-cli/Commands/RunCommand.cs
+++ b/developer-cli/Commands/RunCommand.cs
@@ -17,7 +17,7 @@ public class RunCommand : Command
 
     private void Execute()
     {
-        PrerequisitesChecker.Check("docker", "aspire", "node", "yarn", "SQL_SERVER_PASSWORD", "CERTIFICATE_PASSWORD");
+        PrerequisitesChecker.Check("docker", "aspire", "node", "yarn", "CERTIFICATE_PASSWORD");
 
         var workingDirectory = Path.Combine(Configuration.GetSourceCodeFolder(), "..", "application", "AppHost");
 

--- a/developer-cli/Commands/UninstallCommand.cs
+++ b/developer-cli/Commands/UninstallCommand.cs
@@ -11,7 +11,7 @@ public class UninstallCommand : Command
 {
     public UninstallCommand() : base(
         "uninstall",
-        $"Will remove the {Configuration.AliasName} CLI alias, and delete the CERTIFICATE_PASSWORD and SQL_SERVER_PASSWORD environment variables.")
+        $"Will remove the {Configuration.AliasName} CLI alias, and delete the CERTIFICATE_PASSWORD environment variable.")
     {
         Handler = CommandHandler.Create(Execute);
     }
@@ -30,8 +30,8 @@ public class UninstallCommand : Command
              Confirm uninstallation:
 
              This will do the following:
-             - Remove the PlatformPlatform Developer CLI alias (on Mac) and remove the CLi from the PATH (Windows)
-             - Remove the CERTIFICATE_PASSWORD and SQL_SERVER_PASSWORD environment variables
+             - Remove the PlatformPlatform Developer CLI alias (on Mac) and remove the CLI from the PATH (Windows)
+             - Remove the CERTIFICATE_PASSWORD environment variable
              - Delete the {Configuration.PublishFolder}/{Configuration.AliasName}.* files
              - Remove the {Configuration.PublishFolder} folder if empty
 
@@ -69,7 +69,6 @@ public class UninstallCommand : Command
     private void RemoveEnvironmentVariables()
     {
         RemoveEnvironmentVariable("CERTIFICATE_PASSWORD");
-        RemoveEnvironmentVariable("SQL_SERVER_PASSWORD");
         AnsiConsole.MarkupLine("[green]Environment variables have been removed.[/]");
     }
 

--- a/developer-cli/Installation/PrerequisitesChecker.cs
+++ b/developer-cli/Installation/PrerequisitesChecker.cs
@@ -30,7 +30,7 @@ public static class PrerequisitesChecker
         new Prerequisite(PrerequisiteType.CommandLineTool, "yarn", "Yarn", new Version(1, 22)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "az", "Azure CLI", new Version(2, 55)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "gh", "GitHub CLI", new Version(2, 41)),
-        new Prerequisite(PrerequisiteType.DotnetWorkload, "aspire", "Aspire", Regex: """aspire\s*8\.0\.0-preview.4"""),
+        new Prerequisite(PrerequisiteType.DotnetWorkload, "aspire", "Aspire", Regex: """aspire\s*8\.0\.0-preview.5"""),
         new Prerequisite(PrerequisiteType.EnvironmentVariable, "SQL_SERVER_PASSWORD"),
         new Prerequisite(PrerequisiteType.EnvironmentVariable, "CERTIFICATE_PASSWORD")
     ];
@@ -147,7 +147,7 @@ public static class PrerequisitesChecker
 
            Installed Workload Id      Manifest Version                     Installation Source
            -----------------------------------------------------------------------------------
-           aspire                     8.0.0-preview.4.24156.9/8.0.100     SDK 8.0.200
+           aspire                     8.0.0-preview.5.24201.12/8.0.100     SDK 8.0.200
 
            Use `dotnet workload search` to find additional workloads to install.
          */

--- a/developer-cli/Installation/PrerequisitesChecker.cs
+++ b/developer-cli/Installation/PrerequisitesChecker.cs
@@ -31,7 +31,6 @@ public static class PrerequisitesChecker
         new Prerequisite(PrerequisiteType.CommandLineTool, "az", "Azure CLI", new Version(2, 55)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "gh", "GitHub CLI", new Version(2, 41)),
         new Prerequisite(PrerequisiteType.DotnetWorkload, "aspire", "Aspire", Regex: """aspire\s*8\.0\.0-preview.5"""),
-        new Prerequisite(PrerequisiteType.EnvironmentVariable, "SQL_SERVER_PASSWORD"),
         new Prerequisite(PrerequisiteType.EnvironmentVariable, "CERTIFICATE_PASSWORD")
     ];
 


### PR DESCRIPTION
### Summary & Motivation

Upgrade to .NET Aspire preview 5, including updates to all associated NuGet dependencies and addressing breaking changes. In preview 5, NuGet packages are much more granular, leading to the addition of several new packages and the removal of many that were unused.

Additionally, upgrade all NuGet packages to the latest versions, including OpenTelemetry.Instrumentation, which had a security vulnerability.

Finally, in Aspire preview 5, one can no longer start a SQL Server with a given password using a simple string. It now requires a complex `IResourceBuilder<ParameterResource>`, necessitating the creation of a new `SecretManagerHelper` class with a `CreateStablePassword` method to generate a password. Going forward, the AppHost from Aspire will generate a SQL Server password the first time it starts and store it in .NET secrets. This in turn simplifies the `pp configure-developer-environment`.


### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
