### PR TITLE
Update CI/CD steps and configure-continuous-deployments CLI command

### DIFF
--- a/.github/workflows/cloud-infrastructure.yml
+++ b/.github/workflows/cloud-infrastructure.yml
@@ -125,6 +125,8 @@ jobs:
         run: |
           ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID=${{ steps.deploy_cluster.outputs.ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID }}
           bash ./cloud-infrastructure/cluster/grant-database-permissions.sh 'account-management' $ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID
+          BACK_OFFICE_IDENTITY_CLIENT_ID=${{ steps.deploy_cluster.outputs.BACK_OFFICE_IDENTITY_CLIENT_ID }}
+          bash ./cloud-infrastructure/cluster/grant-database-permissions.sh 'back-office' $BACK_OFFICE_IDENTITY_CLIENT_ID
 
   production:
     name: Production
@@ -186,3 +188,5 @@ jobs:
         run: |
           ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID=${{ steps.deploy_cluster.outputs.ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID }}
           bash ./cloud-infrastructure/cluster/grant-database-permissions.sh 'account-management' $ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID
+          BACK_OFFICE_IDENTITY_CLIENT_ID=${{ steps.deploy_cluster.outputs.BACK_OFFICE_IDENTITY_CLIENT_ID }}
+          bash ./cloud-infrastructure/cluster/grant-database-permissions.sh 'back-office' $BACK_OFFICE_IDENTITY_CLIENT_ID

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -595,12 +595,27 @@ public class ConfigureContinuousDeploymentsCommand : Command
 
     private void TriggerAndMonitorWorkflows()
     {
-        StartGitHubWorkflow("Cloud Infrastructure - Deployment", "cloud-infrastructure.yml");
-        StartGitHubWorkflow("Account Management - Build and Deploy", "account-management.yml");
-        StartGitHubWorkflow("AppGateway - Build and Deploy", "app-gateway.yml");
+        AnsiConsole.Status().Start("Begin d eployment.", ctx =>
+            {
+                for (var i = 60; i >= 0; i--)
+                {
+                    if (Console.KeyAvailable && Console.ReadKey(true).Key == ConsoleKey.Enter)
+                    {
+                        break;
+                    }
+
+                    ctx.Status($"Deployment of Cloud Infrastructure and Application code will automatically start in {i} seconds. Press 'ctrl+c` to exit or Enter to continue.");
+                    Thread.Sleep(TimeSpan.FromSeconds(1));
+                }
+            }
+        );
+
+        StartGithubWorkflow("Cloud Infrastructure - Deployment", "cloud-infrastructure.yml");
+        StartGithubWorkflow("Account Management - Build and Deploy", "account-management.yml");
+        StartGithubWorkflow("AppGateway - Build and Deploy", "app-gateway.yml");
         return;
 
-        void StartGitHubWorkflow(string workflowName, string workflowFileName)
+        void StartGithubWorkflow(string workflowName, string workflowFileName)
         {
             AnsiConsole.MarkupLine($"[green]Starting {workflowName} GitHub workflow...[/]");
 

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -433,6 +433,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
     private void CreateAppRegistrationCredentials(AzureInfo azureInfo, GithubInfo githubInfo)
     {
         CreateFederatedCredential("MainBranch", "ref:refs/heads/main");
+        CreateFederatedCredential("PullRequests", "pull_request");
         CreateFederatedCredential("StagingEnvironment", "environment:staging");
         CreateFederatedCredential("ProductionEnvironment", "environment:production");
 


### PR DESCRIPTION
### Summary & Motivation

Add the missing CI/CD step for granting the BackOffice Managed Identity permissions to the database as part of the BackOffice self-contained system setup.

Update the `configure-continuous-deployments` CLI command to:
- Create federated credentials for pull requests, correcting a removal from the previous pull request.
- Check if a unique prefix is used for an Azure Container Registry on a different subscription.
- Create a 60-second countdown timer to allow canceling deployment to Azure.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary