### PR TITLE
Update .NET Aspire to GA and update other NuGet packages to latest versions

### DIFF
--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -1,16 +1,18 @@
-name: Account Managment - Build and Deploy
+name: Account Management - Build and Deploy
 
 on:
   push:
     branches:
       - main
     paths:
+      - "application/*"
       - "application/shared-kernel/**"
       - "application/account-management/**"
       - ".github/workflows/account-management.yml"
       - "!**.md"
   pull_request:
     paths:
+      - "application/*"
       - "application/shared-kernel/**"
       - "application/account-management/**"
       - ".github/workflows/account-management.yml"

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - main
     paths:
+      - "application/*"
       - "application/shared-kernel/**"
       - "application/AppGateway/**"
       - ".github/workflows/app-gateway.yml"
       - "!**.md"
   pull_request:
     paths:
+      - "application/*"
       - "application/shared-kernel/**"
       - "application/AppGateway/**"
       - ".github/workflows/app-gateway.yml"

--- a/.github/workflows/back-office.yml
+++ b/.github/workflows/back-office.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - main
     paths:
+      - "application/*"
       - "application/shared-kernel/**"
       - "application/back-office/**"
       - ".github/workflows/back-office.yml"
       - "!**.md"
   pull_request:
     paths:
+      - "application/*"
       - "application/shared-kernel/**"
       - "application/back-office/**"
       - ".github/workflows/back-office.yml"

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -4,8 +4,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
-    <AspNetCoreVersion>8.0.4</AspNetCoreVersion>
-    <EfCoreVersion>8.0.4</EfCoreVersion>
+    <AspNetCoreVersion>8.0.5</AspNetCoreVersion>
+    <EfCoreVersion>8.0.5</EfCoreVersion>
     <AspireVersion>8.0.1</AspireVersion>
   </PropertyGroup>
 
@@ -30,7 +30,7 @@
     <PackageVersion Include="IdGen" Version="3.0.5" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="8.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="8.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.0.7" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.0.7" />
@@ -85,7 +85,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <!-- Open Telemetry -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.1" />
@@ -94,7 +94,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
     <!-- VS Test -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <!-- Miscellaneous -->

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -6,7 +6,7 @@
     <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
     <AspNetCoreVersion>8.0.4</AspNetCoreVersion>
     <EfCoreVersion>8.0.4</EfCoreVersion>
-    <AspireVersion>8.0.0-preview.7.24251.11</AspireVersion>
+    <AspireVersion>8.0.1</AspireVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -578,7 +578,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
     private void TriggerAndMonitorWorkflows()
     {
         StartGitHubWorkflow("Cloud Infrastructure - Deployment", "cloud-infrastructure.yml");
-        StartGitHubWorkflow("AccountManagement - Build and Deploy", "account-management.yml");
+        StartGitHubWorkflow("Account Management - Build and Deploy", "account-management.yml");
         StartGitHubWorkflow("AppGateway - Build and Deploy", "app-gateway.yml");
         return;
 

--- a/developer-cli/Installation/PrerequisitesChecker.cs
+++ b/developer-cli/Installation/PrerequisitesChecker.cs
@@ -23,7 +23,7 @@ public static class PrerequisitesChecker
         new Prerequisite(PrerequisiteType.CommandLineTool, "yarn", "Yarn", new Version(1, 22)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "az", "Azure CLI", new Version(2, 55)),
         new Prerequisite(PrerequisiteType.CommandLineTool, "gh", "GitHub CLI", new Version(2, 41)),
-        new Prerequisite(PrerequisiteType.DotnetWorkload, "aspire", "Aspire", Regex: """aspire\s*8\.0\.0-preview.7""")
+        new Prerequisite(PrerequisiteType.DotnetWorkload, "aspire", "Aspire", Regex: """aspire\s*8\.0\.1""")
     ];
 
     public static void Check(params string[] prerequisiteName)
@@ -132,9 +132,9 @@ public static class PrerequisitesChecker
         /*
            The output is on the form:
 
-           Installed Workload Id      Manifest Version                      Installation Source
-           ------------------------------------------------------------------------------------
-           aspire                     8.0.0-preview.7.24251.11/8.0.100      SDK 8.0.200
+           Installed Workload Id      Manifest Version      Installation Source
+           --------------------------------------------------------------------
+           aspire                     8.0.1/8.0.100         SDK 8.0.300
 
            Use `dotnet workload search` to find additional workloads to install.
          */


### PR DESCRIPTION
### Summary & Motivation

Update .NET Aspire to the GA (General Availability) version, replacing the previous preview versions. There are no breaking changes, so this is a straightforward update.

Update other NuGet packages to their latest versions, including updating ASP.NET and EF Core to version 8.0.5.

Update GitHub workflows to trigger build when files in `application/*` are changed.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
