### PR TITLE
Rename UserRole to Role in Users table

### DIFF
--- a/application/account-management/Infrastructure/Migrations/DatabaseMigrations.cs
+++ b/application/account-management/Infrastructure/Migrations/DatabaseMigrations.cs
@@ -51,7 +51,7 @@ public sealed class DatabaseMigrations : Migration
                 Email = table.Column<string>("nvarchar(100)", nullable: false),
                 FirstName = table.Column<string>("nvarchar(30)", nullable: true),
                 LastName = table.Column<string>("nvarchar(30)", nullable: true),
-                UserRole = table.Column<string>("varchar(20)", nullable: false),
+                Role = table.Column<string>("varchar(20)", nullable: false),
                 EmailConfirmed = table.Column<bool>("bit", nullable: false),
                 Avatar = table.Column<string>("varchar(200)", nullable: false)
             },


### PR DESCRIPTION
### Summary & Motivation

Update Entity Framework database migrations to reflect the rename of `User.UserRole` to `User.Role` from a previous pull request. 

**IMPORTANT:** This change requires the existing database to be updated manually.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
