### PR TITLE
Update formatting rules to align Visual Studio and code cleanup

### DIFF
--- a/application/.editorconfig
+++ b/application/.editorconfig
@@ -1,7 +1,7 @@
 [*]
 charset = utf-8
 end_of_line = lf
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4

--- a/application/AppGateway/AppGateway.csproj
+++ b/application/AppGateway/AppGateway.csproj
@@ -10,11 +10,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Yarp.ReverseProxy"/>
+        <PackageReference Include="Yarp.ReverseProxy" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\shared-kernel\InfrastructureCore\SharedKernel.InfrastructureCore.csproj"/>
+        <ProjectReference Include="..\shared-kernel\InfrastructureCore\SharedKernel.InfrastructureCore.csproj" />
     </ItemGroup>
 
 </Project>

--- a/application/AppHost/AppHost.csproj
+++ b/application/AppHost/AppHost.csproj
@@ -10,23 +10,23 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\account-management\Api\AccountManagement.Api.csproj"/>
-        <ProjectReference Include="..\account-management\WebApp\AccountManagement.WebApp.esproj"/>
-        <ProjectReference Include="..\account-management\Workers\AccountManagement.Workers.csproj"/>
-        <ProjectReference Include="..\AppGateway\AppGateway.csproj"/>
-        <ProjectReference Include="..\back-office\Api\BackOffice.Api.csproj"/>
-        <ProjectReference Include="..\back-office\WebApp\BackOffice.WebApp.esproj"/>
-        <ProjectReference Include="..\back-office\Workers\BackOffice.Workers.csproj"/>
+        <ProjectReference Include="..\account-management\Api\AccountManagement.Api.csproj" />
+        <ProjectReference Include="..\account-management\WebApp\AccountManagement.WebApp.esproj" />
+        <ProjectReference Include="..\account-management\Workers\AccountManagement.Workers.csproj" />
+        <ProjectReference Include="..\AppGateway\AppGateway.csproj" />
+        <ProjectReference Include="..\back-office\Api\BackOffice.Api.csproj" />
+        <ProjectReference Include="..\back-office\WebApp\BackOffice.WebApp.esproj" />
+        <ProjectReference Include="..\back-office\Workers\BackOffice.Workers.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Azure.Storage.Blobs"/>
-        <PackageReference Include="Aspire.Hosting.AppHost"/>
-        <PackageReference Include="Aspire.Hosting.Azure.Storage"/>
-        <PackageReference Include="Aspire.Hosting.NodeJs"/>
-        <PackageReference Include="Aspire.Hosting.SqlServer"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets"/>
+        <PackageReference Include="Aspire.Azure.Storage.Blobs" />
+        <PackageReference Include="Aspire.Hosting.AppHost" />
+        <PackageReference Include="Aspire.Hosting.Azure.Storage" />
+        <PackageReference Include="Aspire.Hosting.NodeJs" />
+        <PackageReference Include="Aspire.Hosting.SqlServer" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     </ItemGroup>
 
     <ItemGroup>

--- a/application/account-management/Api/AccountManagement.Api.csproj
+++ b/application/account-management/Api/AccountManagement.Api.csproj
@@ -13,13 +13,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="PlatformPlatform.AccountManagement.Tests"/>
+        <InternalsVisibleTo Include="PlatformPlatform.AccountManagement.Tests" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\shared-kernel\ApiCore\SharedKernel.ApiCore.csproj"/>
-        <ProjectReference Include="..\Application\AccountManagement.Application.csproj"/>
-        <ProjectReference Include="..\Infrastructure\AccountManagement.Infrastructure.csproj"/>
+        <ProjectReference Include="..\..\shared-kernel\ApiCore\SharedKernel.ApiCore.csproj" />
+        <ProjectReference Include="..\Application\AccountManagement.Application.csproj" />
+        <ProjectReference Include="..\Infrastructure\AccountManagement.Infrastructure.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/application/account-management/Application/AccountManagement.Application.csproj
+++ b/application/account-management/Application/AccountManagement.Application.csproj
@@ -9,12 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\shared-kernel\ApplicationCore\SharedKernel.ApplicationCore.csproj"/>
-        <ProjectReference Include="..\Domain\AccountManagement.Domain.csproj"/>
+        <ProjectReference Include="..\..\shared-kernel\ApplicationCore\SharedKernel.ApplicationCore.csproj" />
+        <ProjectReference Include="..\Domain\AccountManagement.Domain.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Identity.Core"/>
+        <PackageReference Include="Microsoft.Extensions.Identity.Core" />
     </ItemGroup>
 
 </Project>

