### PR TITLE
Stabilize infrastructure deployments by fixing race conditions and making deployment names unique

### DIFF
--- a/cloud-infrastructure/cluster/deploy-cluster.sh
+++ b/cloud-infrastructure/cluster/deploy-cluster.sh
@@ -98,7 +98,7 @@ then
 
   # If the domain was not configured during the first run and we didn't receive any warnings about missing DNS entries, we trigger the deployment again to complete the binding of the SSL Certificate to the domain.
   if [[ "$IS_DOMAIN_CONFIGURED" == "false" ]] && [[ "$DOMAIN_NAME" != "" ]]; then
-    echo "Running deployment again to finalize setting up SSL certificate for account-management"
+    echo "Running deployment again to finalize setting up SSL certificate for $DOMAIN_NAME"
     IS_DOMAIN_CONFIGURED=$(is_domain_configured "app-gateway" "$RESOURCE_GROUP_NAME")
     DEPLOYMENT_PARAMETERS="-l $LOCATION -n $CURRENT_DATE-$RESOURCE_GROUP_NAME --output json -f ./main-cluster.bicep -p environment=$ENVIRONMENT locationPrefix=$LOCATION_PREFIX resourceGroupName=$RESOURCE_GROUP_NAME clusterUniqueName=$CLUSTER_UNIQUE_NAME useMssqlElasticPool=$USE_MSSQL_ELASTIC_POOL containerRegistryName=$CONTAINER_REGISTRY_NAME domainName=$DOMAIN_NAME isDomainConfigured=$IS_DOMAIN_CONFIGURED sqlAdminObjectId=$ACTIVE_DIRECTORY_SQL_ADMIN_OBJECT_ID appGatewayVersion=$APP_GATEWAY_VERSION accountManagementVersion=$ACTIVE_ACCOUNT_MANAGEMENT_VERSION backOfficeVersion=$ACTIVE_BACK_OFFICE_VERSION applicationInsightsConnectionString=$APPLICATIONINSIGHTS_CONNECTION_STRING"
 

--- a/cloud-infrastructure/cluster/deploy-cluster.sh
+++ b/cloud-infrastructure/cluster/deploy-cluster.sh
@@ -76,8 +76,9 @@ then
   RED='\033[0;31m'
   RESET='\033[0m' # Reset formatting
 
+  cleaned_output=$(echo "$output" | sed '/^WARNING/d')
   # Check for the specific error message indicating that DNS Records are missing
-  if [[ $output == *"InvalidCustomHostNameValidation"* ]] || [[ $output == *"FailedCnameValidation"* ]] || [[ $output == *"-certificate' under resource group '$RESOURCE_GROUP_NAME' was not found"* ]]; then
+  if [[ $cleaned_output == *"InvalidCustomHostNameValidation"* ]] || [[ $cleaned_output == *"FailedCnameValidation"* ]] || [[ $cleaned_output == *"-certificate' under resource group '$RESOURCE_GROUP_NAME' was not found"* ]]; then
     # Get details about the container apps environment. Although the creation of the container app fails, the verification ID on the container apps environment is consistent across all container apps.
     env_details=$(az containerapp env show --name "$LOCATION_PREFIX-container-apps-environment" --resource-group "$RESOURCE_GROUP_NAME")
     
@@ -90,7 +91,7 @@ then
     echo -e "${RED}- A TXT record with the name 'asuid.$DOMAIN_NAME' and the value '$custom_domain_verification_id'.${RESET}"
     echo -e "${RED}- A CNAME record with the Host name '$DOMAIN_NAME' that points to address 'app-gateway.$default_domain'.${RESET}"
     exit 1
-  elif [[ $output == "ERROR:"* ]]; then
+  elif [[ $cleaned_output == *"ERROR:"* && $cleaned_output == *'"status": "Failed"'* ]]; then
     echo -e "${RED}$output${RESET}"
     exit 1
   fi
@@ -103,14 +104,15 @@ then
 
     . ../deploy.sh
 
-    if [[ $output == "ERROR:"* ]]; then
+    cleaned_output=$(echo "$output" | sed '/^WARNING/d')
+    if [[ $cleaned_output == "ERROR:"* ]]; then
       echo -e "${RED}$output"
       exit 1
     fi
   fi
 
   # Extract the ID of the Managed Identities, which can be used to grant access to SQL Database
