### PR TITLE
Enable development of Account Management self-contained systems in isolation

### DIFF
--- a/application/account-management/AccountManagement.sln
+++ b/application/account-management/AccountManagement.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj
 EndProject
 Project("{54A90642-561A-4BB1-A94E-469ADEE60C69}") = "WebApp", "WebApp\WebApp.esproj", "{7E781B90-C407-4FB2-BC20-10A457E08D7F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppHost", "..\AppHost\AppHost.csproj", "{9D917F36-6DDB-403A-992E-54A63BD681B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +45,10 @@ Global
 		{7E781B90-C407-4FB2-BC20-10A457E08D7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E781B90-C407-4FB2-BC20-10A457E08D7F}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{7E781B90-C407-4FB2-BC20-10A457E08D7F}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{9D917F36-6DDB-403A-992E-54A63BD681B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D917F36-6DDB-403A-992E-54A63BD681B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D917F36-6DDB-403A-992E-54A63BD681B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D917F36-6DDB-403A-992E-54A63BD681B3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{ABEB4337-3606-4730-8ABE-94DF98C2C348} = {92101687-8181-4543-84F9-E702DD874619}


### PR DESCRIPTION
### Summary & Motivation

Add the AppHost project to the Account Management solution. This integration allows developers to work on the Account Management self-contained system in isolation, separate from the Shared Kernel and other self-contained systems. When starting the AppHost, dependencies will automatically be initiated, enabling effective debugging.

This functionality was previously disabled because Visual Studio on Windows did not compile if the AppHost had a dependency on the WebApp, which disrupted this capability.

In Rider, it might be needed to build the Shared Kernel, because Rider tries to optimize the build process and is not using MSBuild. This is not a problem in practice, as the Shared Kernel will likely already be in the correct state.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
