### PR TITLE
Add tests for user search endpoint

### DIFF
--- a/application/account-management/Application/Users/UpdateUser.cs
+++ b/application/account-management/Application/Users/UpdateUser.cs
@@ -24,7 +24,8 @@ public sealed class UpdateUserHandler(IUserRepository userRepository, ITelemetry
         var user = await userRepository.GetByIdAsync(command.Id, cancellationToken);
         if (user is null) return Result.NotFound($"User with id '{command.Id}' not found.");
         
-        user.Update(command.Email, command.UserRole);
+        user.UpdateEmail(command.Email);
+        user.ChangeUserRole(command.UserRole);
         userRepository.Update(user);
         
         events.CollectEvent(new UserUpdated());

--- a/application/account-management/Domain/Users/User.cs
+++ b/application/account-management/Domain/Users/User.cs
@@ -36,9 +36,19 @@ public sealed class User : AggregateRoot<UserId>
         return new User(tenantId, email, userRole, emailConfirmed) { Avatar = avatar };
     }
     
-    public void Update(string email, UserRole userRole)
+    public void Update(string firstName, string lastName)
+    {
+        FirstName = firstName;
+        LastName = lastName;
+    }
+    
+    public void UpdateEmail(string email)
     {
         Email = email;
+    }
+    
+    public void ChangeUserRole(UserRole userRole)
+    {
         UserRole = userRole;
     }
     

--- a/application/account-management/Infrastructure/Users/UserRepository.cs
+++ b/application/account-management/Infrastructure/Users/UserRepository.cs
@@ -31,8 +31,8 @@ internal sealed class UserRepository(AccountManagementDbContext accountManagemen
         
         if (search is not null)
         {
-            // We use the null-forgiving (!) operator here because the SQL LIKE operator handles NULL values gracefully
-            users = users.Where(u => u.Email.Contains(search) || u.FirstName!.Contains(search) || u.LastName!.Contains(search));
+            // Concatenate first and last name to enable searching by full name
+            users = users.Where(u => u.Email.Contains(search) || (u.FirstName + " " + u.LastName).Contains(search));
         }
         
         if (userRole is not null)

--- a/application/account-management/Infrastructure/Users/UserRepository.cs
+++ b/application/account-management/Infrastructure/Users/UserRepository.cs
@@ -64,7 +64,9 @@ internal sealed class UserRepository(AccountManagementDbContext accountManagemen
         var itemOffset = (pageOffset ?? 0) * pageSize.Value;
         var result = await users.Skip(itemOffset).Take(pageSize.Value).ToArrayAsync(cancellationToken);
         
-        var totalItems = await users.CountAsync(cancellationToken);
+        var totalItems = pageOffset == 0 && result.Length < pageSize
+            ? result.Length // If the first page returns fewer items than page size, skip querying the total count
+            : await users.CountAsync(cancellationToken);
         
         var totalPages = (totalItems - 1) / pageSize.Value + 1;
         return (result, totalItems, totalPages);

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -138,6 +138,13 @@ public abstract class BaseApiTests<TContext> : BaseTest<TContext> where TContext
         }
     }
     
+    protected async Task<T?> DeserializeResponse<T>(HttpResponseMessage response)
+    {
+        var responseStream = await response.Content.ReadAsStreamAsync();
+        
+        return await JsonSerializer.DeserializeAsync<T>(responseStream, JsonSerializerOptions);
+    }
+    
     private async Task<ProblemDetails?> DeserializeProblemDetails(HttpResponseMessage response)
     {
         var content = await response.Content.ReadAsStringAsync();

--- a/application/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Tenants/TenantEndpointsTests.cs
@@ -167,7 +167,7 @@ public sealed class TenantEndpointsTests : BaseApiTests<AccountManagementDbConte
         // Arrange
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
         var existingUserId = DatabaseSeeder.User1.Id;
-        _ = await TestHttpClient.DeleteAsync($"/api/users/{existingUserId}");
+        await TestHttpClient.DeleteAsync($"/api/users/{existingUserId}");
         TelemetryEventsCollectorSpy.Reset();
         
         // Act

--- a/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
@@ -75,6 +75,87 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
     }
     
     [Fact]
