### PR TITLE
Set up Entity Framework core DbContext pooling

### DIFF
--- a/application/account-management/Tests/Api/BaseApiTest.cs
+++ b/application/account-management/Tests/Api/BaseApiTest.cs
@@ -29,7 +29,7 @@ public abstract class BaseApiTests<TContext> : BaseTest<TContext> where TContext
                     {
                         // Replace the default DbContext in the WebApplication to use an in-memory SQLite database 
                         services.Remove(services.Single(d => d.ServiceType == typeof(DbContextOptions<TContext>)));
-                        services.AddDbContext<TContext>(options => { options.UseSqlite(Connection); });
+                        services.AddDbContextPool<TContext>(options => { options.UseSqlite(Connection); });
                         
                         TelemetryEventsCollectorSpy = new TelemetryEventsCollectorSpy(new TelemetryEventsCollector());
                         services.AddScoped<ITelemetryEventsCollector>(_ => TelemetryEventsCollectorSpy);

--- a/application/account-management/Tests/BaseTest.cs
+++ b/application/account-management/Tests/BaseTest.cs
@@ -41,7 +41,7 @@ public abstract class BaseTest<TContext> : IDisposable where TContext : DbContex
         // Create connection and add DbContext to the service collection
         Connection = new SqliteConnection("DataSource=:memory:");
         Connection.Open();
-        Services.AddDbContext<TContext>(options => { options.UseSqlite(Connection); });
+        Services.AddDbContextPool<TContext>(options => { options.UseSqlite(Connection); });
         
         Services
             .AddApplicationServices()

--- a/application/shared-kernel/InfrastructureCore/EntityFramework/SharedKernelDbContext.cs
+++ b/application/shared-kernel/InfrastructureCore/EntityFramework/SharedKernelDbContext.cs
@@ -10,14 +10,6 @@ namespace PlatformPlatform.SharedKernel.InfrastructureCore.EntityFramework;
 public abstract class SharedKernelDbContext<TContext>(DbContextOptions<TContext> options)
     : DbContext(options) where TContext : DbContext
 {
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    {
-        optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
-        optionsBuilder.AddInterceptors(new UpdateAuditableEntitiesInterceptor());
-        
-        base.OnConfiguring(optionsBuilder);
-    }
-    
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         // Ensures that all enum properties are stored as strings in the database.

--- a/application/shared-kernel/Tests/TestEntities/TestDbContext.cs
+++ b/application/shared-kernel/Tests/TestEntities/TestDbContext.cs
@@ -8,6 +8,14 @@ public sealed class TestDbContext(DbContextOptions<TestDbContext> options)
 {
     public DbSet<TestAggregate> TestAggregates => Set<TestAggregate>();
     
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
+        optionsBuilder.AddInterceptors(new UpdateAuditableEntitiesInterceptor());
+        
+        base.OnConfiguring(optionsBuilder);
+    }
+    
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);


### PR DESCRIPTION
### Summary & Motivation

This pull request will enable the `DbContext` pooling and moves all the `DbContext` configuration under the `Aspire SqlClient` extension methods. This is because we can't set up any `DbContext` configuration using the `OnConfiguring` method when the pooling is enabled. 


### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
