### PR TITLE
Optimize frontend startup time when using Aspire

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -38,7 +38,7 @@ jobs:
           echo "Generated version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Setup Node
+      - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -47,7 +47,7 @@ jobs:
         working-directory: application/account-management/WebApp
         run: yarn install --frozen-lockfile
 
-      - name: Setup .NET
+      - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
@@ -62,13 +62,13 @@ jobs:
         working-directory: application
         run: dotnet restore
 
-      - name: Setup Java
+      - name: Setup Java JDK
         uses: actions/setup-java@v4
         with:
           distribution: "microsoft"
           java-version: "17"
 
-      - name: Run Test with dotCover and SonarScanner reporting
+      - name: Run tests with dotCover and SonarScanner reporting
         working-directory: application
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -84,7 +84,7 @@ jobs:
             dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
           fi
 
-      - name: Build solution frontend
+      - name: Build frontend artifacts
         working-directory: application/account-management/WebApp
         run: yarn run msbuild
 
@@ -118,7 +118,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -126,7 +127,7 @@ jobs:
         working-directory: application/account-management/WebApp
         run: yarn install --frozen-lockfile
 
-      - name: Setup .NET
+      - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
@@ -141,11 +142,11 @@ jobs:
         working-directory: application
         run: dotnet restore
 
-      - name: Build solution backend
+      - name: Build backend solution
         working-directory: application
         run: dotnet build PlatformPlatform.sln --no-restore
 
-      - name: Build solution frontend
+      - name: Build frontend artifacts
         working-directory: application/account-management/WebApp
         run: yarn run msbuild
 

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -84,6 +84,10 @@ jobs:
             dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
           fi
 
+      - name: Build solution frontend
+        working-directory: application/account-management/WebApp
+        run: yarn run msbuild
+
       - name: Publish Account Management API build
         working-directory: application/account-management
         run: |
@@ -137,9 +141,13 @@ jobs:
         working-directory: application
         run: dotnet restore
 
-      - name: Build solution
+      - name: Build solution backend
         working-directory: application
         run: dotnet build PlatformPlatform.sln --no-restore
+
+      - name: Build solution frontend
+        working-directory: application/account-management/WebApp
+        run: yarn run msbuild
 
       - name: Run code inspections
         working-directory: application

--- a/application/account-management/Api/Properties/launchSettings.json
+++ b/application/account-management/Api/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",
         "PUBLIC_URL": "https://localhost:9000",
-        "CDN_URL": "https://localhost:9099"
+        "CDN_URL": "https://localhost:9101"
       }
     }
   }

--- a/application/account-management/Api/Properties/launchSettings.json
+++ b/application/account-management/Api/Properties/launchSettings.json
@@ -3,6 +3,7 @@
     "Api": {
       "commandName": "Project",
       "launchBrowser": true,
+      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:9100",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",

--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -21,7 +21,7 @@ public abstract class BaseApiTests<TContext> : BaseTest<TContext> where TContext
     protected BaseApiTests()
     {
         Environment.SetEnvironmentVariable(WebAppMiddlewareConfiguration.PublicUrlKey, "https://localhost:9000");
-        Environment.SetEnvironmentVariable(WebAppMiddlewareConfiguration.CdnUrlKey, "https://localhost:9099");
+        Environment.SetEnvironmentVariable(WebAppMiddlewareConfiguration.CdnUrlKey, "https://localhost:9101");
         
         _webApplicationFactory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
             {

--- a/application/account-management/WebApp/WebApp.esproj
+++ b/application/account-management/WebApp/WebApp.esproj
@@ -8,8 +8,8 @@
         <BuildOutputFolder>$(MSBuildProjectDirectory)\dist</BuildOutputFolder>
         <NpmInstallCheck>$(MSBuildProjectDirectory)\yarn.lock</NpmInstallCheck>
         <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
-        <!-- Command to run on project build -->
-        <BuildCommand>yarn run msbuild</BuildCommand>
+        <!-- When building locally, we just need to build the API contract from the Swagger API.json -->
+        <BuildCommand>yarn run swagger</BuildCommand>
         <!-- Command to create an optimized build of the project that's ready for publishing -->
         <ProductionBuildCommand>yarn run msbuild</ProductionBuildCommand>
     </PropertyGroup>

--- a/application/account-management/WebApp/package.json
+++ b/application/account-management/WebApp/package.json
@@ -9,8 +9,8 @@
     "lingui:compile": "lingui compile --typescript",
     "lint": "eslint .",
     "typechecking": "tsc --noEmit",
-    "msbuild": "yarn run msbuild:swagger && yarn run build",
-    "msbuild:swagger": "npx openapi-typescript lib/api/Api.json -o lib/api/api.generated.d.ts && npx prettier lib/api/api.generated.d.ts --write",
+    "msbuild": "yarn run swagger && yarn run build",
+    "swagger": "npx openapi-typescript lib/api/Api.json -o lib/api/api.generated.d.ts && npx prettier lib/api/api.generated.d.ts --write",
     "postinstall": "yarn run lingui:extract && yarn run lingui:compile"
   },
   "dependencies": {

--- a/application/account-management/WebApp/rspack.config.ts
+++ b/application/account-management/WebApp/rspack.config.ts
@@ -146,7 +146,7 @@ const configuration: Configuration = {
     headers: {
       "Access-Control-Allow-Origin": "*",
     },
-    port: 9099,
+    port: 9101,
     server: {
       type: "https",
       options: {


### PR DESCRIPTION
### Summary & Motivation

This update significantly reduces the time required to start the frontend with Aspire, improving the startup time from approximately 10 seconds to less than 1 second, depending on the machine.

Until now, starting the Aspire AppHost required a full build of all frontend artifacts by the WebApp, resulting in slow startup times and a subpar developer experience. When developing, we use the RSPack devserver, so these frontend artifacts were not needed. The `WebApp.esproj` has been updated to only generate the API contract based on the OpenAPI `Api.json` generated by the API build.

The GitHub workflow has been updated to build the frontend bundles needed for production.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