--- a/application/account-management/Directory.Build.props
+++ b/application/account-management/Directory.Build.props
@@ -5,15 +5,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Using Include="JetBrains.Annotations"/>
-        <Using Include="MediatR"/>
-        <Using Include="Microsoft.Extensions.Logging"/>
-        <Using Include="PlatformPlatform.AccountManagement.Domain.Tenants"/>
-        <Using Include="PlatformPlatform.AccountManagement.Domain.Users"/>
-        <Using Include="System.ComponentModel"/>
-        <Using Include="System.Diagnostics"/>
-        <Using Include="System.Reflection"/>
-        <Using Include="System.Text.Json.Serialization"/>
+        <Using Include="JetBrains.Annotations" />
+        <Using Include="MediatR" />
+        <Using Include="Microsoft.Extensions.Logging" />
+        <Using Include="PlatformPlatform.AccountManagement.Domain.Tenants" />
+        <Using Include="PlatformPlatform.AccountManagement.Domain.Users" />
+        <Using Include="System.ComponentModel" />
+        <Using Include="System.Diagnostics" />
+        <Using Include="System.Reflection" />
+        <Using Include="System.Text.Json.Serialization" />
     </ItemGroup>
 
 </Project>

--- a/application/account-management/Domain/AccountManagement.Domain.csproj
+++ b/application/account-management/Domain/AccountManagement.Domain.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\shared-kernel\DomainCore\SharedKernel.DomainCore.csproj"/>
+        <ProjectReference Include="..\..\shared-kernel\DomainCore\SharedKernel.DomainCore.csproj" />
     </ItemGroup>
 
 </Project>

--- a/application/account-management/Infrastructure/AccountManagement.Infrastructure.csproj
+++ b/application/account-management/Infrastructure/AccountManagement.Infrastructure.csproj
@@ -9,12 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="PlatformPlatform.AccountManagement.Tests"/>
+        <InternalsVisibleTo Include="PlatformPlatform.AccountManagement.Tests" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\shared-kernel\InfrastructureCore\SharedKernel.InfrastructureCore.csproj"/>
-        <ProjectReference Include="..\Application\AccountManagement.Application.csproj"/>
+        <ProjectReference Include="..\..\shared-kernel\InfrastructureCore\SharedKernel.InfrastructureCore.csproj" />
+        <ProjectReference Include="..\Application\AccountManagement.Application.csproj" />
     </ItemGroup>
 
 </Project>

--- a/application/account-management/Tests/AccountManagement.Tests.csproj
+++ b/application/account-management/Tests/AccountManagement.Tests.csproj
@@ -12,28 +12,28 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Api\AccountManagement.Api.csproj"/>
-        <ProjectReference Include="..\Application\AccountManagement.Application.csproj"/>
-        <ProjectReference Include="..\Domain\AccountManagement.Domain.csproj"/>
-        <ProjectReference Include="..\Infrastructure\AccountManagement.Infrastructure.csproj"/>
-        <ProjectReference Include="..\..\shared-kernel\Tests\SharedKernel.Tests.csproj"/>
+        <ProjectReference Include="..\Api\AccountManagement.Api.csproj" />
+        <ProjectReference Include="..\Application\AccountManagement.Application.csproj" />
+        <ProjectReference Include="..\Domain\AccountManagement.Domain.csproj" />
+        <ProjectReference Include="..\Infrastructure\AccountManagement.Infrastructure.csproj" />
+        <ProjectReference Include="..\..\shared-kernel\Tests\SharedKernel.Tests.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus"/>
+        <PackageReference Include="Bogus" />
         <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions"/>
