### PR TITLE
 Enhance the CLI for setting up CI/CD and improve the first-time start of Aspire AppHost for better stability and usability

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -62,7 +62,7 @@ jobs:
         working-directory: application
         run: dotnet restore
 
-      - name: Setup Java JDK
+      - name: Setup Java JDK for SonarScanner
         uses: actions/setup-java@v4
         with:
           distribution: "microsoft"

--- a/README.md
+++ b/README.md
@@ -166,16 +166,14 @@ Our clean commit history serves as a great learning and troubleshooting resource
 
 ## 2. Run the Aspire AppHost to spin up everything on localhost
 
-To spin up the backend, frontend and all dependencies like SQL Server, Blob Storage, Mail Server in Docker, simply open the [PlatformPlatform](/application/PlatformPlatform.sln) solution in Rider or Visual Studio and run the [Aspire AppHost](/application/AppHost/AppHost.csproj) project.
-
-With Docker Desktop installed, .NET Aspire will do all the orchestration and spin up everything with a single click. No need to learn Docker, install database and web server, or to learn complicated commands. It just works 🎉
-
-If you prefer the CLI, you can run the following command:
+Using .NET Aspire, docker images with SQL Server, Blob Storage, and mail server will be downloaded and started. No need install anything, or learn complicated commands. Simply run this command, and everything just works 🎉
 
 ```bash
-cd application/AppHost
-dotnet run
+cd developer-cli
+dotnet run dev # First run will be slow as Docker images are downloaded
 ```
+
+Alternatively, open the [PlatformPlatform](/application/PlatformPlatform.sln) solution in Rider or Visual Studio and run the [Aspire AppHost](/application/AppHost/AppHost.csproj) project.
 
 ## 3. Set up CI/CD with passwordless deployments from GitHub to Azure
 

