### PR TITLE
Create HTTP Strict-Transport-Security ResponseHeaderValueTransform in AppGateway

### DIFF
--- a/application/AppGateway/Transformations/HttpStrictTransportSecurityTransform.cs
+++ b/application/AppGateway/Transformations/HttpStrictTransportSecurityTransform.cs
@@ -1,0 +1,6 @@
+using Yarp.ReverseProxy.Transforms;
+
+namespace PlatformPlatform.AppGateway.Transformations;
+
+public class HttpStrictTransportSecurityTransform()
+    : ResponseHeaderValueTransform("Strict-Transport-Security", "max-age=2592000", false, ResponseCondition.Success);

--- a/application/AppGateway/Transformations/ManagedIdentityTransform.cs
+++ b/application/AppGateway/Transformations/ManagedIdentityTransform.cs
@@ -20,8 +20,6 @@ public class ApiVersionHeaderTransform() : RequestHeaderTransform("x-ms-version"
 {
     protected override string? GetValue(RequestTransformContext context)
     {
-        if (!context.HttpContext.Request.Path.StartsWithSegments("/avatars")) return null;
-
-        return "2023-11-03";
+        return !context.HttpContext.Request.Path.StartsWithSegments("/avatars") ? null : "2023-11-03";
     }
 }


### PR DESCRIPTION
### Summary & Motivation

Create HTTP Strict-Transport-Security (HSTS) `ResponseHeaderValueTransform` in AppGateway to enforce HSTS on all self-contained systems. This replaces the `app.UseHsts()` in the AppGateway `Program.cs`, which did not affect downstream services.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
