### PR TITLE
Use rimraf for operating system agnostic deleting WebApp dist folder

### DIFF
--- a/application/account-management/WebApp/package.json
+++ b/application/account-management/WebApp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "rm ./dist/*.* && yarn run update-translations && yarn run swagger && rspack serve",
+    "dev": "rimraf ./dist && yarn run update-translations && yarn run swagger && rspack serve",
     "build": "yarn run update-translations && yarn run swagger && rspack build && yarn run typechecking",
     "update-translations": "yarn run lingui extract && yarn run lingui compile --typescript",
     "lint": "eslint .",
@@ -49,6 +49,7 @@
     "openapi-typescript": "6.7.5",
     "postcss": "^8.4.38",
     "postcss-loader": "^8.1.1",
+    "rimraf": "^5.0.7",
     "swc-loader": "0.2.6",
     "tailwindcss": "^3.4.3",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
### Summary & Motivation

When running on Windows, the WebApp build for Account-Management fails because it is using `rm` for deleting all files in the `dist` folder. `rm` does not exist on Windows so it fails. `rimraf` is an operating system agnostic tool for deleting files.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
