### PR TITLE
Revert changes to GitHub Actions workflow for artifact publishing

### DIFF
--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -84,31 +84,31 @@ jobs:
           fi
 
       - name: Publish frontend artifacts
-        if: github.ref != 'refs/heads/main'
+        if:   github.ref == 'refs/heads/main'
         working-directory: application/account-management/WebApp
         run: yarn run publish
 
       - name: Publish API build
-        if: github.ref != 'refs/heads/main'
+        if:   github.ref == 'refs/heads/main'
         working-directory: application/account-management
         run: |
           dotnet publish ./Api/AccountManagement.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
       - name: Save API artifacts
-        if: github.ref != 'refs/heads/main'
+        if:   github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: account-management-api
           path: application/account-management/Api/publish/**/*
 
       - name: Publish Worker build
-        if: github.ref != 'refs/heads/main'
+        if:   github.ref == 'refs/heads/main'
         working-directory: application/account-management
         run: |
           dotnet publish ./Workers/AccountManagement.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
       - name: Save Workers artifacts
-        if: github.ref != 'refs/heads/main'
+        if:   github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: account-management-workers

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -61,13 +61,13 @@ jobs:
           dotnet build PlatformPlatform.sln --no-restore /p:Version=${{ steps.generate_version.outputs.version }}
 
       - name: Publish build
-        if: github.ref != 'refs/heads/main'
+        if:   github.ref == 'refs/heads/main'
         working-directory: application
         run: |
           dotnet publish ./AppGateway/AppGateway.csproj --no-restore --configuration Release --output ./AppGateway/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
       - name: Save artifacts
-        if: github.ref != 'refs/heads/main'
+        if:   github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: app-gateway


### PR DESCRIPTION
### Summary & Motivation

Revert previous changes made to the GitHub Actions workflow. The initial modification was intended to stop publishing artifacts used for Docker images on pull requests, but it had the opposite effect. This PR corrects that issue.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