-  ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID=$(echo "$output" | jq -r '.properties.outputs.accountManagementIdentityClientId.value')
+  ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID=$(echo "$cleaned_output" | jq -r '.properties.outputs.accountManagementIdentityClientId.value')
   if [[ -n "$GITHUB_OUTPUT" ]]; then
     echo "ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID=$ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID" >> $GITHUB_OUTPUT
   else

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -474,7 +474,7 @@ module appGateway '../modules/container-app.bicep' = {
 
 module appGatwayAccountManagementStorageBlobDataReaderRoleAssignment '../modules/role-assignments-storage-blob-data-reader.bicep' = {
   scope: clusterResourceGroup
-  name: '${clusterUniqueName}-${appGatewayContainerAppName}-blob-reader-role-assignment'
+  name: '${clusterUniqueName}-${appGatewayContainerAppName}-blob-reader'
   params: {
     storageAccountName: accountManagementStorageAccountName
     userAssignedIdentityName: appGatewayIdentityName

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -43,7 +43,7 @@ var subnetId = resourceId(
 
 module diagnosticStorageAccount '../modules/storage-account.bicep' = {
   scope: clusterResourceGroup
-  name: 'diagnostic-storage-account'
+  name: '${clusterUniqueName}-diagnostic-storage-account'
   params: {
     location: location
     name: diagnosticStorageAccountName
@@ -54,7 +54,7 @@ module diagnosticStorageAccount '../modules/storage-account.bicep' = {
 
 module virtualNetwork '../modules/virtual-network.bicep' = {
   scope: clusterResourceGroup
-  name: 'virtual-network'
+  name: '${clusterUniqueName}-virtual-network'
   params: {
     location: location
     name: virtualNetworkName
@@ -64,7 +64,7 @@ module virtualNetwork '../modules/virtual-network.bicep' = {
 
 module containerAppsEnvironment '../modules/container-apps-environment.bicep' = {
   scope: clusterResourceGroup
-  name: 'container-apps-environment'
+  name: '${clusterUniqueName}-container-apps-environment'
   params: {
     location: location
     name: '${locationPrefix}-container-apps-environment'
@@ -76,7 +76,7 @@ module containerAppsEnvironment '../modules/container-apps-environment.bicep' = 
 
 module microsoftSqlServer '../modules/microsoft-sql-server.bicep' = {
   scope: clusterResourceGroup
-  name: 'microsoft-sql-server'
+  name: '${clusterUniqueName}-microsoft-sql-server'
   params: {
     location: location
     name: clusterUniqueName
@@ -90,7 +90,7 @@ module microsoftSqlServer '../modules/microsoft-sql-server.bicep' = {
 
 module microsoftSqlDerverDiagnosticConfiguration '../modules/microsoft-sql-server-diagnostic.bicep' = {
   scope: clusterResourceGroup
-  name: 'microsoft-sql-server-diagnostic'
+  name: '${clusterUniqueName}-microsoft-sql-server-diagnostic'
   params: {
     diagnosticStorageAccountName: diagnosticStorageAccountName
     microsoftSqlServerName: clusterUniqueName
@@ -103,7 +103,7 @@ module microsoftSqlDerverDiagnosticConfiguration '../modules/microsoft-sql-serve
 module microsoftSqlServerElasticPool '../modules/microsoft-sql-server-elastic-pool.bicep' =
   if (useMssqlElasticPool) {
     scope: clusterResourceGroup
-    name: 'microsoft-sql-server-elastic-pool'
+    name: '${clusterUniqueName}-microsoft-sql-server-elastic-pool'
     params: {
       location: location
       name: '${locationPrefix}-microsoft-sql-server-elastic-pool'
@@ -118,7 +118,7 @@ module microsoftSqlServerElasticPool '../modules/microsoft-sql-server-elastic-po
 
 module communicationService '../modules/communication-services.bicep' = {
   scope: clusterResourceGroup
-  name: 'communication-services'
+  name: '${clusterUniqueName}-communication-services'
   params: {
     name: clusterUniqueName
     tags: tags
@@ -130,7 +130,7 @@ module communicationService '../modules/communication-services.bicep' = {
 
 module keyVault '../modules/key-vault.bicep' = {
   scope: clusterResourceGroup
-  name: 'key-vault'
+  name: '${clusterUniqueName}-key-vault'
   params: {
     location: location
     name: clusterUniqueName
@@ -153,7 +153,7 @@ var cdnUrl = publicUrl
 
 var accountManagementIdentityName = 'account-management-${resourceGroupName}'
 module accountManagementIdentity '../modules/user-assigned-managed-identity.bicep' = {
-  name: 'account-management-managed-identity'
+  name: '${clusterUniqueName}-account-management-managed-identity'
   scope: clusterResourceGroup
   params: {
     name: accountManagementIdentityName
@@ -165,7 +165,7 @@ module accountManagementIdentity '../modules/user-assigned-managed-identity.bice
 }
 
 module accountManagementDatabase '../modules/microsoft-sql-database.bicep' = {
-  name: 'account-management-database'
+  name: '${clusterUniqueName}-account-management-database'
   scope: clusterResourceGroup
   params: {
     sqlServerName: clusterUniqueName
@@ -179,7 +179,7 @@ module accountManagementDatabase '../modules/microsoft-sql-database.bicep' = {
 var accountManagementStorageAccountName = '${clusterUniqueName}acctmgmt'
 module accountManagementStorageAccount '../modules/storage-account.bicep' = {
   scope: clusterResourceGroup
-  name: 'account-management-storage-account'
+  name: '${clusterUniqueName}-account-management-storage-account'
   params: {
     location: location
     name: accountManagementStorageAccountName
@@ -232,7 +232,7 @@ var accountManagementEnvironmentVariables = [
 ]
 
 module accountManagementWorkers '../modules/container-app.bicep' = {
-  name: 'account-management-workers-container-app'
+  name: '${clusterUniqueName}-account-management-workers-container-app'
   scope: clusterResourceGroup
   params: {
     name: 'account-management-workers'
@@ -256,7 +256,7 @@ module accountManagementWorkers '../modules/container-app.bicep' = {
 }
 
 module accountManagementApi '../modules/container-app.bicep' = {
-  name: 'account-management-api-container-app'
+  name: '${clusterUniqueName}-account-management-api-container-app'
   scope: clusterResourceGroup
   params: {
     name: 'account-management-api'
@@ -284,7 +284,7 @@ module accountManagementApi '../modules/container-app.bicep' = {
 
 var backOfficeIdentityName = 'back-office-${resourceGroupName}'
 module backOfficeIdentity '../modules/user-assigned-managed-identity.bicep' = {
-  name: 'back-office-managed-identity'
+  name: '${clusterUniqueName}-back-office-managed-identity'
   scope: clusterResourceGroup
   params: {
     name: backOfficeIdentityName
@@ -296,7 +296,7 @@ module backOfficeIdentity '../modules/user-assigned-managed-identity.bicep' = {
 }
 
 module backOfficeDatabase '../modules/microsoft-sql-database.bicep' = {
-  name: 'back-office-database'
+  name: '${clusterUniqueName}-back-office-database'
   scope: clusterResourceGroup
   params: {
     sqlServerName: clusterUniqueName
@@ -310,7 +310,7 @@ module backOfficeDatabase '../modules/microsoft-sql-database.bicep' = {
 var backOfficeStorageAccountName = '${clusterUniqueName}backoffice'
 module backOfficeStorageAccount '../modules/storage-account.bicep' = {
   scope: clusterResourceGroup
-  name: 'back-office-storage-account'
+  name: '${clusterUniqueName}-back-office-storage-account'
   params: {
     location: location
     name: backOfficeStorageAccountName
@@ -357,7 +357,7 @@ var backOfficeEnvironmentVariables = [
 ]
 
 module backOfficeWorkers '../modules/container-app.bicep' = {
-  name: 'back-office-workers-container-app'
+  name: '${clusterUniqueName}-back-office-workers-container-app'
   scope: clusterResourceGroup
   params: {
     name: 'back-office-workers'
@@ -381,7 +381,7 @@ module backOfficeWorkers '../modules/container-app.bicep' = {
 }
 
 module backOfficeApi '../modules/container-app.bicep' = {
-  name: 'back-office-api-container-app'
+  name: '${clusterUniqueName}-back-office-api-container-app'
   scope: clusterResourceGroup
   params: {
     name: 'back-office-api'
@@ -408,7 +408,7 @@ module backOfficeApi '../modules/container-app.bicep' = {
 
 var appGatewayIdentityName = 'app-gateway-${resourceGroupName}'
 module mainAppIdentity '../modules/user-assigned-managed-identity.bicep' = {
-  name: 'app-gateway-managed-identity'
+  name: '${clusterUniqueName}-app-gateway-managed-identity'
   scope: clusterResourceGroup
   params: {
     name: appGatewayIdentityName
@@ -421,7 +421,7 @@ module mainAppIdentity '../modules/user-assigned-managed-identity.bicep' = {
 
 var appGatewayContainerAppName = 'app-gateway'
 module appGateway '../modules/container-app.bicep' = {
-  name: 'app-gateway-container-app'
+  name: '${clusterUniqueName}-app-gateway-container-app'
   scope: clusterResourceGroup
   params: {
     name: appGatewayContainerAppName
@@ -474,7 +474,7 @@ module appGateway '../modules/container-app.bicep' = {
 
 module appGatwayAccountManagementStorageBlobDataReaderRoleAssignment '../modules/role-assignments-storage-blob-data-reader.bicep' = {
   scope: clusterResourceGroup
-  name: '${appGatewayContainerAppName}-blob-reader-role-assignment'
+  name: '${clusterUniqueName}-${appGatewayContainerAppName}-blob-reader-role-assignment'
   params: {
     storageAccountName: accountManagementStorageAccountName
     userAssignedIdentityName: appGatewayIdentityName

--- a/cloud-infrastructure/environment/deploy-environment.sh
+++ b/cloud-infrastructure/environment/deploy-environment.sh
@@ -7,7 +7,8 @@ DEPLOYMENT_PARAMETERS="-l $LOCATION -n "$CURRENT_DATE-$ENVIRONMENT" --output tab
 cd "$(dirname "${BASH_SOURCE[0]}")"
 . ../deploy.sh
 
-if [[ $output == "ERROR:"* ]]; then
+cleaned_output=$(echo "$output" | sed '/^WARNING/d')
+if [[ $cleaned_output == "ERROR:"* ]]; then
   echo -e "${RED}$output"
   exit 1
 fi

--- a/cloud-infrastructure/environment/main-environment.bicep
+++ b/cloud-infrastructure/environment/main-environment.bicep
@@ -13,7 +13,7 @@ resource monitorResourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = 
 }
 
 module logAnalyticsWorkspace '../modules/log-analytics-workspace.bicep' = {
-  name: 'log-analytics-workspace'
+  name: '${resourceGroupName}-log-analytics-workspace'
   scope: resourceGroup(monitorResourceGroup.name)
   params: {
     name: '${environment}-log-analytics-workspace'
@@ -23,7 +23,7 @@ module logAnalyticsWorkspace '../modules/log-analytics-workspace.bicep' = {
 }
 
 module applicationInsights '../modules/application-insights.bicep' = {
-  name: 'application-insights'
+  name: '${resourceGroupName}-application-insights'
   scope: resourceGroup(monitorResourceGroup.name)
   params: {
     name: '${environment}-application-insights'

--- a/cloud-infrastructure/modules/application-insights.bicep
+++ b/cloud-infrastructure/modules/application-insights.bicep
@@ -25,7 +25,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
 }
 
 resource applicationInsightsSmartDetection 'Microsoft.Insights/actionGroups@2023-01-01' = {
-  name: 'Application Insights Smart Detection'
+  name: '${name}-smart-detection'
   location: 'Global'
   tags: tags
   properties: {

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -34,7 +34,7 @@ resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-02-
 
 module newManagedCertificate './managed-certificate.bicep' =
   if (isCustomDomainSet) {
-    name: certificateName
+    name: '${resourceGroupName}-${name}-managed-certificate'
     scope: resourceGroup(resourceGroupName)
     dependsOn: [containerApp]
     params: {

--- a/cloud-infrastructure/modules/microsoft-sql-server-diagnostic.bicep
+++ b/cloud-infrastructure/modules/microsoft-sql-server-diagnostic.bicep
@@ -5,7 +5,7 @@ param dianosticStorageAccountSubscriptionId string
 param dianosticStorageAccountBlobEndpoint string
 
 module diagnosticStorageBlobDataContributorRoleAssignment 'role-assignments-storage-blob-data-contributor.bicep' = if (principalId != '') {
-  name: '${microsoftSqlServerName}-sql-server-blob-contributer-role-assignment'
+  name: '${microsoftSqlServerName}-sql-server-blob-contributer'
   params: {
     storageAccountName: diagnosticStorageAccountName
     principalId: principalId

--- a/cloud-infrastructure/modules/storage-account.bicep
+++ b/cloud-infrastructure/modules/storage-account.bicep
@@ -55,7 +55,7 @@ resource blobContainers 'Microsoft.Storage/storageAccounts/blobServices/containe
 }]
 
 module storageBlobDataContributorRoleAssignment 'role-assignments-storage-blob-data-contributor.bicep' = if (userAssignedIdentityName != '') {
-  name: '${name}-blob-contributer-role-assignment'
+  name: '${name}-blob-contributer'
   params: {
     storageAccountName: name
     userAssignedIdentityName: userAssignedIdentityName

--- a/cloud-infrastructure/modules/user-assigned-managed-identity.bicep
+++ b/cloud-infrastructure/modules/user-assigned-managed-identity.bicep
@@ -12,14 +12,13 @@ resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@
 
 var containerRegistryResourceGroupName = 'shared'
 module containerRegistryPermission './role-assignments-container-registry-acr-pull.bicep' = {
-  name: 'container-registry-permission'
+  name: '${name}-permission'
   scope: resourceGroup(subscription().subscriptionId, containerRegistryResourceGroupName)
   params: {
     containerRegistryName: containerRegistryName
     principalId: userAssignedIdentity.properties.principalId
   }
 }
-
 
 resource keyVault 'Microsoft.KeyVault/vaults@2021-10-01' existing = {
   name: keyVaultName

--- a/cloud-infrastructure/modules/user-assigned-managed-identity.bicep
+++ b/cloud-infrastructure/modules/user-assigned-managed-identity.bicep
@@ -30,6 +30,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   scope: keyVault
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleDefinitionId)
+    principalType: 'ServicePrincipal'
     principalId: userAssignedIdentity.properties.principalId
   }
 }

--- a/cloud-infrastructure/shared/deploy-shared.sh
+++ b/cloud-infrastructure/shared/deploy-shared.sh
@@ -20,7 +20,8 @@ DEPLOYMENT_PARAMETERS="-l $LOCATION -n "$CURRENT_DATE-$RESOURCE_GROUP_NAME" --ou
 cd "$(dirname "${BASH_SOURCE[0]}")"
 . ../deploy.sh
 
-if [[ $output == "ERROR:"* ]]; then
+cleaned_output=$(echo "$output" | sed '/^WARNING/d')
+if [[ $cleaned_output == "ERROR:"* ]]; then
   echo -e "${RED}$output"
   exit 1
 fi

--- a/cloud-infrastructure/shared/main-shared.bicep
+++ b/cloud-infrastructure/shared/main-shared.bicep
@@ -14,7 +14,7 @@ resource sharedResourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
 }
 
 module containerRegistry '../modules/container-registry.bicep' = {
-  name: 'container-registry'
+  name: '${resourceGroupName}-${containerRegistryName}-container-registry'
   scope: resourceGroup(sharedResourceGroup.name)
   params: {
     name: containerRegistryName


### PR DESCRIPTION
### Summary & Motivation

Make all Bicep module deployment names unique to avoid concurrent deployments of resources like managed identity container permissions. This resolves issues where deployments failed due to naming conflicts.

Fix race condition when assigning user-managed identity permissions to container registry immediately after creation. The fix involves setting the `principalType` to `ServicePrincipal` on Bicep `roleAssignments` resource.

Remove `-role-assignment` postfix from Bicep module names to allow for longer resource names, as deployment names in Bicep cannot be longer than 64 characters.

Ensure `deploy-cluster.sh` reliably checks for failed deployments even when `az CLI` outputs warnings. This ensures JSON results are parsed correctly by stripping any prefixed warning messages.

Rename Application Insights smart detection resource from `Application Insights smart detection` to `staging-application-insights-smart-detection`.

Fix information message about setting up SSL certificate to use domain name instead of `account-management`.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
