### PR TITLE
Improve database migration and container apps logging

### DIFF
--- a/application/account-management/Workers/Program.cs
+++ b/application/account-management/Workers/Program.cs
@@ -26,4 +26,4 @@ var host = builder.Build();
 // Apply migrations to the database (should be moved to GitHub Actions or similar in production)
 host.Services.ApplyMigrations<AccountManagementDbContext>();
 
-host.Run();
+// host.Run(); is disabled for now, as the worker is only doing database migrations, which is a one-time operation, so we just let the host finish

--- a/application/back-office/Workers/Program.cs
+++ b/application/back-office/Workers/Program.cs
@@ -26,4 +26,4 @@ var host = builder.Build();
 // Apply migrations to the database (should be moved to GitHub Actions or similar in production)
 host.Services.ApplyMigrations<BackOfficeDbContext>();
 
-host.Run();
+// host.Run(); is disabled for now, as the worker is only doing database migrations, which is a one-time operation, so we just let the host finish

--- a/cloud-infrastructure/cluster/deploy-cluster.sh
+++ b/cloud-infrastructure/cluster/deploy-cluster.sh
@@ -104,7 +104,7 @@ then
     echo "ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID=$ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID" >> $GITHUB_OUTPUT
     echo "BACK_OFFICE_IDENTITY_CLIENT_ID=$BACK_OFFICE_IDENTITY_CLIENT_ID" >> $GITHUB_OUTPUT
   else
-    . ./grant-database-permissions.sh 'account-management' $ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID
-    . ./grant-database-permissions.sh 'back-office' $BACK_OFFICE_IDENTITY_CLIENT_ID
+    . ./grant-database-permissions.sh $UNIQUE_PREFIX $ENVIRONMENT $CLUSTER_LOCATION_ACRONYM 'account-management' $ACCOUNT_MANAGEMENT_IDENTITY_CLIENT_ID
+    . ./grant-database-permissions.sh $UNIQUE_PREFIX $ENVIRONMENT $CLUSTER_LOCATION_ACRONYM 'back-office' $BACK_OFFICE_IDENTITY_CLIENT_ID
   fi
 fi

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -67,6 +67,7 @@ module containerAppsEnvironment '../modules/container-apps-environment.bicep' = 
     name: resourceGroupName
     tags: tags
     subnetId: subnetId
+    environmentResourceGroupName: environmentResourceGroupName
   }
   dependsOn: [virtualNetwork]
 }

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -71,32 +71,6 @@ module containerAppsEnvironment '../modules/container-apps-environment.bicep' = 
   dependsOn: [virtualNetwork]
 }
 
-module microsoftSqlServer '../modules/microsoft-sql-server.bicep' = {
-  scope: clusterResourceGroup
-  name: '${resourceGroupName}-microsoft-sql-server'
-  params: {
-    location: location
-    name: resourceGroupName
-    tags: tags
-    subnetId: subnetId
-    tenantId: subscription().tenantId
-    sqlAdminObjectId: sqlAdminObjectId
-  }
-  dependsOn: [virtualNetwork]
-}
-
-module microsoftSqlDerverDiagnosticConfiguration '../modules/microsoft-sql-server-diagnostic.bicep' = {
-  scope: clusterResourceGroup
-  name: '${resourceGroupName}-microsoft-sql-server-diagnostic'
-  params: {
-    diagnosticStorageAccountName: diagnosticStorageAccountName
-    microsoftSqlServerName: resourceGroupName
-    principalId: microsoftSqlServer.outputs.principalId
-    dianosticStorageAccountBlobEndpoint: diagnosticStorageAccount.outputs.blobEndpoint
-    dianosticStorageAccountSubscriptionId: subscription().subscriptionId
-  }
-}
-
 module keyVault '../modules/key-vault.bicep' = {
   scope: clusterResourceGroup
   name: '${resourceGroupName}-key-vault'
@@ -121,6 +95,32 @@ module communicationService '../modules/communication-services.bicep' = {
     dataLocation: communicatoinServicesDataLocation
     mailSenderDisplayName: mailSenderDisplayName
     keyVaultName: keyVault.outputs.name
+  }
+}
+
+module microsoftSqlServer '../modules/microsoft-sql-server.bicep' = {
+  scope: clusterResourceGroup
+  name: '${resourceGroupName}-microsoft-sql-server'
+  params: {
+    location: location
+    name: resourceGroupName
+    tags: tags
+    subnetId: subnetId
+    tenantId: subscription().tenantId
+    sqlAdminObjectId: sqlAdminObjectId
+  }
+  dependsOn: [virtualNetwork]
+}
+
+module microsoftSqlDerverDiagnosticConfiguration '../modules/microsoft-sql-server-diagnostic.bicep' = {
+  scope: clusterResourceGroup
+  name: '${resourceGroupName}-microsoft-sql-server-diagnostic'
+  params: {
+    diagnosticStorageAccountName: diagnosticStorageAccountName
+    microsoftSqlServerName: resourceGroupName
+    principalId: microsoftSqlServer.outputs.principalId
+    dianosticStorageAccountBlobEndpoint: diagnosticStorageAccount.outputs.blobEndpoint
+    dianosticStorageAccountSubscriptionId: subscription().subscriptionId
   }
 }
 

