### PR TITLE
Update rimraf usage to only delete contents inside the dist folder, keeping the folder itself

### DIFF
--- a/application/account-management/WebApp/package.json
+++ b/application/account-management/WebApp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "rimraf ./dist && yarn run update-translations && yarn run swagger && rspack serve",
+    "dev": "rimraf ./dist/* && yarn run update-translations && yarn run swagger && rspack serve",
     "build": "yarn run update-translations && yarn run swagger && rspack build && yarn run typechecking",
     "update-translations": "yarn run lingui extract && yarn run lingui compile --typescript",
     "lint": "eslint .",


### PR DESCRIPTION
### Summary & Motivation

Update the use of `rimraf` to only delete the content inside the folder, as deleting the entire folder made starting the WebApp fail.


### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
