### PR TITLE
Correct directory name for developer cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ dotnet run
 Run this command to automate Azure Subscription configuration and set up [GitHub Workflows](https://github.com/platformplatform/PlatformPlatform/actions) for deploying [Azure Infrastructure](/cloud-infrastructure/) (using Bicep) and compiling [application code](/application/) to Docker images deployed to Azure Container Apps:
 
 ```bash
-cd development-cli
+cd developer-cli
 dotnet run configure-continuous-deployments # Tip: Add --verbose-logging to show the used CLI commands
 ```
 


### PR DESCRIPTION
### Summary & Motivation

Fix incorrect instructions in the README file where the directory name `development-cli` is mentioned. It should be `developer-cli`.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
