### PR TITLE
Update to .NET Aspire preview 6

### DIFF
--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageVersion Include="Mapster" Version="7.4.0" />
     <PackageVersion Include="MediatR" Version="12.2.0" />
-    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.1" />
     <!-- PlatformPlatform dependencies - Domain-->
     <PackageVersion Include="IdGen" Version="3.0.5" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
@@ -57,8 +57,8 @@
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="NJsonSchema" Version="11.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="xunit" Version="2.7.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageVersion Include="xunit" Version="2.7.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
@@ -89,8 +89,8 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <!-- Open Telemetry -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -6,7 +6,7 @@
     <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
     <AspNetCoreVersion>8.0.4</AspNetCoreVersion>
     <EfCoreVersion>8.0.4</EfCoreVersion>
-    <AspireVersion>8.0.0-preview.5.24201.12</AspireVersion>
+    <AspireVersion>8.0.0-preview.6.24214.1</AspireVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddleware.cs
@@ -51,7 +51,7 @@ public sealed class WebAppMiddleware(
             Encoding.UTF8.GetBytes(JsonSerializer.Serialize(userInfo, jsonOptions.Value.SerializerOptions))
         );
         
-        var html = webAppConfiguration.HtmlTemplate;
+        var html = webAppConfiguration.GetHtmlTemplate();
         html = html.Replace("%ENCODED_RUNTIME_ENV%", webAppConfiguration.StaticRuntimeEnvironmentEncoded);
         html = html.Replace("%ENCODED_USER_INFO_ENV%", encodedUserInfo);
         html = html.Replace("%LOCALE%", userInfo.Locale);

--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddlewareConfiguration.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddlewareConfiguration.cs
@@ -13,7 +13,9 @@ public class WebAppMiddlewareConfiguration
     public const string CdnUrlKey = "CDN_URL";
     private const string PublicKeyPrefix = "PUBLIC_";
     private const string ApplicationVersionKey = "APPLICATION_VERSION";
+    private readonly string _htmlTemplatePath = GetHtmlTemplatePath();
     private readonly string[] _publicAllowedKeys = [CdnUrlKey, ApplicationVersionKey];
+    private string? _htmlTemplate;
     
     public WebAppMiddlewareConfiguration(IOptions<JsonOptions> jsonOptions, bool isDevelopment)
     {
@@ -35,8 +37,6 @@ public class WebAppMiddlewareConfiguration
         VerifyRuntimeEnvironment(StaticRuntimeEnvironment);
         
         BuildRootPath = GetWebAppDistRoot("WebApp", "dist");
-        HtmlTemplate = ReadHtmlTemplate(GetHtmlTemplatePath(), isDevelopment);
-        
         PermissionPolicies = GetPermissionsPolicies();
         ContentSecurityPolicies = GetContentSecurityPolicies(isDevelopment);
     }
@@ -47,8 +47,6 @@ public class WebAppMiddlewareConfiguration
     
     public string BuildRootPath { get; }
     
-    public string HtmlTemplate { get; }
-    
     public Dictionary<string, string> StaticRuntimeEnvironment { get; }
     
     public string StaticRuntimeEnvironmentEncoded { get; }
@@ -56,6 +54,22 @@ public class WebAppMiddlewareConfiguration
     public StringValues PermissionPolicies { get; }
     
     public string ContentSecurityPolicies { get; }
+    
+    public string GetHtmlTemplate()
+    {
+        if (_htmlTemplate is not null)
+        {
+            return _htmlTemplate;
+        }
+        
+        if (!File.Exists(_htmlTemplatePath))
+        {
+            throw new FileNotFoundException("index.html does not exist.", _htmlTemplatePath);
+        }
+        
+        _htmlTemplate = File.ReadAllText(_htmlTemplatePath, new UTF8Encoding());
+        return _htmlTemplate;
+    }
     
     private static string GetWebAppDistRoot(string webAppProjectName, string webAppDistRootName)
     {
@@ -76,26 +90,17 @@ public class WebAppMiddlewareConfiguration
     public static string GetHtmlTemplatePath()
     {
         var buildRootPath = GetWebAppDistRoot("WebApp", "dist");
-        return Path.Combine(buildRootPath, "index.html");
-    }
-    
-    private string ReadHtmlTemplate(string htmlTemplatePath, bool isDevelopment)
-    {
-        if (isDevelopment)
+        var htmlTemplatePath = Path.Combine(buildRootPath, "index.html");
+        
+        for (var i = 0; i < 10; i++)
         {
-            for (var i = 0; i < 10; i++)
-            {
-                if (File.Exists(htmlTemplatePath)) break;
-                Thread.Sleep(TimeSpan.FromSeconds(1));
-            }
+            // Fixing a race condition where this code might be called before the frontend build has created index.html
+            // When generating the Open API (Api.json) using OpenApiGenerateDocuments the index.html is not created yet
+            if (File.Exists(htmlTemplatePath)) break;
+            Thread.Sleep(TimeSpan.FromSeconds(1));
         }
         
-        if (!File.Exists(htmlTemplatePath))
-        {
-            throw new FileNotFoundException("index.html does not exist.", htmlTemplatePath);
-        }
-        
-        return File.ReadAllText(htmlTemplatePath, new UTF8Encoding());
+        return htmlTemplatePath;
     }
     
     private StringValues GetPermissionsPolicies()

--- a/developer-cli/Installation/PrerequisitesChecker.cs
+++ b/developer-cli/Installation/PrerequisitesChecker.cs
@@ -23,7 +23,7 @@ public static class PrerequisitesChecker
         new Prerequisite(PrerequisiteType.CommandLineTool, "yarn", "Yarn", new Version(1, 22)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "az", "Azure CLI", new Version(2, 55)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "gh", "GitHub CLI", new Version(2, 41)),
-        new Prerequisite(PrerequisiteType.DotnetWorkload, "aspire", "Aspire", Regex: """aspire\s*8\.0\.0-preview.5"""),
+        new Prerequisite(PrerequisiteType.DotnetWorkload, "aspire", "Aspire", Regex: """aspire\s*8\.0\.0-preview.6"""),
     ];
 
     public static void Check(params string[] prerequisiteName)
@@ -134,7 +134,7 @@ public static class PrerequisitesChecker
 
            Installed Workload Id      Manifest Version                     Installation Source
            -----------------------------------------------------------------------------------
-           aspire                     8.0.0-preview.5.24201.12/8.0.100     SDK 8.0.200
+           aspire                     8.0.0-preview.6.24214.1/8.0.100      SDK 8.0.200
 
            Use `dotnet workload search` to find additional workloads to install.
          */


### PR DESCRIPTION
### Summary & Motivation

Upgrade to Aspire preview 6, a minor update that is likely the last preview before its general availability (GA). This update introduces no breaking changes.

The prerequisites in the PlatformPlatform CLI have been upgraded to check for preview 6.

Upgrade all NuGet packages to latest version including OpenTelemetry, XUnit, and FluentValidation.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
