### PR TITLE
Remove deprecated package Microsoft.AspNetCore.Mvc.ApiExplorer 

### DIFF
--- a/application/shared-kernel/ApiCore/ApiCore.csproj
+++ b/application/shared-kernel/ApiCore/ApiCore.csproj
@@ -22,7 +22,6 @@
     <ItemGroup>
         <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore"/>
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer"/>
         <PackageReference Include="Microsoft.Extensions.Http.Resilience"/>
         <PackageReference Include="Microsoft.Extensions.ServiceDiscovery"/>
         <PackageReference Include="NSwag.AspNetCore"/>


### PR DESCRIPTION
### Summary & Motivation

Remove the `Microsoft.AspNetCore.Mvc.ApiExplorer` deprecated package, since the `Microsoft.AspNetCore.Mvc.ApiExplorer` assembly is referenced by the `Microsoft.AspNetCore.App` framework


### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