-        <PackageReference Include="Meziantou.Xunit.ParallelTestFramework"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="NetArchTest.Rules"/>
-        <PackageReference Include="NJsonSchema"/>
-        <PackageReference Include="NSubstitute"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NetArchTest.Rules" />
+        <PackageReference Include="NJsonSchema" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/application/account-management/Workers/AccountManagement.Workers.csproj
+++ b/application/account-management/Workers/AccountManagement.Workers.csproj
@@ -10,12 +10,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Application\AccountManagement.Application.csproj"/>
-        <ProjectReference Include="..\Infrastructure\AccountManagement.Infrastructure.csproj"/>
+        <ProjectReference Include="..\Application\AccountManagement.Application.csproj" />
+        <ProjectReference Include="..\Infrastructure\AccountManagement.Infrastructure.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
     </ItemGroup>
 
     <ItemGroup>

--- a/application/back-office/Api/BackOffice.Api.csproj
+++ b/application/back-office/Api/BackOffice.Api.csproj
@@ -13,13 +13,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="PlatformPlatform.BackOffice.Tests"/>
+        <InternalsVisibleTo Include="PlatformPlatform.BackOffice.Tests" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\shared-kernel\ApiCore\SharedKernel.ApiCore.csproj"/>
-        <ProjectReference Include="..\Application\BackOffice.Application.csproj"/>
-        <ProjectReference Include="..\Infrastructure\BackOffice.Infrastructure.csproj"/>
+        <ProjectReference Include="..\..\shared-kernel\ApiCore\SharedKernel.ApiCore.csproj" />
+        <ProjectReference Include="..\Application\BackOffice.Application.csproj" />
+        <ProjectReference Include="..\Infrastructure\BackOffice.Infrastructure.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/application/back-office/Application/BackOffice.Application.csproj
+++ b/application/back-office/Application/BackOffice.Application.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\shared-kernel\ApplicationCore\SharedKernel.ApplicationCore.csproj"/>
-        <ProjectReference Include="..\Domain\BackOffice.Domain.csproj"/>
+        <ProjectReference Include="..\..\shared-kernel\ApplicationCore\SharedKernel.ApplicationCore.csproj" />
+        <ProjectReference Include="..\Domain\BackOffice.Domain.csproj" />
     </ItemGroup>
 
 </Project>

--- a/application/back-office/Directory.Build.props
+++ b/application/back-office/Directory.Build.props
@@ -5,13 +5,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Using Include="JetBrains.Annotations"/>
-        <Using Include="MediatR"/>
-        <Using Include="Microsoft.Extensions.Logging"/>
-        <Using Include="System.ComponentModel"/>
-        <Using Include="System.Diagnostics"/>
-        <Using Include="System.Reflection"/>
-        <Using Include="System.Text.Json.Serialization"/>
+        <Using Include="JetBrains.Annotations" />
+        <Using Include="MediatR" />
+        <Using Include="Microsoft.Extensions.Logging" />
+        <Using Include="System.ComponentModel" />
+        <Using Include="System.Diagnostics" />
+        <Using Include="System.Reflection" />
+        <Using Include="System.Text.Json.Serialization" />
     </ItemGroup>
 
 </Project>

--- a/application/back-office/Domain/BackOffice.Domain.csproj
+++ b/application/back-office/Domain/BackOffice.Domain.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\shared-kernel\DomainCore\SharedKernel.DomainCore.csproj"/>
+        <ProjectReference Include="..\..\shared-kernel\DomainCore\SharedKernel.DomainCore.csproj" />
     </ItemGroup>
 
 </Project>

