### PR TITLE
Split application.yml for isolated deployment of AppGateway and AccountManagement

### DIFF
--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -1,0 +1,230 @@
+name: Account Managment - Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "application/shared-kernel/**"
+      - "application/account-management/**"
+      - ".github/workflows/app-gateway.yml"
+      - "!**.md"
+  pull_request:
+    paths:
+      - "application/shared-kernel/**"
+      - "application/account-management/**"
+      - ".github/workflows/app-gateway.yml"
+      - "!**.md"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.generate_version.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Generate version
+        id: generate_version
+        run: |
+          # Strip leading 0s of Hours and Minutes after midnight
+          MINUTE=$(printf "%s" $(date +"%-H%M") | sed 's/^0*//')
+          VERSION=$(date +"%Y.%-m.%-d.")$MINUTE
+          echo "Generated version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Node modules
+        working-directory: application/account-management/WebApp
+        run: yarn install --frozen-lockfile
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore .NET tools
+        working-directory: application
+        run: |
+          dotnet tool restore &&
+          dotnet workload install aspire
+
+      - name: Restore .NET dependencies
+        working-directory: application
+        run: dotnet restore
+
+      - name: Setup Java JDK for SonarScanner
+        uses: actions/setup-java@v4
+        with:
+          distribution: "microsoft"
+          java-version: "17"
+
+      - name: Run tests with dotCover and SonarScanner reporting
+        working-directory: application
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          if [[ "${{ vars.SONAR_PROJECT_KEY }}" == "" ]]; then
+            echo "SonarCloud is not enabled. Skipping SonarCloud analysis."
+            dotnet build PlatformPlatform.sln --no-restore /p:Version=${{ steps.generate_version.outputs.version }}
+          else
+            dotnet sonarscanner begin /k:"${{ vars.SONAR_PROJECT_KEY }}" /o:"${{ vars.SONAR_ORGANIZATION }}" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.dotcover.reportsPaths="coverage/dotCover.html" &&
+            dotnet build PlatformPlatform.sln --no-restore /p:Version=${{ steps.generate_version.outputs.version }} &&
+            dotnet dotcover test PlatformPlatform.sln --no-build --dcOutput=coverage/dotCover.html --dcReportType=HTML --dcFilters="+:PlatformPlatform.*;-:*.Tests;-:type=*.AppHost.*" &&
+            dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
+          fi
+
+      - name: Publish frontend artifacts
+        working-directory: application/account-management/WebApp
+        run: yarn run publish
+
+      - name: Publish Account Management API build
+        working-directory: application/account-management
+        run: |
+          dotnet publish ./Api/AccountManagement.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }}
+
+      - name: Save Account Management API artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: account-management-api
+          path: application/account-management/Api/publish/**/*
+
+      - name: Publish Account Management Worker build
+        working-directory: application/account-management
+        run: |
+          dotnet publish ./Workers/AccountManagement.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }}
+
+      - name: Save Account Management Workers artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: account-management-workers
+          path: application/account-management/Workers/publish/**/*
+
+  code-style-and-linting:
+    name: Code Style and Linting
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Node modules
+        working-directory: application/account-management/WebApp
+        run: yarn install --frozen-lockfile
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore .NET tools
+        working-directory: application
+        run: |
+          dotnet tool restore &&
+          dotnet workload install aspire
+
+      - name: Restore .NET dependencies
+        working-directory: application
+        run: dotnet restore
+
+      - name: Build backend solution
+        working-directory: application
+        run: dotnet build PlatformPlatform.sln --no-restore
+
+      - name: Run code inspections
+        working-directory: application
+        run: |
+          dotnet jb inspectcode PlatformPlatform.sln --no-build --output=result.json --severity=SUGGESTION
+
+          # Check if there are any issues. <Issues /> indicates no issues found.
+          if ! grep -q '\"results\": \[\],' result.json; then
+            cat result.json
+            echo "Code inspection issues found."
+            exit 1
+          fi
+
+      - name: Check for code formatting issues
+        working-directory: application
+        run: |
+          dotnet jb cleanupcode PlatformPlatform.sln --no-build --profile=".NET only"
+
+          # Check for any changes made by the code formatter
+          git diff --exit-code || {
+            echo "Formatting issues detected. Please run 'dotnet jb cleanupcode PlatformPlatform.sln --profile=\".NET only\"' locally and commit the formatted code."
+            exit 1
+          }
+
+      - name: Build frontend artifacts
+        working-directory: application/account-management/WebApp
+        run: yarn run build
+
+      - name: Run ESLint
+        working-directory: application/account-management/WebApp
+        run: yarn run lint
+
+      - name: Run Type Checking
+        working-directory: application/account-management/WebApp
+        run: yarn run typechecking
+
+  account-management-api-publish:
+    name: Account Management API Publish
+    needs: [build-and-test]
+    uses: ./.github/workflows/_publish-container.yml
+    secrets: inherit
+    with:
+      artifacts_name: account-management-api
+      artifacts_path: application/account-management/Api/publish
+      image_name: account-management-api
+      version: ${{ needs.build-and-test.outputs.version }}
+      docker_context: ./application/account-management
+      docker_file: ./Api/Dockerfile
+
+  account-management-api-deploy:
+    name: Account Management API Deploy
+    if: github.ref == 'refs/heads/main'
+    needs: [build-and-test, account-management-api-publish]
+    uses: ./.github/workflows/_deploy-container.yml
+    secrets: inherit
+    with:
+      image_name: account-management-api
+      version: ${{ needs.build-and-test.outputs.version }}
+
+  account-management-workers-publish:
+    name: Account Management Workers Publish
+    needs: [build-and-test]
+    uses: ./.github/workflows/_publish-container.yml
+    secrets: inherit
+    with:
+      artifacts_name: account-management-workers
+      artifacts_path: application/account-management/Workers/publish
+      image_name: account-management-workers
+      version: ${{ needs.build-and-test.outputs.version }}
+      docker_context: ./application/account-management
+      docker_file: ./Workers/Dockerfile
+
+  account-management-workers-deploy:
+    name: Account Management Workers Deploy
+    if: github.ref == 'refs/heads/main'
+    needs: [build-and-test, account-management-workers-publish]
+    uses: ./.github/workflows/_deploy-container.yml
+    secrets: inherit
+    with:
+      image_name: account-management-workers
+      version: ${{ needs.build-and-test.outputs.version }}

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -1,17 +1,19 @@
-name: Application - Build and Deploy
+name: App Gateway - Build and Deploy
 
 on:
   push:
     branches:
       - main
     paths:
