### PR TITLE
Update WSL guide installing and trusting certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ Open a terminal and run the following commands:
   curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
   ```
 
+- Install Certificate
+  ```bash
+  dotnet tool update -g linux-dev-certs
+  dotnet linux-dev-certs install
+  ```
+
+- Trust Certificates
+
+  ```bash
+  cd /usr/local/share/ca-certificates/aspnet-dev-{Environment.UserName}.crt && explorer.exe .
+  # Install self signed root certificate
+
+  # Open the windows certificate manager and import root certificate
+  # "\\wsl.localhost\Ubuntu-20.04\home\maximus\.aspnet\dev-certs\https\platformplatform.pfx"
+  ```
+
 </details>
 
 ## 1. Fork and clone the repository


### PR DESCRIPTION
### Summary & Motivation

The `dotnet dev-certs` tool currently does not support Linux. To address this, we have added a small guide using the `dotnet` tool's `linux-dev-certs` command. Additionally, the guide includes steps on how to manually trust the generated certificates on Windows.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