--- a/application/back-office/Infrastructure/BackOffice.Infrastructure.csproj
+++ b/application/back-office/Infrastructure/BackOffice.Infrastructure.csproj
@@ -9,12 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="PlatformPlatform.BackOffice.Tests"/>
+        <InternalsVisibleTo Include="PlatformPlatform.BackOffice.Tests" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\shared-kernel\InfrastructureCore\SharedKernel.InfrastructureCore.csproj"/>
-        <ProjectReference Include="..\Application\BackOffice.Application.csproj"/>
+        <ProjectReference Include="..\..\shared-kernel\InfrastructureCore\SharedKernel.InfrastructureCore.csproj" />
+        <ProjectReference Include="..\Application\BackOffice.Application.csproj" />
     </ItemGroup>
 
 </Project>

--- a/application/back-office/Tests/BackOffice.Tests.csproj
+++ b/application/back-office/Tests/BackOffice.Tests.csproj
@@ -12,28 +12,28 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Api\BackOffice.Api.csproj"/>
-        <ProjectReference Include="..\Application\BackOffice.Application.csproj"/>
-        <ProjectReference Include="..\Domain\BackOffice.Domain.csproj"/>
-        <ProjectReference Include="..\Infrastructure\BackOffice.Infrastructure.csproj"/>
-        <ProjectReference Include="..\..\shared-kernel\Tests\SharedKernel.Tests.csproj"/>
+        <ProjectReference Include="..\Api\BackOffice.Api.csproj" />
+        <ProjectReference Include="..\Application\BackOffice.Application.csproj" />
+        <ProjectReference Include="..\Domain\BackOffice.Domain.csproj" />
+        <ProjectReference Include="..\Infrastructure\BackOffice.Infrastructure.csproj" />
+        <ProjectReference Include="..\..\shared-kernel\Tests\SharedKernel.Tests.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus"/>
+        <PackageReference Include="Bogus" />
         <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions"/>
-        <PackageReference Include="Meziantou.Xunit.ParallelTestFramework"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="NetArchTest.Rules"/>
-        <PackageReference Include="NJsonSchema"/>
-        <PackageReference Include="NSubstitute"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NetArchTest.Rules" />
+        <PackageReference Include="NJsonSchema" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/application/back-office/Workers/BackOffice.Workers.csproj
+++ b/application/back-office/Workers/BackOffice.Workers.csproj
@@ -10,12 +10,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Application\BackOffice.Application.csproj"/>
-        <ProjectReference Include="..\Infrastructure\BackOffice.Infrastructure.csproj"/>
+        <ProjectReference Include="..\Application\BackOffice.Application.csproj" />
+        <ProjectReference Include="..\Infrastructure\BackOffice.Infrastructure.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
     </ItemGroup>
 
     <ItemGroup>

--- a/application/shared-kernel/ApiCore/Endpoints/TestEndpoints.cs
+++ b/application/shared-kernel/ApiCore/Endpoints/TestEndpoints.cs
@@ -9,7 +9,7 @@ public class TestEndpoints : IEndpoints
     {
         if (!bool.TryParse(Environment.GetEnvironmentVariable("TestEndpointsEnabled"), out _)) return;
 
-        // Add dummy endpoints to simulate exception throwing for testing
+        // These endpoints are only enabled when running tests, and serve to simulate exception throwing for testing
         routes.MapGet("/api/throwException", _ => throw new InvalidOperationException("Simulate an exception."));
         routes.MapGet("/api/throwTimeoutException", _ => throw new TimeoutException("Simulating a timeout exception."));
     }