--- a/developer-cli/Commands/BuildCommand.cs
+++ b/developer-cli/Commands/BuildCommand.cs
@@ -24,7 +24,7 @@ public class BuildCommand : Command
 
     private int Execute(string? solutionName)
     {
-        PrerequisitesChecker.Check("aspire", "node", "yarn");
+        PrerequisitesChecker.Check("dotnet", "aspire", "node", "yarn");
 
         var workingDirectory = Path.Combine(Configuration.GetSourceCodeFolder(), "..", "application");
 

--- a/developer-cli/Commands/CodeCleanupCommand.cs
+++ b/developer-cli/Commands/CodeCleanupCommand.cs
@@ -17,6 +17,8 @@ public class CodeCleanupCommand : Command
 
     private int Execute()
     {
+        PrerequisitesChecker.Check("dotnet");
+
         var workingDirectory = Path.Combine(Configuration.GetSourceCodeFolder(), "..", "application");
 
         ProcessHelper.StartProcess("dotnet tool restore", workingDirectory);

--- a/developer-cli/Commands/CodeCoverageCommand.cs
+++ b/developer-cli/Commands/CodeCoverageCommand.cs
@@ -17,6 +17,8 @@ public class CodeCoverageCommand : Command
 
     private int Execute()
     {
+        PrerequisitesChecker.Check("dotnet");
+
         var workingDirectory = new DirectoryInfo(Path.Combine(Configuration.GetSourceCodeFolder(), "..", "application")).FullName;
 
         ProcessHelper.StartProcess("dotnet tool restore", workingDirectory);

--- a/developer-cli/Commands/CodeInspectionsCommand.cs
+++ b/developer-cli/Commands/CodeInspectionsCommand.cs
@@ -17,6 +17,8 @@ public class CodeInspectionsCommand : Command
 
     private int Execute()
     {
+        PrerequisitesChecker.Check("dotnet");
+
         var workingDirectory = Path.Combine(Configuration.GetSourceCodeFolder(), "..", "application");
 
         ProcessHelper.StartProcess("dotnet tool restore", workingDirectory);

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -28,7 +28,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
 
     private int Execute(bool skipAzureLogin = false, bool verboseLogging = false)
     {
-        PrerequisitesChecker.Check("az", "gh");
+        PrerequisitesChecker.Check("dotnet", "az", "gh");
 
         AzureInfo azureInfo = new();
 

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -597,7 +597,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
         }
 
         var watchWorkflowRunCommand = $"gh run watch {workflowId.Value}";
-        ProcessHelper.StartProcess(watchWorkflowRunCommand, Configuration.GetSourceCodeFolder());
+        ProcessHelper.StartProcessWithSystemShell(watchWorkflowRunCommand, Configuration.GetSourceCodeFolder());
     }
 
     private void ShowSuccessMessage(GithubInfo githubInfo)

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -392,40 +392,38 @@ public class ConfigureContinuousDeploymentsCommand : Command
 
     private void ConfirmChangesPrompt(GithubInfo githubInfo, AzureInfo azureInfo)
     {
-        var appRegistrationInto = azureInfo.AppRegistrationExists ? "Update" : "Create";
-        var reuseSqlAdminsSecurityGroupIntro = azureInfo.SqlAdminsSecurityGroupExists ? "Update" : "Create";
+        var appRegistrationAction = azureInfo.AppRegistrationExists ? "updated" : "created";
+        var reuseSqlAdminsSecurityGroupAction = azureInfo.SqlAdminsSecurityGroupExists ? "updated" : "created";
 
         var setupConfirmPrompt =
             $"""
-             [bold]If you continue the following changes will be made:[/]
+             [bold]If you continue the following will happen:[/]
 
-             1. Ensure deployment of Azure Container Apps Environment is enabled on Azure Subscription: [blue]{azureInfo.Subscription.Name} ({azureInfo.Subscription.Id})[/]
+             1. The App Registration named [blue]{azureInfo.AppRegistrationName}[/] will be {appRegistrationAction} allowing GitHub to do passwordless deployments to Azure.
 
-             2. {appRegistrationInto} [blue]{azureInfo.AppRegistrationName}[/] App Registration with Federated Credentials and trust deployments from Github
+             2. The App Registration will be granted the 'Contributor' and 'User Access Administrator' roles in the Azure Subscription.
 
-             3. Grant the App Registration 'Contributor' and 'User Access Administrator' role to the Azure Subscription
+             3. The AD Security Group [blue]{azureInfo.SqlAdminsSecurityGroupName}[/] will be {reuseSqlAdminsSecurityGroupAction}, with the App Registration set as the owner.
 
-             4. {reuseSqlAdminsSecurityGroupIntro} [blue]{azureInfo.SqlAdminsSecurityGroupName}[/] AD Security Group and make the App Registration owner
-
-             5. Configure GitHub Repository [blue]{githubInfo.GithubUrl}[/] with the following
+             4. The GitHub Repository [blue]{githubInfo.GithubUrl}[/] will be configured with the following secrets and variables:
              
-                GitHub Secrets:
+                GitHub Secrets (soft secrets):
                 * AZURE_TENANT_ID: [blue]{azureInfo.Subscription.TenantId}[/]
                 * AZURE_SUBSCRIPTION_ID: [blue]{azureInfo.Subscription.Id}[/]
                 * AZURE_SERVICE_PRINCIPAL_ID: [blue]{azureInfo.AppRegistrationId ?? "will be generated"}[/]
                 * ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID: [blue]{azureInfo.SqlAdminsSecurityGroupId ?? "will be generated"}[/]
-                
+             
                 GitHub Variables:
                 * CONTAINER_REGISTRY_NAME: [blue]{azureInfo.ContainerRegistry.Name}[/]
-                * DOMAIN_NAME_PRODUCTION: [blue]{azureInfo.ProductionDomainName}[/]
-                * DOMAIN_NAME_STAGING: [blue]{azureInfo.StagingDomainName}[/]
+                * DOMAIN_NAME_PRODUCTION: [blue]{azureInfo.ProductionDomainName}[/] (can be changed later)
+                * DOMAIN_NAME_STAGING: [blue]{azureInfo.StagingDomainName}[/] (can be changed later)
                 * UNIQUE_CLUSTER_PREFIX: [blue]{azureInfo.UniquePrefix}[/]
 
-             6. Create [blue]shared[/], [blue]staging[/], and [blue]production[/] environments in GitHub repository
+             5. The following environments will be created in the GitHub repository [blue]shared[/], [blue]staging[/], and [blue]production[/] if they do not exist.
 
-             7. Provide instructions on how to do the first deployment of infrastructure and application to Azure, and make recommendations configuring to GitHub
+             6. You will receive instructions for initial infrastructure and application deployment to Azure, as well as GitHub configuration recommendations.
 
-             Please note that you can run this command multiple times to update the configuration.
+             Please note that this command can be run again update the configuration. Use the [yellow]--skip-azure-login[/] flag to avoid logging in to Azure again.
 
              [bold]Would you like to continue?[/]
              """;

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -579,14 +579,14 @@ public class ConfigureContinuousDeploymentsCommand : Command
             var state = element.GetProperty("state").GetString()!;
 
             if (name != workflowName || state != "active") continue;
-            
+
             // Disable the workflow if it is active
             var workflowId = element.GetProperty("id").GetInt64();
             var disableCommand = $"gh workflow disable {workflowId}";
             ProcessHelper.StartProcess(disableCommand, Configuration.GetSourceCodeFolder(), true);
 
             AnsiConsole.MarkupLine($"[green]Workflow {workflowName} has been disabled.[/]");
-            
+
             break;
         }
     }

--- a/developer-cli/Commands/DevCommand.cs
+++ b/developer-cli/Commands/DevCommand.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using JetBrains.Annotations;
 using PlatformPlatform.DeveloperCli.Installation;
 using PlatformPlatform.DeveloperCli.Utilities;
+using Spectre.Console;
 
 namespace PlatformPlatform.DeveloperCli.Commands;
 
@@ -21,6 +22,21 @@ public class DevCommand : Command
 
         var workingDirectory = Path.Combine(Configuration.GetSourceCodeFolder(), "..", "application", "AppHost");
 
+        if (!ProcessHelper.IsProcessRunning("Docker"))
+        {
+            AnsiConsole.MarkupLine("[green]Starting Docker Desktop[/]");
+            ProcessHelper.StartProcess("open -a Docker", waitForExit: true);
+        }
+
+        AnsiConsole.MarkupLine("\n[green]Ensuring Docker image for SQL Server is up to date ...[/]");
+        ProcessHelper.StartProcessWithSystemShell("docker pull mcr.microsoft.com/mssql/server:2022-latest");
+
+        AnsiConsole.MarkupLine("\n[green]Ensuring Docker image for Azure Blob Storage Emulator ...[/]");
+        ProcessHelper.StartProcessWithSystemShell("docker pull mcr.microsoft.com/azure-storage/azurite:latest");
+
+        AnsiConsole.MarkupLine("\n[green]Ensuring Docker image for Mail Server and Web Client is up to date ...[/]");
+        ProcessHelper.StartProcessWithSystemShell("docker pull axllent/mailpit:latest");
+
         Task.Run(async () =>
             {
                 // Start a background task that monitors the websites and opens the browser when ready
@@ -31,6 +47,7 @@ public class DevCommand : Command
             }
         );
 
+        AnsiConsole.MarkupLine("\n[green]Starting the Aspire AppHost...[/]");
         ProcessHelper.StartProcess("dotnet run", workingDirectory);
     }
 

--- a/developer-cli/Commands/DevCommand.cs
+++ b/developer-cli/Commands/DevCommand.cs
@@ -8,9 +8,9 @@ using PlatformPlatform.DeveloperCli.Utilities;
 namespace PlatformPlatform.DeveloperCli.Commands;
 
 [UsedImplicitly]
-public class RunCommand : Command
+public class DevCommand : Command
 {
-    public RunCommand() : base("run", "Run the Aspire AppHost with all self-contained systems")
+    public DevCommand() : base("dev", "Run the Aspire AppHost with all self-contained systems")
     {
         Handler = CommandHandler.Create(Execute);
     }

--- a/developer-cli/Commands/InstallCommand.cs
+++ b/developer-cli/Commands/InstallCommand.cs
@@ -48,6 +48,8 @@ public class InstallCommand : Command
 
     private void Execute()
     {
+        PrerequisitesChecker.Check("dotnet");
+
         if (IsAliasRegistered())
         {
             AnsiConsole.MarkupLine($"[yellow]The CLI is already installed please run {Configuration.AliasName} to use it.[/]");

--- a/developer-cli/Commands/RunCommand.cs
+++ b/developer-cli/Commands/RunCommand.cs
@@ -17,7 +17,7 @@ public class RunCommand : Command
 
     private void Execute()
     {
-        PrerequisitesChecker.Check("docker", "aspire", "node", "yarn");
+        PrerequisitesChecker.Check("dotnet", "docker", "aspire", "node", "yarn");
 
         var workingDirectory = Path.Combine(Configuration.GetSourceCodeFolder(), "..", "application", "AppHost");
 

--- a/developer-cli/Commands/TestCommand.cs
+++ b/developer-cli/Commands/TestCommand.cs
@@ -24,6 +24,8 @@ public class TestCommand : Command
 
     private int Execute(string? solutionName)
     {
+        PrerequisitesChecker.Check("dotnet");
+
         var workingDirectory = Path.Combine(Configuration.GetSourceCodeFolder(), "..", "application");
 
         var solutionsFiles = Directory

--- a/developer-cli/Commands/TranslateCommand.cs
+++ b/developer-cli/Commands/TranslateCommand.cs
@@ -35,7 +35,7 @@ public class TranslateCommand : Command
 
     private async Task<int> Execute(string? language)
     {
-        PrerequisitesChecker.Check("docker");
+        PrerequisitesChecker.Check("dotnet", "docker");
 
         var dockerServer = new DockerServer(DockerImageName, InstanceName, Port, "/root/.ollama");
         try

--- a/developer-cli/Installation/Configuration.cs
+++ b/developer-cli/Installation/Configuration.cs
@@ -15,8 +15,8 @@ public static class Configuration
     private static readonly string UserFolder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
     public static readonly string PublishFolder = IsWindows
-        ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),"PlatformPlatform")
-        : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),".PlatformPlatform");
+        ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "PlatformPlatform")
+        : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".PlatformPlatform");
 
     public static readonly string AliasName = Assembly.GetExecutingAssembly().GetName().Name!;
 

--- a/developer-cli/Installation/PrerequisitesChecker.cs
+++ b/developer-cli/Installation/PrerequisitesChecker.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
-using PlatformPlatform.DeveloperCli.Commands;
 using PlatformPlatform.DeveloperCli.Utilities;
 using Spectre.Console;
 
@@ -18,12 +17,13 @@ public static class PrerequisitesChecker
 {
     private static readonly List<Prerequisite> Dependencies =
     [
+        new Prerequisite(PrerequisiteType.CommandLineTool, "dotnet", "dotnet", new Version(8, 0, 200)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "docker", "Docker", new Version(24, 0)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "node", "NodeJS", new Version(21, 0)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "yarn", "Yarn", new Version(1, 22)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "az", "Azure CLI", new Version(2, 55)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "gh", "GitHub CLI", new Version(2, 41)),
-        new Prerequisite(PrerequisiteType.DotnetWorkload, "aspire", "Aspire", Regex: """aspire\s*8\.0\.0-preview.7"""),
+        new Prerequisite(PrerequisiteType.DotnetWorkload, "aspire", "Aspire", Regex: """aspire\s*8\.0\.0-preview.7""")
     ];
 
     public static void Check(params string[] prerequisiteName)
@@ -131,11 +131,11 @@ public static class PrerequisitesChecker
 
         /*
            The output is on the form:
-           
+
            Installed Workload Id      Manifest Version                      Installation Source
            ------------------------------------------------------------------------------------
            aspire                     8.0.0-preview.7.24251.11/8.0.100      SDK 8.0.200
-           
+
            Use `dotnet workload search` to find additional workloads to install.
          */
         var regex = new Regex(workloadRegex);

--- a/developer-cli/Utilities/ProcessHelper.cs
+++ b/developer-cli/Utilities/ProcessHelper.cs
@@ -6,17 +6,42 @@ namespace PlatformPlatform.DeveloperCli.Utilities;
 
 public static class ProcessHelper
 {
-    public static string StartProcess(string command, string? solutionFolder = null, bool redirectOutput = false)
+    public static void StartProcessWithSystemShell(string command, string? solutionFolder = null)
+    {
+        var processStartInfo = CreateProcessStartInfo(command, solutionFolder, useShellExecute: true, createNoWindow: false);
+        using var process = Process.Start(processStartInfo)!;
+        process.WaitForExit();
+    }
+
+    public static string StartProcess(
+        string command,
+        string? solutionFolder = null,
+        bool redirectOutput = false,
+        bool waitForExit = true
+    )
+    {
+        var processStartInfo = CreateProcessStartInfo(command, solutionFolder, redirectOutput);
+        return StartProcess(processStartInfo, waitForExit: waitForExit);
+    }
+
+    private static ProcessStartInfo CreateProcessStartInfo(
+        string command,
+        string? solutionFolder,
+        bool redirectOutput = false,
+        bool useShellExecute = false,
+        bool createNoWindow = false
+    )
     {
         var fileName = command.Split(' ')[0];
-        var arguments = command.Length > fileName.Length ? command.Substring(fileName.Length + 1) : null;
+        var arguments = command.Length > fileName.Length ? command.Substring(fileName.Length + 1) : string.Empty;
         var processStartInfo = new ProcessStartInfo
         {
             FileName = fileName,
-            Arguments = arguments ?? string.Empty,
+            Arguments = arguments,
             RedirectStandardOutput = redirectOutput,
             RedirectStandardError = redirectOutput,
-            UseShellExecute = false
+            UseShellExecute = useShellExecute,
+            CreateNoWindow = createNoWindow
         };
 
         if (solutionFolder is not null)
@@ -24,7 +49,7 @@ public static class ProcessHelper
             processStartInfo.WorkingDirectory = solutionFolder;
         }
 
-        return StartProcess(processStartInfo);
+        return processStartInfo;
     }
 
     public static string StartProcess(ProcessStartInfo processStartInfo, string? input = null, bool waitForExit = true)
@@ -50,5 +75,10 @@ public static class ProcessHelper
         process.WaitForExit();
 
         return output;
+    }
+
+    public static bool IsProcessRunning(string process)
+    {
+        return Process.GetProcessesByName(process).Length > 0;
     }
 }


