### PR TITLE
Streamline workflows and build processes

### DIFF
--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -87,23 +87,23 @@ jobs:
         working-directory: application/account-management/WebApp
         run: yarn run publish
 
-      - name: Publish Account Management API build
+      - name: Publish API build
         working-directory: application/account-management
         run: |
           dotnet publish ./Api/AccountManagement.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
-      - name: Save Account Management API artifacts
+      - name: Save API artifacts
         uses: actions/upload-artifact@v4
         with:
           name: account-management-api
           path: application/account-management/Api/publish/**/*
 
-      - name: Publish Account Management Worker build
+      - name: Publish Worker build
         working-directory: application/account-management
         run: |
           dotnet publish ./Workers/AccountManagement.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
-      - name: Save Account Management Workers artifacts
+      - name: Save Workers artifacts
         uses: actions/upload-artifact@v4
         with:
           name: account-management-workers
@@ -176,8 +176,8 @@ jobs:
         working-directory: application/account-management/WebApp
         run: yarn run typechecking
 
-  account-management-api-publish:
-    name: Account Management API Publish
+  api-publish:
+    name: Publish API
     needs: [build-and-test]
     uses: ./.github/workflows/_publish-container.yml
     secrets: inherit
@@ -189,18 +189,18 @@ jobs:
       docker_context: ./application/account-management
       docker_file: ./Api/Dockerfile
 
-  account-management-api-deploy:
-    name: Account Management API Deploy
+  api-deploy:
+    name: Deploy API
     if: github.ref == 'refs/heads/main'
-    needs: [build-and-test, account-management-api-publish]
+    needs: [build-and-test, api-publish]
     uses: ./.github/workflows/_deploy-container.yml
     secrets: inherit
     with:
       image_name: account-management-api
       version: ${{ needs.build-and-test.outputs.version }}
 
-  account-management-workers-publish:
-    name: Account Management Workers Publish
+  workers-publish:
+    name: Publish Workers
     needs: [build-and-test]
     uses: ./.github/workflows/_publish-container.yml
     secrets: inherit
@@ -212,10 +212,10 @@ jobs:
       docker_context: ./application/account-management
       docker_file: ./Workers/Dockerfile
 
-  account-management-workers-deploy:
-    name: Account Management Workers Deploy
+  workers-deploy:
+    name: Deploy Workers
     if: github.ref == 'refs/heads/main'
-    needs: [build-and-test, account-management-workers-publish]
+    needs: [build-and-test, workers-publish]
     uses: ./.github/workflows/_deploy-container.yml
     secrets: inherit
     with:

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -45,10 +45,6 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install Node modules
-        working-directory: application/account-management/WebApp
-        run: yarn install --frozen-lockfile
-
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
@@ -124,10 +120,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Install Node modules
-        working-directory: application/account-management/WebApp
-        run: yarn install --frozen-lockfile
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -84,26 +84,31 @@ jobs:
           fi
 
       - name: Publish frontend artifacts
+        if: github.ref != 'refs/heads/main'
         working-directory: application/account-management/WebApp
         run: yarn run publish
 
       - name: Publish API build
+        if: github.ref != 'refs/heads/main'
         working-directory: application/account-management
         run: |
           dotnet publish ./Api/AccountManagement.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
       - name: Save API artifacts
+        if: github.ref != 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: account-management-api
           path: application/account-management/Api/publish/**/*
 
       - name: Publish Worker build
+        if: github.ref != 'refs/heads/main'
         working-directory: application/account-management
         run: |
           dotnet publish ./Workers/AccountManagement.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
       - name: Save Workers artifacts
+        if: github.ref != 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: account-management-workers
@@ -178,6 +183,7 @@ jobs:
 
   api-publish:
     name: Publish API
+    if: github.ref == 'refs/heads/main'
     needs: [build-and-test]
     uses: ./.github/workflows/_publish-container.yml
     secrets: inherit
@@ -201,6 +207,7 @@ jobs:
 
   workers-publish:
     name: Publish Workers
+    if: github.ref == 'refs/heads/main'
     needs: [build-and-test]
     uses: ./.github/workflows/_publish-container.yml
     secrets: inherit

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -7,13 +7,13 @@ on:
     paths:
       - "application/shared-kernel/**"
       - "application/account-management/**"