--- a/cloud-infrastructure/modules/container-apps-environment.bicep
+++ b/cloud-infrastructure/modules/container-apps-environment.bicep
@@ -2,6 +2,16 @@ param name string
 param location string
 param tags object
 param subnetId string
+param environmentResourceGroupName string
+
+
+resource existingLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
+  scope: resourceGroup('${environmentResourceGroupName}')
+  name: environmentResourceGroupName
+}
+
+var logAnalyticsCustomerId = existingLogAnalyticsWorkspace.properties.customerId
+var logAnalyticsSharedKey = existingLogAnalyticsWorkspace.listKeys().primarySharedKey
 
 resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-02-preview' = {
   name: name
@@ -16,7 +26,11 @@ resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-02-
       platformReservedDnsIP: '10.1.0.2'
     }
     appLogsConfiguration: {
-      destination: 'azure-monitor'
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalyticsCustomerId
+        sharedKey: logAnalyticsSharedKey
+      }
     }
     peerAuthentication: {
       mtls: {

--- a/cloud-infrastructure/modules/microsoft-sql-database.bicep
+++ b/cloud-infrastructure/modules/microsoft-sql-database.bicep
@@ -18,4 +18,4 @@ resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-05-01-preview' = {
   }
 }
 
-output connectionString string = 'Server=tcp:${sqlServerName}${environment().suffixes.sqlServerHostname},1433;Initial Catalog=${databaseName};Authentication=Active Directory Default;TrustServerCertificate=True;'
+output connectionString string = 'Server=tcp:${sqlServerName}${environment().suffixes.sqlServerHostname},1433;Initial Catalog=${databaseName};Authentication=Active Directory Default;TrustServerCertificate=True'

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -553,7 +553,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
             ).Trim();
 
             AnsiConsole.MarkupLine(
-                $"[green]Successfully created an App Registration {appRegistration} ({appRegistration.AppRegistrationId}).[/]"
+                $"[green]Successfully created an App Registration '{appRegistration.Name}' ({appRegistration.AppRegistrationId}).[/]"
             );
         }
     }
@@ -616,7 +616,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
             );
 
             AnsiConsole.MarkupLine(
-                $"[green]Successfully granted Service Principal ({appRegistrationName}) 'Contributor' and `User Access Administrator` rights to Azure Subscription {subscription.Name}.[/]"
+                $"[green]Successfully granted Service Principal ('{appRegistrationName}') 'Contributor' and `User Access Administrator` rights to Azure Subscription '{subscription.Name}'.[/]"
             );
         }
     }
@@ -641,7 +641,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
             );
 
             AnsiConsole.MarkupLine(
-                $"[green]Successfully created AD Security Group '{sqlAdminGroup.Name}' and granted the App Registration {appRegistration.Name} owner.[/]"
+                $"[green]Successfully created AD Security Group '{sqlAdminGroup.Name}' and assigned the App Registration '{appRegistration.Name}' owner role.[/]"
             );
         }
     }
@@ -659,7 +659,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
         );
 
         AnsiConsole.MarkupLine(
-            "[green]Successfully created [bold]staging[/] and [bold]production[/] environments in GitHub repository.[/]"
+            "[green]Successfully created 'staging' and 'production' environments in the GitHub repository.[/]"
         );
     }
 
@@ -724,7 +724,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
                 var disableCommand = $"gh workflow disable {workflowId}";
                 ProcessHelper.StartProcess(disableCommand, Configuration.GetSourceCodeFolder(), true);
 
-                AnsiConsole.MarkupLine($"[green]Workflow {workflowName} has been disabled.[/]");
+                AnsiConsole.MarkupLine($"[green]Reusable Git Workflow '{workflowName}' has been disabled.[/]");
 
                 break;
             }
@@ -803,7 +803,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
             }
             catch (Exception)
             {
-                AnsiConsole.MarkupLine($"[red]Error: Failed to run the {workflowName} GitHub workflow.[/]");
+                AnsiConsole.MarkupLine($"[red]Error: Failed to run the '{workflowName}' GitHub workflow.[/]");
                 Environment.Exit(1);
             }
         }


### PR DESCRIPTION
### Summary & Motivation

Enhance the behavior of Azure Container Apps for Workers by stopping background workers after database migrations. This change allows the workers to scale to zero, reducing hosting costs.

Update Azure Container App logs to use Log Analytics instead of Azure Monitor, enabling proper log viewing.

Fix the `grant-database-permissions` script to work correctly when deploying from localhost by correcting the parameters.

Reorder `main-cluster.bicep` to prioritize the creation of the Azure Communication Service resource, speeding up overall deployment.

Correct the "Successfully created an App Registration" message to include the App Registration name.

Remove double `;;` in the SQL connection string in Bicep, ensuring proper string formatting.


### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
