### PR TITLE
Suppress TypeScript errors in generated client router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,17 +391,18 @@ FodyWeavers.xsd
 
 # Frontend builds
 .swc/
-**/WebApp/dist/*.js*
-**/WebApp/dist/*.css
-**/WebApp/dist/*.json
-**/WebApp/dist/*.ts*
-**/WebApp/dist/*.ico
-**/WebApp/dist/*.jpg
-**/WebApp/dist/*.jpeg
-**/WebApp/dist/*.png
-**/WebApp/dist/*.svg
-**/WebApp/dist/*.webm
-**/WebApp/dist/*.webp
-**/WebApp/dist/*.txt
+**/WebApp/dist/**/*.js*
+**/WebApp/dist/**/*.css
+**/WebApp/dist/**/*.map
+**/WebApp/dist/**/*.json
+**/WebApp/dist/**/*.ts*
+**/WebApp/dist/**/*.ico
+**/WebApp/dist/**/*.jpg
+**/WebApp/dist/**/*.jpeg
+**/WebApp/dist/**/*.png
+**/WebApp/dist/**/*.svg
+**/WebApp/dist/**/*.webm
+**/WebApp/dist/**/*.webp
+**/WebApp/dist/**/*.txt
 
 **/translations/locale/*.ts

--- a/application/client-foundation/clientFilesystemRouter/lib/pageReactRoutesCode.ts
+++ b/application/client-foundation/clientFilesystemRouter/lib/pageReactRoutesCode.ts
@@ -28,13 +28,16 @@ export interface PageProps<T extends unknown = unknown> {
   params: T;
 };
 
+// @ts-ignore
 export interface ErrorPageProps<E extends unknown = unknown> extends PageProps {
   error: E;
   reset: () => void;
 };
 
+// @ts-ignore
 export type LazyLoadedPage = () => Promise<{ default: ComponentType<any> }>;
 
+// @ts-ignore
 function createErrorPage(errorPage: FunctionComponent) {
   return createElement(() => {
     /* Error page */
@@ -48,6 +51,7 @@ function createErrorPage(errorPage: FunctionComponent) {
   });
 }
 
+// @ts-ignore
 function createLazyLoadedPage(fallbackPage: FunctionComponent, pageImport: LazyLoadedPage) {
   return createElement(() => {
     /* Lazy loading */
@@ -58,6 +62,7 @@ function createLazyLoadedPage(fallbackPage: FunctionComponent, pageImport: LazyL
   });
 }
 
+// @ts-ignore
 function createNormalPage(pageImport: FunctionComponent) {
   return createElement(() => {
     /* Normal page */
@@ -66,6 +71,7 @@ function createNormalPage(pageImport: FunctionComponent) {
   });
 }
 
+// @ts-ignore
 function createLayoutPage(layoutImport: FunctionComponent) {
   return createElement(() => {
     /* Layout */


### PR DESCRIPTION
### Summary & Motivation

Mark unused methods in the generated client router with `// @ts-ignore` to prevent build errors when creating new self-contained systems like BackOffice.

Add generated files like images and `.map` files in the `WebApp/dist` folder to `.gitignore` to avoid including them in the repository during production builds.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