-      - ".github/workflows/app-gateway.yml"
+      - ".github/workflows/account-management.yml"
       - "!**.md"
   pull_request:
     paths:
       - "application/shared-kernel/**"
       - "application/account-management/**"
-      - ".github/workflows/app-gateway.yml"
+      - ".github/workflows/account-management.yml"
       - "!**.md"
   workflow_dispatch:
 

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -74,7 +74,8 @@ jobs:
         run: |
           if [[ "${{ vars.SONAR_PROJECT_KEY }}" == "" ]]; then
             echo "SonarCloud is not enabled. Skipping SonarCloud analysis."
-            dotnet build account-management/AccountManagement.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }}
+            dotnet build account-management/AccountManagement.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} &&
+            dotnet dotcover test account-management/AccountManagement.slnf --no-build --dcOutput=coverage/dotCover.html --dcReportType=HTML --dcFilters="+:PlatformPlatform.*;-:*.Tests;-:type=*.AppHost.*"
           else
             dotnet sonarscanner begin /k:"${{ vars.SONAR_PROJECT_KEY }}" /o:"${{ vars.SONAR_ORGANIZATION }}" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.dotcover.reportsPaths="coverage/dotCover.html" &&
             dotnet build account-management/AccountManagement.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} &&

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -60,12 +60,12 @@ jobs:
         run: |
           dotnet build PlatformPlatform.sln --no-restore /p:Version=${{ steps.generate_version.outputs.version }}
 
-      - name: Publish App Gateway build
+      - name: Publish build
         working-directory: application
         run: |
           dotnet publish ./AppGateway/AppGateway.csproj --no-restore --configuration Release --output ./AppGateway/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
-      - name: Save App Gateway artifacts
+      - name: Save artifacts
         uses: actions/upload-artifact@v4
         with:
           name: app-gateway
@@ -121,8 +121,8 @@ jobs:
             exit 1
           }
 
-  app-gateway-publish:
-    name: App Gateway Publish
+  publish:
+    name: Publish
     needs: [build-and-test]
     uses: ./.github/workflows/_publish-container.yml
     secrets: inherit
@@ -134,10 +134,10 @@ jobs:
       docker_context: ./application
       docker_file: ./AppGateway/Dockerfile
 
-  app-gateway-deploy:
-    name: App Gateway Deploy
+  deploy:
+    name: Deploy
     if: github.ref == 'refs/heads/main'
-    needs: [build-and-test, app-gateway-publish]
+    needs: [build-and-test, publish]
     uses: ./.github/workflows/_deploy-container.yml
     secrets: inherit
     with:

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -61,11 +61,13 @@ jobs:
           dotnet build PlatformPlatform.sln --no-restore /p:Version=${{ steps.generate_version.outputs.version }}
 
       - name: Publish build
+        if: github.ref != 'refs/heads/main'
         working-directory: application
         run: |
           dotnet publish ./AppGateway/AppGateway.csproj --no-restore --configuration Release --output ./AppGateway/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
       - name: Save artifacts
+        if: github.ref != 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: app-gateway
@@ -123,6 +125,7 @@ jobs:
 
   publish:
     name: Publish
+    if: github.ref == 'refs/heads/main'
     needs: [build-and-test]
     uses: ./.github/workflows/_publish-container.yml
     secrets: inherit


### PR DESCRIPTION
### Summary & Motivation

Rename workflow jobs and steps with more generic names after splitting App Gateway and Account Management API into separate workflows. This removes the need for self-contained system prefixes in GitHub steps and actions.

Skip publishing Docker images when workflow is triggered from pull requests. This avoids unnecessary and failing Docker image publications, especially for external pull requests, as only workflows triggered by a maintainer have OIDC permissions to publish to Azure Container Registry.

Ensure unit tests and code coverage run even when Sonar Cloud is not configured. This ensures unit tests are executed when forking PlatformPlatform where Sonar Cloud is not configured by default.

Remove explicit "Install Node modules" step when building the WebApp as this step is now done automatically when building the WebApp.

Fix trigger path in account-management workflow to use `.github/workflows/account-management.yml` instead of `app-gateway.yml` to prevent incorrect triggering.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