-      - "application/**"
-      - ".github/workflows/application.yml"
+      - "application/shared-kernel/**"
+      - "application/AppGateway/**"
+      - ".github/workflows/app-gateway.yml"
       - "!**.md"
   pull_request:
     paths:
-      - "application/**"
-      - ".github/workflows/application.yml"
+      - "application/shared-kernel/**"
+      - "application/AppGateway/**"
+      - ".github/workflows/app-gateway.yml"
       - "!**.md"
   workflow_dispatch:
 
@@ -37,15 +39,6 @@ jobs:
           VERSION=$(date +"%Y.%-m.%-d.")$MINUTE
           echo "Generated version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install Node modules
-        working-directory: application/account-management/WebApp
-        run: yarn install --frozen-lockfile
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
@@ -84,32 +77,6 @@ jobs:
             dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
           fi
 
-      - name: Publish frontend artifacts
-        working-directory: application/account-management/WebApp
-        run: yarn run publish
-
-      - name: Publish Account Management API build
-        working-directory: application/account-management
-        run: |
-          dotnet publish ./Api/AccountManagement.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }}
-
-      - name: Save Account Management API artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: account-management-api
-          path: application/account-management/Api/publish/**/*
-
-      - name: Publish Account Management Worker build
-        working-directory: application/account-management
-        run: |
-          dotnet publish ./Workers/AccountManagement.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }}
-
-      - name: Save Account Management Workers artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: account-management-workers
-          path: application/account-management/Workers/publish/**/*
-
       - name: Publish App Gateway build
         working-directory: application
         run: |
@@ -128,15 +95,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install Node modules
-        working-directory: application/account-management/WebApp
-        run: yarn install --frozen-lockfile
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
@@ -179,64 +137,6 @@ jobs:
             echo "Formatting issues detected. Please run 'dotnet jb cleanupcode PlatformPlatform.sln --profile=\".NET only\"' locally and commit the formatted code."
             exit 1
           }
-
-      - name: Build frontend artifacts
-        working-directory: application/account-management/WebApp
-        run: yarn run build
-
-      - name: Run ESLint
-        working-directory: application/account-management/WebApp
-        run: yarn run lint
-
-      - name: Run Type Checking
-        working-directory: application/account-management/WebApp
-        run: yarn run typechecking
-
-  account-management-api-publish:
-    name: Account Management API Publish
-    needs: [build-and-test]
-    uses: ./.github/workflows/_publish-container.yml
-    secrets: inherit
-    with:
-      artifacts_name: account-management-api
-      artifacts_path: application/account-management/Api/publish
-      image_name: account-management-api
-      version: ${{ needs.build-and-test.outputs.version }}
-      docker_context: ./application/account-management
-      docker_file: ./Api/Dockerfile
-
-  account-management-api-deploy:
-    name: Account Management API Deploy
-    if: github.ref == 'refs/heads/main'
-    needs: [build-and-test, account-management-api-publish]
-    uses: ./.github/workflows/_deploy-container.yml
-    secrets: inherit
-    with:
-      image_name: account-management-api
-      version: ${{ needs.build-and-test.outputs.version }}
-
-  account-management-workers-publish:
-    name: Account Management Workers Publish
-    needs: [build-and-test]
-    uses: ./.github/workflows/_publish-container.yml
-    secrets: inherit
-    with:
-      artifacts_name: account-management-workers
-      artifacts_path: application/account-management/Workers/publish
-      image_name: account-management-workers
-      version: ${{ needs.build-and-test.outputs.version }}
-      docker_context: ./application/account-management
-      docker_file: ./Workers/Dockerfile
-
-  account-management-workers-deploy:
-    name: Account Management Workers Deploy
-    if: github.ref == 'refs/heads/main'
-    needs: [build-and-test, account-management-workers-publish]
-    uses: ./.github/workflows/_deploy-container.yml
-    secrets: inherit
-    with:
-      image_name: account-management-workers
-      version: ${{ needs.build-and-test.outputs.version }}
 
   app-gateway-publish:
     name: App Gateway Publish

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -55,27 +55,10 @@ jobs:
         working-directory: application
         run: dotnet restore
 
-      - name: Setup Java JDK for SonarScanner
-        uses: actions/setup-java@v4
-        with:
-          distribution: "microsoft"
-          java-version: "17"
-
-      - name: Run tests with dotCover and SonarScanner reporting
+      - name: Build backend solution
         working-directory: application
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          if [[ "${{ vars.SONAR_PROJECT_KEY }}" == "" ]]; then
-            echo "SonarCloud is not enabled. Skipping SonarCloud analysis."
-            dotnet build PlatformPlatform.sln --no-restore /p:Version=${{ steps.generate_version.outputs.version }}
-          else
-            dotnet sonarscanner begin /k:"${{ vars.SONAR_PROJECT_KEY }}" /o:"${{ vars.SONAR_ORGANIZATION }}" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.dotcover.reportsPaths="coverage/dotCover.html" &&
-            dotnet build PlatformPlatform.sln --no-restore /p:Version=${{ steps.generate_version.outputs.version }} &&
-            dotnet dotcover test PlatformPlatform.sln --no-build --dcOutput=coverage/dotCover.html --dcReportType=HTML --dcFilters="+:PlatformPlatform.*;-:*.Tests;-:type=*.AppHost.*" &&
-            dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
-          fi
+          dotnet build PlatformPlatform.sln --no-restore /p:Version=${{ steps.generate_version.outputs.version }}
 
       - name: Publish App Gateway build
         working-directory: application

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 <h4 align="center">
 
-[![PlatformPlatform](https://github.com/platformplatform/PlatformPlatform/actions/workflows/application.yml/badge.svg)](https://github.com/platformplatform/PlatformPlatform/actions/workflows/application.yml?query=branch%3Amain)
+[![AppGateway](https://github.com/platformplatform/PlatformPlatform/actions/workflows/app-gateway.yml/badge.svg)](https://github.com/platformplatform/PlatformPlatform/actions/workflows/app-gateway.yml?query=branch%3Amain)
+[![AccountManagement](https://github.com/platformplatform/PlatformPlatform/actions/workflows/account-management.yml/badge.svg)](https://github.com/platformplatform/PlatformPlatform/actions/workflows/account-management.yml?query=branch%3Amain)
 [![GitHub issues with enhancement label](https://img.shields.io/github/issues-raw/platformplatform/PlatformPlatform/enhancement?label=enhancements&logo=github&color=%23A2EEEF)](https://github.com/orgs/PlatformPlatform/projects/1/views/3?filterQuery=-status%3A%22%E2%9C%85+Done%22+label%3Aenhancement)
 [![GitHub issues with roadmap label](https://img.shields.io/github/issues-raw/platformplatform/PlatformPlatform/roadmap?label=roadmap&logo=github&color=%23006B75)](https://github.com/orgs/PlatformPlatform/projects/2/views/2?filterQuery=is%3Aopen+label%3Aroadmap)
 [![GitHub issues with bug label](https://img.shields.io/github/issues-raw/platformplatform/PlatformPlatform/bug?label=bugs&logo=github&color=red)](https://github.com/platformplatform/PlatformPlatform/issues?q=is%3Aissue+is%3Aopen+label%3Abug)

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -630,7 +630,8 @@ public class ConfigureContinuousDeploymentsCommand : Command
     private void TriggerAndMonitorWorkflows()
     {
         StartGitHubWorkflow("Cloud Infrastructure - Deployment", "cloud-infrastructure.yml");
-        StartGitHubWorkflow("Application - Build and Deploy", "application.yml");
+        StartGitHubWorkflow("AccountManagement - Build and Deploy", "account-management.yml");
+        StartGitHubWorkflow("AppGateway - Build and Deploy", "app-gateway.yml");
         return;
 
         void StartGitHubWorkflow(string workflowName, string workflowFileName)


### PR DESCRIPTION
### Summary & Motivation

Prepare for multiple self-contained systems by enabling isolated deployment of the AppGateway and AccountManagement. Split `application.yml` into `app-gateway.yml` and `application.yml`. Update the CLI for setting up CI/CD accordingly. Update the badges in the README file to reflect these changes.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