+    public async Task GetUsers_WhenSearchingBasedOnUserEmail_ShouldReturnUser()
+    {
+        // Arrange
+        var searchString = "willgate";
+        
+        // Act
+        var response = await TestHttpClient.GetAsync($"/api/users?search={searchString}");
+        
+        // Assert
+        EnsureSuccessGetRequest(response);
+        var userResponse = await DeserializeResponse<GetUsersResponseDto>(response);
+        userResponse.Should().NotBeNull();
+        userResponse!.TotalCount.Should().Be(1);
+        userResponse.Users.First().Email.Should().Be(DatabaseSeeder.User1ForSearching.Email);
+    }
+    
+    [Fact]
+    public async Task GetUsers_WhenSearchingBasedOnUserFirstName_ShouldReturnUser()
+    {
+        // Arrange
+        var searchString = "Will";
+        
+        // Act
+        var response = await TestHttpClient.GetAsync($"/api/users?search={searchString}");
+        
+        // Assert
+        EnsureSuccessGetRequest(response);
+        var userResponse = await DeserializeResponse<GetUsersResponseDto>(response);
+        userResponse.Should().NotBeNull();
+        userResponse!.TotalCount.Should().Be(1);
+        userResponse.Users.First().FirstName.Should().Be(DatabaseSeeder.User1ForSearching.FirstName);
+    }
+    
+    [Fact]
+    public async Task GetUsers_WhenSearchingBasedOnUserLastName_ShouldReturnUser()
+    {
+        // Arrange
+        var searchString = "Gate";
+        
+        // Act
+        var response = await TestHttpClient.GetAsync($"/api/users?search={searchString}");
+        
+        // Assert
+        EnsureSuccessGetRequest(response);
+        var userResponse = await DeserializeResponse<GetUsersResponseDto>(response);
+        userResponse.Should().NotBeNull();
+        userResponse!.TotalCount.Should().Be(1);
+        userResponse.Users.First().LastName.Should().Be(DatabaseSeeder.User1ForSearching.LastName);
+    }
+    
+    [Fact]
+    public async Task GetUsers_WhenSearchingBasedOnUserRole_ShouldReturnUser()
+    {
+        // Arrange
+        // Act
+        var response = await TestHttpClient.GetAsync($"/api/users?userRole={UserRole.TenantUser}");
+        
+        // Assert
+        EnsureSuccessGetRequest(response);
+        var userResponse = await DeserializeResponse<GetUsersResponseDto>(response);
+        userResponse.Should().NotBeNull();
+        userResponse!.TotalCount.Should().Be(1);
+        userResponse.Users.First().UserRole.Should().Be(DatabaseSeeder.User1ForSearching.UserRole);
+    }
+    
+    [Fact]
+    public async Task GetUsers_WhenSearchingWithSpecificOrdering_ShouldReturnOrderedUsers()
+    {
+        // Act
+        var response = await TestHttpClient.GetAsync($"/api/users?orderBy={SortableUserProperties.UserRole}");
+        
+        // Assert
+        EnsureSuccessGetRequest(response);
+        var userResponse = await DeserializeResponse<GetUsersResponseDto>(response);
+        userResponse.Should().NotBeNull();
+        userResponse!.TotalCount.Should().Be(3);
+        userResponse.Users.First().UserRole.Should().Be(UserRole.TenantOwner);
+        userResponse.Users.Last().UserRole.Should().Be(UserRole.TenantUser);
+    }
+    
+    [Fact]
     public async Task CreateUser_WhenValid_ShouldCreateUser()
     {
         // Arrange

--- a/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
@@ -109,10 +109,10 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
     }
     
     [Fact]
-    public async Task GetUsers_WhenSearchingBasedOnUserLastName_ShouldReturnUser()
+    public async Task GetUsers_WhenSearchingBasedOnFullName_ShouldReturnUser()
     {
         // Arrange
-        var searchString = "Gate";
+        var searchString = "William Henry Gates";
         
         // Act
         var response = await TestHttpClient.GetAsync($"/api/users?search={searchString}");

--- a/application/account-management/Tests/DatabaseSeeder.cs
+++ b/application/account-management/Tests/DatabaseSeeder.cs
@@ -12,7 +12,10 @@ public sealed class DatabaseSeeder
     public readonly AccountRegistration AccountRegistration1;
     public readonly string OneTimePassword;
     public readonly Tenant Tenant1;
+    public readonly Tenant TenantForSearching;
     public readonly User User1;
+    public readonly User User1ForSearching;
+    public readonly User User2ForSearching;
     
     public DatabaseSeeder(AccountManagementDbContext accountManagementDbContext)
     {
@@ -28,6 +31,18 @@ public sealed class DatabaseSeeder
         
         User1 = User.Create(Tenant1.Id, _faker.Internet.Email(), UserRole.TenantOwner, true, null);
         accountManagementDbContext.Users.AddRange(User1);
+        
+        TenantForSearching = Tenant.Create(new TenantId(_faker.Subdomain()), _faker.Internet.Email());
+        accountManagementDbContext.Tenants.AddRange(TenantForSearching);
+        
+        User1ForSearching = User.Create(TenantForSearching.Id, "willgates@email.com", UserRole.TenantUser, true, null);
+        User1ForSearching.Update("William Henry", "Gates");
+        
+        User2ForSearching = User.Create(TenantForSearching.Id, _faker.Internet.Email(), UserRole.TenantOwner, true, null);
+        
+        accountManagementDbContext.Users.AddRange(User1);
+        accountManagementDbContext.Users.AddRange(User1ForSearching);
+        accountManagementDbContext.Users.AddRange(User2ForSearching);
         
         accountManagementDbContext.SaveChanges();
     }


### PR DESCRIPTION
### Summary & Motivation

This pull request adds extra tests for the `GetUsersQuery` that handles user searches.

The search logic is updated to enable searches on full name. Additionally, the query logic has been optimized to request the Total Count from the database only if the primary result exceeds the page size, avoiding an extra database roundtrip in most cases.

The `User.Update` method is repurposed to update only the first name and last name. The existing `User.Update(email, userRole)` method is split into two separate methods, `UpdateEmail` and `ChangeUserRole`, to provide a clearer separation of use cases.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
