### PR TITLE
Remove links to API from the Aspire dashboard

### DIFF
--- a/application/account-management/Api/Program.cs
+++ b/application/account-management/Api/Program.cs
@@ -13,7 +13,8 @@ builder.Services
     .AddInfrastructureServices()
     .AddApiCoreServices(builder, Assembly.GetExecutingAssembly(), DomainConfiguration.Assembly)
     .AddConfigureStorage(builder)
-    .AddSinglePageAppFallback();
+    .AddSinglePageAppFallback()
+    .ServeOnPort(builder, 9100);
 
 var app = builder.Build();
 

--- a/application/account-management/Api/Properties/launchSettings.json
+++ b/application/account-management/Api/Properties/launchSettings.json
@@ -3,9 +3,6 @@
   "profiles": {
     "Api": {
       "commandName": "Project",
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:9100",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",
         "PUBLIC_URL": "https://localhost:9000",

--- a/application/back-office/Api/Program.cs
+++ b/application/back-office/Api/Program.cs
@@ -13,7 +13,8 @@ builder.Services
     .AddInfrastructureServices()
     .AddApiCoreServices(builder, Assembly.GetExecutingAssembly(), DomainConfiguration.Assembly)
     .AddConfigureStorage(builder)
-    .AddSinglePageAppFallback();
+    .AddSinglePageAppFallback()
+    .ServeOnPort(builder, 9200);
 
 var app = builder.Build();
 

--- a/application/back-office/Api/Properties/launchSettings.json
+++ b/application/back-office/Api/Properties/launchSettings.json
@@ -3,9 +3,6 @@
   "profiles": {
     "Api": {
       "commandName": "Project",
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:9200",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",
         "PUBLIC_URL": "https://localhost:9000",

--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -126,6 +126,21 @@ public static class ApiCoreConfiguration
         return services;
     }
 
+    public static IServiceCollection ServeOnPort(this IServiceCollection services, WebApplicationBuilder builder, int port)
+    {
+        builder.WebHost.ConfigureKestrel((context, serverOptions) =>
+            {
+                if (!context.HostingEnvironment.IsDevelopment()) return;
+
+                serverOptions.ConfigureEndpointDefaults(listenOptions => listenOptions.UseHttps());
+
+                serverOptions.ListenAnyIP(port, listenOptions => listenOptions.UseHttps());
+            }
+        );
+
+        return services;
+    }
+
     public static WebApplication UseApiCoreConfiguration(this WebApplication app)
     {
         if (app.Environment.IsDevelopment())


### PR DESCRIPTION
### Summary & Motivation

Simplify the .NET Aspire dashboard by removing `applicationUrl` from `launchSettings.json and moving the configuration to .NET code. This change ensures that only a link to the AppGateway is shown, making it easier to know which link to click to access the application.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