--- a/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandler.cs
+++ b/application/shared-kernel/ApiCore/Middleware/GlobalExceptionHandler.cs
@@ -6,11 +6,7 @@ namespace PlatformPlatform.SharedKernel.ApiCore.Middleware;
 
 public sealed class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IExceptionHandler
 {
-    public async ValueTask<bool> TryHandleAsync(
-        HttpContext httpContext,
-        Exception exception,
-        CancellationToken cancellationToken
-    )
+    public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
     {
         var traceId = Activity.Current?.Id ?? httpContext.TraceIdentifier;
 

--- a/application/shared-kernel/ApiCore/SharedKernel.ApiCore.csproj
+++ b/application/shared-kernel/ApiCore/SharedKernel.ApiCore.csproj
@@ -11,26 +11,26 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\DomainCore\SharedKernel.DomainCore.csproj"/>
-        <ProjectReference Include="..\InfrastructureCore\SharedKernel.InfrastructureCore.csproj"/>
+        <ProjectReference Include="..\DomainCore\SharedKernel.DomainCore.csproj" />
+        <ProjectReference Include="..\InfrastructureCore\SharedKernel.InfrastructureCore.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore"/>
-        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore"/>
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience"/>
-        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery"/>
-        <PackageReference Include="NSwag.AspNetCore"/>
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol"/>
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting"/>
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore"/>
-        <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient"/>
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http"/>
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime"/>
+        <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
+        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+        <PackageReference Include="NSwag.AspNetCore" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
     </ItemGroup>
 
 </Project>

--- a/application/shared-kernel/ApplicationCore/SharedKernel.ApplicationCore.csproj
+++ b/application/shared-kernel/ApplicationCore/SharedKernel.ApplicationCore.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\DomainCore\SharedKernel.DomainCore.csproj"/>
+        <ProjectReference Include="..\DomainCore\SharedKernel.DomainCore.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions"/>
-        <PackageReference Include="Mapster"/>
-        <PackageReference Include="MediatR"/>
-        <PackageReference Include="Microsoft.ApplicationInsights"/>
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+        <PackageReference Include="Mapster" />
+        <PackageReference Include="MediatR" />
+        <PackageReference Include="Microsoft.ApplicationInsights" />
     </ItemGroup>
 
 </Project>

--- a/application/shared-kernel/Directory.Build.props
+++ b/application/shared-kernel/Directory.Build.props
@@ -5,13 +5,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Using Include="JetBrains.Annotations"/>
-        <Using Include="MediatR"/>
-        <Using Include="Microsoft.Extensions.Logging"/>
-        <Using Include="System.ComponentModel"/>
-        <Using Include="System.Diagnostics"/>
-        <Using Include="System.Reflection"/>
-        <Using Include="System.Text.Json.Serialization"/>
+        <Using Include="JetBrains.Annotations" />
+        <Using Include="MediatR" />
+        <Using Include="Microsoft.Extensions.Logging" />
+        <Using Include="System.ComponentModel" />
+        <Using Include="System.Diagnostics" />
+        <Using Include="System.Reflection" />
+        <Using Include="System.Text.Json.Serialization" />
     </ItemGroup>
 
 </Project>

--- a/application/shared-kernel/DomainCore/SharedKernel.DomainCore.csproj
+++ b/application/shared-kernel/DomainCore/SharedKernel.DomainCore.csproj
@@ -9,11 +9,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="IdGen"/>
-        <PackageReference Include="JetBrains.Annotations"/>
-        <PackageReference Include="MediatR.Contracts"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
-        <PackageReference Include="NUlid"/>
+        <PackageReference Include="IdGen" />
+        <PackageReference Include="JetBrains.Annotations" />
+        <PackageReference Include="MediatR.Contracts" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="NUlid" />
     </ItemGroup>
 
 </Project>

--- a/application/shared-kernel/InfrastructureCore/SharedKernel.InfrastructureCore.csproj
+++ b/application/shared-kernel/InfrastructureCore/SharedKernel.InfrastructureCore.csproj
@@ -9,22 +9,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\ApplicationCore\SharedKernel.ApplicationCore.csproj"/>
-        <ProjectReference Include="..\DomainCore\SharedKernel.DomainCore.csproj"/>
+        <ProjectReference Include="..\ApplicationCore\SharedKernel.ApplicationCore.csproj" />
+        <ProjectReference Include="..\DomainCore\SharedKernel.DomainCore.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Azure.Storage.Blobs"/>
-        <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer"/>
-        <PackageReference Include="Azure.Communication.Email"/>
-        <PackageReference Include="Azure.Security.KeyVault.Secrets"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
+        <PackageReference Include="Aspire.Azure.Storage.Blobs" />
+        <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" />
+        <PackageReference Include="Azure.Communication.Email" />
+        <PackageReference Include="Azure.Security.KeyVault.Secrets" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Scrutor"/>
+        <PackageReference Include="Scrutor" />
     </ItemGroup>
 
 </Project>

--- a/application/shared-kernel/Tests/SharedKernel.Tests.csproj
+++ b/application/shared-kernel/Tests/SharedKernel.Tests.csproj
@@ -12,20 +12,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\ApiCore\SharedKernel.ApiCore.csproj"/>
-        <ProjectReference Include="..\DomainCore\SharedKernel.DomainCore.csproj"/>
-        <ProjectReference Include="..\InfrastructureCore\SharedKernel.InfrastructureCore.csproj"/>
+        <ProjectReference Include="..\ApiCore\SharedKernel.ApiCore.csproj" />
+        <ProjectReference Include="..\DomainCore\SharedKernel.DomainCore.csproj" />
+        <ProjectReference Include="..\InfrastructureCore\SharedKernel.InfrastructureCore.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions"/>
-        <PackageReference Include="Meziantou.Xunit.ParallelTestFramework"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="NetArchTest.Rules"/>
-        <PackageReference Include="NSubstitute"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NetArchTest.Rules" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/developer-cli/.editorconfig
+++ b/developer-cli/.editorconfig
@@ -1,7 +1,7 @@
 [*]
 charset = utf-8
 end_of_line = lf
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4

--- a/developer-cli/DeveloperCli.csproj
+++ b/developer-cli/DeveloperCli.csproj
@@ -11,19 +11,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.11.4"/>
-        <PackageReference Include="Azure.ResourceManager" Version="1.9.0"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0"/>
-        <PackageReference Include="Karambolo.PO" Version="1.11.0"/>
-        <PackageReference Include="OllamaSharp" Version="1.0.4"/>
-        <PackageReference Include="Spectre.Console" Version="0.48.0"/>
-        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
-        <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
+        <PackageReference Include="Azure.Identity" Version="1.11.4" />
+        <PackageReference Include="Azure.ResourceManager" Version="1.9.0" />
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+        <PackageReference Include="Karambolo.PO" Version="1.11.0" />
+        <PackageReference Include="OllamaSharp" Version="1.0.4" />
+        <PackageReference Include="Spectre.Console" Version="0.48.0" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+        <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="DeveloperCli.sln.DotSettings"/>
-        <None Remove="Directory.Build.props"/>
+        <None Remove="DeveloperCli.sln.DotSettings" />
+        <None Remove="Directory.Build.props" />
     </ItemGroup>
 
 </Project>

--- a/developer-cli/dotnet-tools.json
+++ b/developer-cli/dotnet-tools.json
@@ -4,7 +4,9 @@
   "tools": {
     "jetbrains.resharper.globaltools": {
       "version": "2024.1.3",
-      "commands": ["jb"]
+      "commands": [
+        "jb"
+      ]
     }
   }
 }


### PR DESCRIPTION
### Summary & Motivation

Update formatting rules to avoid conflicts between Visual Studio and code cleanup. The `.editorconfig` file has been updated to insert a space before the closing tag in XML. For example, `<ProjectReference Include="..."/>` is now `<ProjectReference Include="..." />`. This aligns with the default format when using Visual Studio and Rider to create project references. All `.csproj` and `.props` files have been updated to reflect this change.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
