### PR TITLE
Revert React and React Dom to canary

### DIFF
--- a/application/account-management/WebApp/package.json
+++ b/application/account-management/WebApp/package.json
@@ -19,9 +19,9 @@
     "@microsoft/applicationinsights-web": "^3.2.0",
     "lucide-react": "^0.376.0",
     "openapi-fetch": "^0.9.5",
-    "react": "18.3.1",
+    "react": "18.3.0-canary-c47c306a7-20231109",
     "react-aria-components": "^1.1.1",
-    "react-dom": "18.3.1",
+    "react-dom": "18.3.0-canary-c47c306a7-20231109",
     "react-dom-confetti": "^0.2.0",
     "tailwind-merge": "^2.3.0",
     "tailwind-variants": "^0.2.1",
@@ -55,6 +55,14 @@
     "tailwindcss-react-aria-components": "^1.1.1",
     "tslib": "2.6.2",
     "typescript": "^5.4.5"
+  },
+  "overrides": {
+    "react": "$react",
+    "react-dom": "$react-dom"
+  },
+  "resolutions": {
+    "react": "18.3.0-canary-c47c306a7-20231109",
+    "react-dom": "18.3.0-canary-c47c306a7-20231109"
   },
   "browserslist": [
     "last 1 version",


### PR DESCRIPTION
### Summary & Motivation

Upgrading to React 18.3.x broke the use of `useFormState`, which remains an experimental feature, which will hopefully make it into React 19. Until a permanent fix is found, we will continue to use React 18.3 canary.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
