### PR TITLE
Speed up starting and simplify building the WebApp

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -84,9 +84,9 @@ jobs:
             dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
           fi
 
-      - name: Build frontend artifacts
+      - name: Publish frontend artifacts
         working-directory: application/account-management/WebApp
-        run: yarn run msbuild
+        run: yarn run publish
 
       - name: Publish Account Management API build
         working-directory: application/account-management
@@ -146,10 +146,6 @@ jobs:
         working-directory: application
         run: dotnet build PlatformPlatform.sln --no-restore
 
-      - name: Build frontend artifacts
-        working-directory: application/account-management/WebApp
-        run: yarn run msbuild
-
       - name: Run code inspections
         working-directory: application
         run: |
@@ -172,6 +168,10 @@ jobs:
             echo "Formatting issues detected. Please run 'dotnet jb cleanupcode PlatformPlatform.sln --profile=\".NET only\"' locally and commit the formatted code."
             exit 1
           }
+
+      - name: Build frontend artifacts
+        working-directory: application/account-management/WebApp
+        run: yarn run build
 
       - name: Run ESLint
         working-directory: application/account-management/WebApp

--- a/application/AppGateway/AppGateway.csproj
+++ b/application/AppGateway/AppGateway.csproj
@@ -6,6 +6,7 @@
         <RootNamespace>PlatformPlatform.AppGateway</RootNamespace>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <DefaultItemExcludes>$(DefaultItemExcludes);publish\**;Dockerfile</DefaultItemExcludes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -14,11 +15,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\shared-kernel\InfrastructureCore\InfrastructureCore.csproj"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <Content Remove="publish\**"/>
-        <None Remove="publish\**"/>
     </ItemGroup>
 
 </Project>

--- a/application/account-management/Api/Api.csproj
+++ b/application/account-management/Api/Api.csproj
@@ -9,6 +9,7 @@
         <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/../WebApp/lib/api/</OpenApiDocumentsDirectory>
         <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>
         <OpenApiGenerateDocumentsOnBuild>true</OpenApiGenerateDocumentsOnBuild>
+        <DefaultItemExcludes>$(DefaultItemExcludes);publish\**;Dockerfile</DefaultItemExcludes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -40,11 +41,6 @@
         <Content Update="appsettings.development.json">
             <DependentUpon>appsettings.json</DependentUpon>
         </Content>
-    </ItemGroup>
-
-    <ItemGroup>
-        <Content Remove="publish\**"/>
-        <None Remove="publish\**"/>
     </ItemGroup>
 
 </Project>

--- a/application/account-management/WebApp/App.tsx
+++ b/application/account-management/WebApp/App.tsx
@@ -1,9 +1,0 @@
-function App() {
-  return (
-    <div className="App">
-      <h1>Account Management</h1>
-    </div>
-  );
-}
-
-export default App;

--- a/application/account-management/WebApp/WebApp.esproj
+++ b/application/account-management/WebApp/WebApp.esproj
@@ -4,6 +4,7 @@
         <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
         <BuildCommand>yarn install --frozen-lockfile --ignore-engines</BuildCommand>
         <TargetFrameworkMoniker>net8.0</TargetFrameworkMoniker>
+        <DefaultItemExcludes>$(DefaultItemExcludes);dist\**;*.config.*;*.d.ts</DefaultItemExcludes>
     </PropertyGroup>
 
 </Project>

--- a/application/account-management/WebApp/WebApp.esproj
+++ b/application/account-management/WebApp/WebApp.esproj
@@ -1,41 +1,9 @@
 <Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/1.0.751930">
 
     <PropertyGroup>
-        <StartupCommand>set BROWSER=none;yarn dev</StartupCommand>
-        <JavaScriptTestRoot>.\</JavaScriptTestRoot>
-        <JavaScriptTestFramework>Jest</JavaScriptTestFramework>
-        <!-- Folder where production build objects will be placed -->
-        <BuildOutputFolder>$(MSBuildProjectDirectory)\dist</BuildOutputFolder>
-        <NpmInstallCheck>$(MSBuildProjectDirectory)\yarn.lock</NpmInstallCheck>
         <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
-        <!-- When building locally, we just need to build the API contract from the Swagger API.json -->
-        <BuildCommand>yarn run swagger</BuildCommand>
-        <!-- Command to create an optimized build of the project that's ready for publishing -->
-        <ProductionBuildCommand>yarn run msbuild</ProductionBuildCommand>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(OS)'=='WINDOWS_NT'">
+        <BuildCommand>yarn install --frozen-lockfile --ignore-engines</BuildCommand>
         <TargetFrameworkMoniker>net8.0</TargetFrameworkMoniker>
     </PropertyGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\Api\Api.csproj"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <Script Include="tsconfig.json"/>
