### PR TITLE
Update to .NET Aspire preview 7

### DIFF
--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -16,7 +16,7 @@ var azureStorage = builder
     .RunAsEmulator(resourceBuilder =>
         {
             resourceBuilder.WithVolume("azure-storage-data", "/data");
-            resourceBuilder.UseBlobPort(10000);
+            resourceBuilder.WithBlobPort(10000);
         }
     )
     .AddBlobs("blobs");

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -6,7 +6,7 @@
     <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
     <AspNetCoreVersion>8.0.4</AspNetCoreVersion>
     <EfCoreVersion>8.0.4</EfCoreVersion>
-    <AspireVersion>8.0.0-preview.6.24214.1</AspireVersion>
+    <AspireVersion>8.0.0-preview.7.24251.11</AspireVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -45,7 +45,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />
     <!-- PlatformPlatform dependencies - Tests -->
-    <PackageVersion Include="Bogus" Version="35.5.0" />
+    <PackageVersion Include="Bogus" Version="35.5.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -57,8 +57,8 @@
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="NJsonSchema" Version="11.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="xunit" Version="2.7.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.8">
+    <PackageVersion Include="xunit" Version="2.8.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
@@ -88,7 +88,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <!-- Open Telemetry -->
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />

--- a/developer-cli/Installation/PrerequisitesChecker.cs
+++ b/developer-cli/Installation/PrerequisitesChecker.cs
@@ -23,7 +23,7 @@ public static class PrerequisitesChecker
         new Prerequisite(PrerequisiteType.CommandLineTool, "yarn", "Yarn", new Version(1, 22)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "az", "Azure CLI", new Version(2, 55)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "gh", "GitHub CLI", new Version(2, 41)),
-        new Prerequisite(PrerequisiteType.DotnetWorkload, "aspire", "Aspire", Regex: """aspire\s*8\.0\.0-preview.6"""),
+        new Prerequisite(PrerequisiteType.DotnetWorkload, "aspire", "Aspire", Regex: """aspire\s*8\.0\.0-preview.7"""),
     ];
 
     public static void Check(params string[] prerequisiteName)
@@ -131,11 +131,11 @@ public static class PrerequisitesChecker
 
         /*
            The output is on the form:
-
-           Installed Workload Id      Manifest Version                     Installation Source
-           -----------------------------------------------------------------------------------
-           aspire                     8.0.0-preview.6.24214.1/8.0.100      SDK 8.0.200
-
+           
+           Installed Workload Id      Manifest Version                      Installation Source
+           ------------------------------------------------------------------------------------
+           aspire                     8.0.0-preview.7.24251.11/8.0.100      SDK 8.0.200
+           
            Use `dotnet workload search` to find additional workloads to install.
          */
         var regex = new Regex(workloadRegex);


### PR DESCRIPTION
### Summary & Motivation

Upgrade to Aspire preview 7, a minor unplanned update before general availability (GA). This update includes a small breaking change where `UseBlobPort()` was renamed to `WithBlobPort()`.

The prerequisites in the PlatformPlatform CLI have been upgraded to check for preview 7.

Additionally, upgrade all NuGet packages to the latest versions, including OpenTelemetry, XUnit, and Bogus.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