### PR DESCRIPTION
### Summary & Motivation

Update the `configure-continuous-deployments` command, so it now automatically triggers the `Cloud Infrastructure - Deployment` and `Application - Build and Deploy` GitHub workflows. This allows for a full setup of Azure infrastructure and CI/CD for application code by just answering two questions about naming of Azure resources, in addition to logging in to Azure and GitHub. After this, the entire process of setting up a fully automated CI/CD takes a few seconds, and the initial deployment takes about 45 minutes (primarily because of spinning up a full Azure container App Environment).

The `configure-continuous-deployments` has also been enhanced so it now only prompts users to log in to GitHub if they are not already authenticated, and a check has been added to ensure the user has Admin permissions on the repository, providing clear error messages if not (this avoids confusion when users tried to configure the PlatformPlatform repository without first forking). Also, the command has been further enhanced to handle multiple git remotes by prioritizing 'origin', which is beneficial in forked repository scenarios. Again, a challenge when the fork still has the PlatformPlatform repository in the upstream.

The `configure-continuous-deployments` has been updated to disable the two reusable workflows called `Deploy container` and `Publish container`, to avoid users trying to run these manually. And the command has also been updated to not ask the users to specify domain names for production and staging during setup. Instead, users can now add domain names post-setup, by changing the GitHub environment variables. Finally, the command has been updated to work whether the GitHub repository is cloned using SSH or HTTPS, and it now also works whether the Azure CLI has been configured to use e.g., YAML as the default output.

To enhance the first-time experience when cloning and running PlatformPlatform on localhost, the CLI command previously known as `run` has been renamed to `dev`. The getting started steps in README.md have been updated to instruct users to run `dotnet run dev` in the `developer-cli` folder. This command has been enhanced in several ways. It now ensures that Docker Desktop is running and now downloads all Docker images for SQL Server, Azure Storage Emulator, etc., showing the progress, before starting the Aspire AppHost. This ensures that the user is getting feedback that things are happening while also ensuring that the Aspire host will start successfully the first time. It previously failed with a timeout because downloading Docker images took too long. This adjustment significantly improves the first-time setup experience by providing continuous feedback during Docker image setup and enhancing the overall reliability of the startup process.

When running the CLI, it now also checks for the correct version of the .NET SDK (`NET 8.0.200`), the same way that all other dependencies are verified.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