-    </ItemGroup>
-
-    <Target Name="FrontendDependencies" BeforeTargets="BeforeBuild">
-        <Exec Command="yarn install --frozen-lockfile --ignore-engines" WorkingDirectory="$(ProjectDir)"/>
-    </Target>
-
-    <Target Name="BuildFrontend" AfterTargets="Build">
-        <ItemGroup>
-            <WebAppSourceFiles Include="$(ProjectDir)dist/**/*.*"/>
-        </ItemGroup>
-
-        <Copy SourceFiles="@(WebAppSourceFiles)" DestinationFolder="$(ProjectDir)../Api/publish/WebApp/dist/%(RecursiveDir)"/>
-    </Target>
 
 </Project>

--- a/application/account-management/WebApp/dist/index.html
+++ b/application/account-management/WebApp/dist/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="%LOCALE%">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="robots" content="nofollow" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <meta content="PlatformPlatform ACME demo" name="description" />
+    <title>PlatformPlatform</title>
+    <link rel="preload" as="image" href="%CDN_URL%/images/hero-mobile-xl.webp" />
+    <link rel="preload" as="image" href="%CDN_URL%/images/hero-desktop-xl.webp" />
+  <meta content="%ENCODED_RUNTIME_ENV%" name="runtimeEnv" /><meta content="%ENCODED_USER_INFO_ENV%" name="userInfoEnv" /><script src="%CDN_URL%/main.js" defer></script><link href="%CDN_URL%/main.css" rel="stylesheet" /></head>
+  <body>
+    <div id="root"></div>
+  
+
+</body></html>

--- a/application/account-management/WebApp/package.json
+++ b/application/account-management/WebApp/package.json
@@ -9,8 +9,9 @@
     "lingui:compile": "lingui compile --typescript",
     "lint": "eslint .",
     "typechecking": "tsc --noEmit",
-    "msbuild": "yarn run swagger && yarn run build",
+    "msbuild": "yarn run swagger && yarn run build && yarn run publish",
     "swagger": "npx openapi-typescript lib/api/Api.json -o lib/api/api.generated.d.ts && npx prettier lib/api/api.generated.d.ts --write",
+    "publish": "mkdir -p ../Api/publish/WebApp/dist/ && rsync -r ./dist/ ../Api/publish/WebApp/dist/",
     "postinstall": "yarn run lingui:extract && yarn run lingui:compile"
   },
   "dependencies": {

--- a/application/account-management/WebApp/package.json
+++ b/application/account-management/WebApp/package.json
@@ -3,15 +3,13 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "rspack serve",
-    "build": "rspack build && tsc --noEmit",
-    "lingui:extract": "lingui extract",
-    "lingui:compile": "lingui compile --typescript",
+    "dev": "yarn run update-translations && yarn run swagger && rspack serve",
+    "build": "yarn run update-translations && yarn run swagger && rspack build && yarn run typechecking",
+    "update-translations": "yarn run lingui extract && yarn run lingui compile --typescript",
     "lint": "eslint .",
     "typechecking": "tsc --noEmit",
-    "publish": "yarn run swagger && yarn run build && mkdir -p ../Api/publish/WebApp/dist/ && rsync -r ./dist/ ../Api/publish/WebApp/dist/",
     "swagger": "npx openapi-typescript lib/api/Api.json -o lib/api/api.generated.d.ts && npx prettier lib/api/api.generated.d.ts --write",
-    "postinstall": "yarn run lingui:extract && yarn run lingui:compile"
+    "publish": "yarn run build && mkdir -p ../Api/publish/WebApp/dist/ && rsync -r ./dist/ ../Api/publish/WebApp/dist/"
   },
   "dependencies": {
     "@lingui/core": "^4.6.0",

--- a/application/account-management/WebApp/package.json
+++ b/application/account-management/WebApp/package.json
@@ -9,9 +9,8 @@
     "lingui:compile": "lingui compile --typescript",
     "lint": "eslint .",
     "typechecking": "tsc --noEmit",
-    "msbuild": "yarn run swagger && yarn run build && yarn run publish",
+    "publish": "yarn run swagger && yarn run build && mkdir -p ../Api/publish/WebApp/dist/ && rsync -r ./dist/ ../Api/publish/WebApp/dist/",
     "swagger": "npx openapi-typescript lib/api/Api.json -o lib/api/api.generated.d.ts && npx prettier lib/api/api.generated.d.ts --write",
-    "publish": "mkdir -p ../Api/publish/WebApp/dist/ && rsync -r ./dist/ ../Api/publish/WebApp/dist/",
     "postinstall": "yarn run lingui:extract && yarn run lingui:compile"
   },
   "dependencies": {

--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddlewareConfiguration.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddlewareConfiguration.cs
@@ -13,7 +13,8 @@ public class WebAppMiddlewareConfiguration
     public const string CdnUrlKey = "CDN_URL";
     private const string PublicKeyPrefix = "PUBLIC_";
     private const string ApplicationVersionKey = "APPLICATION_VERSION";
-    private readonly string _htmlTemplatePath = GetHtmlTemplatePath();
+    
+    public static readonly string HtmlTemplatePath = Path.Combine(GetWebAppDistRoot("WebApp", "dist"), "index.html");
     private readonly string[] _publicAllowedKeys = [CdnUrlKey, ApplicationVersionKey];
     private string? _htmlTemplate;
     
@@ -62,12 +63,12 @@ public class WebAppMiddlewareConfiguration
             return _htmlTemplate;
         }
         
