### PR TITLE
Enable background workers to scale to 0

### DIFF
--- a/application/account-management/Workers/AccountManagement.Workers.csproj
+++ b/application/account-management/Workers/AccountManagement.Workers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -10,6 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\shared-kernel\ApiCore\SharedKernel.ApiCore.csproj" />
         <ProjectReference Include="..\Application\AccountManagement.Application.csproj" />
         <ProjectReference Include="..\Infrastructure\AccountManagement.Infrastructure.csproj" />
     </ItemGroup>

--- a/application/account-management/Workers/Program.cs
+++ b/application/account-management/Workers/Program.cs
@@ -1,25 +1,18 @@
 using PlatformPlatform.AccountManagement.Application;
 using PlatformPlatform.AccountManagement.Infrastructure;
+using PlatformPlatform.SharedKernel.ApiCore;
 using PlatformPlatform.SharedKernel.InfrastructureCore;
 
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.Services.Configure<HostOptions>(options =>
-    {
-        options.ServicesStartConcurrently = true;
-        options.StartupTimeout = TimeSpan.FromSeconds(60);
-
-        options.ServicesStopConcurrently = true;
-        options.ShutdownTimeout = TimeSpan.FromSeconds(10);
-    }
-);
+// Worker service is using WebApplication.CreateBuilder instead of Host.CreateDefaultBuilder to allow scaling to zero
+var builder = WebApplication.CreateBuilder(args);
 
 // Configure services for the Application, Infrastructure layers like Entity Framework, Repositories, MediatR,
 // FluentValidation validators, Pipelines.
 builder.Services
     .AddApplicationServices()
     .AddInfrastructureServices()
-    .AddConfigureStorage(builder);
+    .AddConfigureStorage(builder)
+    .ServeOnPort(builder, 9199);
 
 var host = builder.Build();
 

--- a/application/account-management/Workers/Properties/launchSettings.json
+++ b/application/account-management/Workers/Properties/launchSettings.json
@@ -3,7 +3,6 @@
   "profiles": {
     "Workers": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "development"
       }

--- a/application/back-office/Workers/BackOffice.Workers.csproj
+++ b/application/back-office/Workers/BackOffice.Workers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -10,6 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\shared-kernel\ApiCore\SharedKernel.ApiCore.csproj" />
         <ProjectReference Include="..\Application\BackOffice.Application.csproj" />
         <ProjectReference Include="..\Infrastructure\BackOffice.Infrastructure.csproj" />
     </ItemGroup>

--- a/application/back-office/Workers/Program.cs
+++ b/application/back-office/Workers/Program.cs
@@ -1,25 +1,18 @@
 using PlatformPlatform.BackOffice.Application;
 using PlatformPlatform.BackOffice.Infrastructure;
+using PlatformPlatform.SharedKernel.ApiCore;
 using PlatformPlatform.SharedKernel.InfrastructureCore;
 
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.Services.Configure<HostOptions>(options =>
-    {
-        options.ServicesStartConcurrently = true;
-        options.StartupTimeout = TimeSpan.FromSeconds(60);
-
-        options.ServicesStopConcurrently = true;
-        options.ShutdownTimeout = TimeSpan.FromSeconds(10);
-    }
-);
+// Worker service is using WebApplication.CreateBuilder instead of Host.CreateDefaultBuilder to allow scaling to zero
+var builder = WebApplication.CreateBuilder(args);
 
 // Configure services for the Application, Infrastructure layers like Entity Framework, Repositories, MediatR,
 // FluentValidation validators, Pipelines.
 builder.Services
     .AddApplicationServices()
     .AddInfrastructureServices()
-    .AddConfigureStorage(builder);
+    .AddConfigureStorage(builder)
+    .ServeOnPort(builder, 9299);
 
 var host = builder.Build();
 

--- a/application/back-office/Workers/Properties/launchSettings.json
+++ b/application/back-office/Workers/Properties/launchSettings.json
@@ -3,7 +3,6 @@
   "profiles": {
     "Workers": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "development"
       }

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -131,7 +131,6 @@ var publicUrl = isCustomDomainSet
   : 'https://${appGatewayContainerAppName}.${containerAppsEnvironment.outputs.defaultDomainName}'
 var cdnUrl = publicUrl
 
-
 // Account Management
 
 var accountManagementIdentityName = '${resourceGroupName}-account-management'
@@ -233,7 +232,7 @@ module accountManagementWorkers '../modules/container-app.bicep' = {
     minReplicas: 0
     maxReplicas: 3
     userAssignedIdentityName: accountManagementIdentityName
-    ingress: false
+    ingress: true
     environmentVariables: accountManagementEnvironmentVariables
   }
   dependsOn: [accountManagementDatabase, accountManagementIdentity, communicationService]
@@ -262,7 +261,6 @@ module accountManagementApi '../modules/container-app.bicep' = {
   }
   dependsOn: [accountManagementDatabase, accountManagementIdentity, communicationService, accountManagementWorkers]
 }
-
 
 // Back Office
 
@@ -359,7 +357,7 @@ module backOfficeWorkers '../modules/container-app.bicep' = {
     minReplicas: 0
     maxReplicas: 1
     userAssignedIdentityName: backOfficeIdentityName
-    ingress: false
+    ingress: true
     environmentVariables: backOfficeEnvironmentVariables
   }
   dependsOn: [backOfficeDatabase, backOfficeIdentity, communicationService]


### PR DESCRIPTION
### Summary & Motivation

Allow background workers to scale to 0 by changing `Microsoft.NET.Sdk.Worker` to `Microsoft.NET.Sdk.Web` and `Host.CreateApplicationBuilder` to `WebApplication.CreateBuilder`. This hack enables workers to expose a minimal API, allowing Azure Container Apps to monitor ingress and scale the Container Apps to zero. The Bicep infrastructure has been updated to enable internal ingress.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
