### PR TITLE
Revert and optimize database migration and email handling processes

### DIFF
--- a/application/account-management/Workers/Program.cs
+++ b/application/account-management/Workers/Program.cs
@@ -26,4 +26,4 @@ var host = builder.Build();
 // Apply migrations to the database (should be moved to GitHub Actions or similar in production)
 host.Services.ApplyMigrations<AccountManagementDbContext>();
 
-// host.Run(); is disabled for now, as the worker is only doing database migrations, which is a one-time operation, so we just let the host finish
+host.Run();

--- a/application/back-office/Workers/Program.cs
+++ b/application/back-office/Workers/Program.cs
@@ -26,4 +26,4 @@ var host = builder.Build();
 // Apply migrations to the database (should be moved to GitHub Actions or similar in production)
 host.Services.ApplyMigrations<BackOfficeDbContext>();
 
-// host.Run(); is disabled for now, as the worker is only doing database migrations, which is a one-time operation, so we just let the host finish
+host.Run();

--- a/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
+++ b/application/shared-kernel/InfrastructureCore/InfrastructureCoreConfiguration.cs
@@ -1,6 +1,8 @@
+using System.Net.Sockets;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using Azure.Storage.Blobs;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -144,14 +146,45 @@ public static class InfrastructureCoreConfiguration
         var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "Unknown";
         logger.LogInformation("Applying database migrations. Version: {Version}.", version);
         
-        var dbContext = scope.ServiceProvider.GetRequiredService<T>();
-        
-        var errorNumbersToAdd = new[] { 0 }; // On macOS and Linux exceptions with Error Number 0 are thrown when SQL Server is starting up
-        var maxRetryDelay = TimeSpan.FromSeconds(20);
-        var strategy = new SqlServerRetryingExecutionStrategy(dbContext, 10, maxRetryDelay, errorNumbersToAdd);
-        
-        strategy.Execute(() => dbContext.Database.Migrate());
-        
-        logger.LogInformation("Finished migrating database.");
+        var retryCount = 1;
+        while (retryCount <= 20)
+        {
+            try
+            {
+                if (retryCount % 5 == 0) logger.LogInformation("Waiting for databases to be ready...");
+                
+                var dbContext = scope.ServiceProvider.GetService<T>() ??
+                                throw new UnreachableException("Missing DbContext.");
+                
+                var strategy = dbContext.Database.CreateExecutionStrategy();
+                
+                strategy.Execute(() => dbContext.Database.Migrate());
+                
+                logger.LogInformation("Finished migrating database.");
+                
+                break;
+            }
+            catch (SqlException ex) when (ex.Message.Contains("an error occurred during the pre-login handshake"))
+            {
+                // Known error in Aspire, when SQL Server is not ready
+                retryCount++;
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+            }
+            catch (SocketException ex) when (ex.Message.Contains("Invalid argument"))
+            {
+                // Known error in Aspire, when SQL Server is not ready
+                retryCount++;
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "An error occurred while applying migrations.");
+                
+                // Wait for the logger to flush
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+                
+                break;
+            }
+        }
     }
 }

--- a/application/shared-kernel/InfrastructureCore/Services/AzureEmailService.cs
+++ b/application/shared-kernel/InfrastructureCore/Services/AzureEmailService.cs
@@ -17,6 +17,6 @@ public sealed class AzureEmailService(SecretClient secretClient) : IEmailService
         
         var emailClient = new EmailClient(connectionString.Value.Value);
         EmailMessage message = new(Sender, recipient, new EmailContent(subject) { Html = htmlContent });
-        await emailClient.SendAsync(WaitUntil.Completed, message, cancellationToken);
+        await emailClient.SendAsync(WaitUntil.Started, message, cancellationToken);
     }
 }


### PR DESCRIPTION
### Summary & Motivation

Revert "Simplify retry logic for handling when SQL Server is still starting on localhost". In a previous pull request, a different DB context execution strategy was introduced to simplify code that handles errors during database migrations locally while SQL Server was still starting. This change caused migrations to fail in Azure.

Revert "Stop background workers after they have run database migrations". In an earlier pull request, background workers running database migrations were made to stop in hopes of allowing Azure container apps to scale to 0. However, this caused the servers to crash and continuously restart.

Change mail sending in Azure to return when mail is initiated instead of waiting for delivery. Previously, sending mail using Azure Communication Services had `WaitUntil.Completed`, causing up to a 10-second delay in the UI during sign-up. This is now changed to `WaitUntil.Started` for faster response.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