-        if (!File.Exists(_htmlTemplatePath))
+        if (!File.Exists(HtmlTemplatePath))
         {
-            throw new FileNotFoundException("index.html does not exist.", _htmlTemplatePath);
+            throw new FileNotFoundException("index.html does not exist.", HtmlTemplatePath);
         }
         
-        _htmlTemplate = File.ReadAllText(_htmlTemplatePath, new UTF8Encoding());
+        _htmlTemplate = File.ReadAllText(HtmlTemplatePath, new UTF8Encoding());
         return _htmlTemplate;
     }
     
@@ -85,22 +86,6 @@ public class WebAppMiddlewareConfiguration
         }
         
         return Path.Join(directoryInfo!.FullName, webAppProjectName, webAppDistRootName);
-    }
-    
-    public static string GetHtmlTemplatePath()
-    {
-        var buildRootPath = GetWebAppDistRoot("WebApp", "dist");
-        var htmlTemplatePath = Path.Combine(buildRootPath, "index.html");
-        
-        for (var i = 0; i < 10; i++)
-        {
-            // Fixing a race condition where this code might be called before the frontend build has created index.html
-            // When generating the Open API (Api.json) using OpenApiGenerateDocuments the index.html is not created yet
-            if (File.Exists(htmlTemplatePath)) break;
-            Thread.Sleep(TimeSpan.FromSeconds(1));
-        }
-        
-        return htmlTemplatePath;
     }
     
     private StringValues GetPermissionsPolicies()

--- a/application/shared-kernel/ApiCore/Middleware/WebAppMiddlewareExtensions.cs
+++ b/application/shared-kernel/ApiCore/Middleware/WebAppMiddlewareExtensions.cs
@@ -24,7 +24,16 @@ public static class WebAppMiddlewareExtensions
     
     public static IApplicationBuilder UseWebAppMiddleware(this IApplicationBuilder app)
     {
-        if (!Path.Exists(WebAppMiddlewareConfiguration.GetHtmlTemplatePath())) return app;
+        if (!File.Exists(WebAppMiddlewareConfiguration.HtmlTemplatePath))
+        {
+            // When running locally, this code might be called while index.html is recreated, give it a few seconds to finish.
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+        }
+        
+        if (!File.Exists(WebAppMiddlewareConfiguration.HtmlTemplatePath))
+        {
+            throw new InvalidOperationException("The index.html file is missing.");
+        }
         
         var webAppConfiguration = app.ApplicationServices.GetRequiredService<WebAppMiddlewareConfiguration>();
         


### PR DESCRIPTION
### Summary & Motivation

Speed up starting the frontend WebApp. Starting Aspire Dashboard and all dependencies now only takes a handful of seconds depending on the machine. This is accomplished while simultaneously optimizing the orchestration of the frontend build.

The following changes have been made:
- `dist/index.html` is added to git. This guarantees it's always available, allowing the API to start faster, as it previously waits for `index.html` to be created, which takes between 1-10 seconds. Retry logic from `WebAppMiddleware` is hence no longer needed and is removed. This in turn enables simplifying the generation of OpenAPI `Api.json` as this no longer needs to gracefully handle if `index.html` did not exist.
- MSBuild logic has been moved from the `WebApp.esproj` into `package.json`, greatly simplifying setup using only classic `package.json` scripts.
- `msbuild` and `publish` yarn scripts have been combined into one script called `publish`.
- Frontend translations and swagger generation have been moved into yarn `dev` and `build`. These now run when starting the Aspire process instead of when building the WebApp. This allows removing the dependency on `Api.csproj`, enabling .NET to build the `WebApp` in parallel, enhancing startup time.

Finally, all configuration files (`*.config.*` and `*.d.ts`) are now hidden in the WebApp in Rider and Visual Studio, allowing for a focused developer experience when not changing the frontend build. Similarly, `Dockerfiles` have been hidden in .NET projects. This is done using the `DefaultItemExcludes` property, which also ensures that MSBuild does not evaluate these files, yielding a minor performance improvement.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
