### PR TITLE
Add infrastructure for the user to change the theme mode

### DIFF
--- a/application/account-management/WebApp/pages/-landing/sections/HeroSection.tsx
+++ b/application/account-management/WebApp/pages/-landing/sections/HeroSection.tsx
@@ -5,6 +5,7 @@ import { Button } from "@repo/ui/components/Button";
 import { Popover } from "@repo/ui/components/Popover";
 import { Dialog } from "@repo/ui/components/Dialog";
 import { Link } from "@repo/ui/components/Link";
+import { ThemeModeSelector } from "@repo/infrastructure/themeMode/ThemeModeSelector";
 
 const logoWrap = "https://platformplatformgithub.blob.core.windows.net/logo-wrap.svg?url";
 const heroimgDesktop = "https://platformplatformgithub.blob.core.windows.net/hero-image-desktop.png";
@@ -28,6 +29,7 @@ export function HeroSection() {
             <GithubIcon className="wmax-5 h-5" />
             <span className="md:hidden lg:inline">Github</span>
           </Link>
+          <ThemeModeSelector />
         </div>
         <div className="flex flex-col md:gap-8 md:flex-row items-center">
           <Button onPress={() => navigate({ to: "/register" })} variant="secondary" className="text-nowrap">

--- a/application/account-management/WebApp/pages/__root.tsx
+++ b/application/account-management/WebApp/pages/__root.tsx
@@ -3,6 +3,7 @@ import { ErrorPage } from "./-components/ErrorPage";
 import { NotFound } from "./-components/NotFoundPage";
 import { AuthenticationProvider } from "@repo/infrastructure/auth/AuthenticationProvider";
 import { ReactAriaRouterProvider } from "@repo/infrastructure/router/ReactAriaRouterProvider";
+import { ThemeModeProvider } from "@repo/infrastructure/themeMode/useThemeMode";
 
 export const Route = createRootRoute({
   component: Root,
@@ -13,10 +14,12 @@ export const Route = createRootRoute({
 function Root() {
   const navigate = useNavigate();
   return (
-    <ReactAriaRouterProvider>
-      <AuthenticationProvider navigate={(options) => navigate(options)} afterSignIn="/admin/users" afterSignOut="/">
-        <Outlet />
-      </AuthenticationProvider>
-    </ReactAriaRouterProvider>
+    <ThemeModeProvider>
+      <ReactAriaRouterProvider>
+        <AuthenticationProvider navigate={(options) => navigate(options)} afterSignIn="/admin/users" afterSignOut="/">
+          <Outlet />
+        </AuthenticationProvider>
+      </ReactAriaRouterProvider>
+    </ThemeModeProvider>
   );
 }

--- a/application/back-office/WebApp/pages/__root.tsx
+++ b/application/back-office/WebApp/pages/__root.tsx
@@ -3,6 +3,7 @@ import { ErrorPage } from "./-components/ErrorPage";
 import { NotFound } from "./-components/NotFoundPage";
 import { AuthenticationProvider } from "@repo/infrastructure/auth/AuthenticationProvider";
 import { ReactAriaRouterProvider } from "@repo/infrastructure/router/ReactAriaRouterProvider";
+import { ThemeModeProvider } from "@repo/infrastructure/themeMode/useThemeMode";
 
 export const Route = createRootRoute({
   component: Root,
@@ -13,10 +14,12 @@ export const Route = createRootRoute({
 function Root() {
   const navigate = useNavigate();
   return (
-    <ReactAriaRouterProvider>
-      <AuthenticationProvider navigate={(options) => navigate(options)} afterSignIn="/" afterSignOut="/">
-        <Outlet />
-      </AuthenticationProvider>
-    </ReactAriaRouterProvider>
+    <ThemeModeProvider>
+      <ReactAriaRouterProvider>
+        <AuthenticationProvider navigate={(options) => navigate(options)} afterSignIn="/" afterSignOut="/">
+          <Outlet />
+        </AuthenticationProvider>
+      </ReactAriaRouterProvider>
+    </ThemeModeProvider>
   );
 }

--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -8032,6 +8032,7 @@
       "devDependencies": {
         "@repo/build": "*",
         "@repo/config": "*",
+        "@repo/ui": "*",
         "@repo/utils": "*"
       }
     },

--- a/application/package.json
+++ b/application/package.json
@@ -6,7 +6,7 @@
   "packageManager": "npm@10.2.4",
   "workspaces": ["account-management/WebApp", "back-office/WebApp", "shared-webapp/*"],
   "scripts": {
-    "start": "npm install && npm run dev",
+    "start": "npm install && turbo dev",
     "dev": "turbo dev",
     "build": "turbo build",
     "test": "turbo test",

--- a/application/shared-webapp/build/package.json
+++ b/application/shared-webapp/build/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "dev": "tsc -p . -w",
+    "dev:setup": "tsc -p .",
     "build": "rm -rf ./dist && tsc -p .",
     "check": "biome check",
     "lint": "biome lint --write",

--- a/application/shared-webapp/infrastructure/package.json
+++ b/application/shared-webapp/infrastructure/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@repo/config": "*",
     "@repo/build": "*",
+    "@repo/ui": "*",
     "@repo/utils": "*"
   }
 }

--- a/application/shared-webapp/infrastructure/package.json
+++ b/application/shared-webapp/infrastructure/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "dev": "tsc -p . -w",
+    "dev:setup": "tsc -p .",
     "build": "rm -rf ./dist && tsc -p .",
     "check": "biome check",
     "lint": "biome lint --write",

--- a/application/shared-webapp/infrastructure/themeMode/ThemeModeSelector.tsx
+++ b/application/shared-webapp/infrastructure/themeMode/ThemeModeSelector.tsx
@@ -1,0 +1,19 @@
+import { useThemeMode } from "./useThemeMode";
+import { Button } from "@repo/ui/components/Button";
+import { MoonIcon, SunIcon } from "lucide-react";
+
+/**
+ * A button that toggles the theme mode between light and dark.
+ */
+export function ThemeModeSelector() {
+  const [themeMode, setThemeMode] = useThemeMode();
+  return (
+    <Button variant="icon">
+      {themeMode === "light" ? (
+        <MoonIcon onClick={() => setThemeMode("dark")} />
+      ) : (
+        <SunIcon onClick={() => setThemeMode("light")} />
+      )}
+    </Button>
+  );
+}

--- a/application/shared-webapp/infrastructure/themeMode/useThemeMode.tsx
+++ b/application/shared-webapp/infrastructure/themeMode/useThemeMode.tsx
@@ -1,0 +1,42 @@
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+const storageKey = "themeMode";
+type ThemeMode = "light" | "dark";
+
+export type ThemeModeContextType = [ThemeMode, (mode: ThemeMode) => void];
+
+export const ThemeModeContext = createContext<ThemeModeContextType>(["light", () => {}]);
+
+const setClassName = (mode: ThemeMode) => {
+  document.body.classList.remove("light", "dark");
+  document.body.classList.add(mode);
+};
+
+const initialThemeMode = localStorage.getItem(storageKey) === "dark" ? "dark" : "light";
+setClassName(initialThemeMode);
+
+type ThemeModeProviderProps = {
+  children: React.ReactNode;
+};
+
+export function ThemeModeProvider({ children }: Readonly<ThemeModeProviderProps>) {
+  const [themeMode, setThemeMode] = useState<ThemeMode>(initialThemeMode);
+
+  const setAndStoreThemeMode = useCallback((mode: ThemeMode) => {
+    localStorage.setItem(storageKey, mode);
+    setClassName(mode);
+    setThemeMode(mode);
+  }, []);
+
+  const value = useMemo<ThemeModeContextType>(
+    () => [themeMode, setAndStoreThemeMode],
+    [themeMode, setAndStoreThemeMode]
+  );
+
+  return <ThemeModeContext.Provider value={value}>{children}</ThemeModeContext.Provider>;
+}
+
+/**
+ * Hook to get the current theme mode and a function to set it.
+ */
+export const useThemeMode = () => useContext(ThemeModeContext);

--- a/application/shared-webapp/ui/package.json
+++ b/application/shared-webapp/ui/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "dev": "tsc -p . -w",
+    "dev:setup": "tsc -p .",
     "build": "rm -rf ./dist && tsc -p .",
     "check": "biome check",
     "lint": "biome lint --write",

--- a/application/shared-webapp/utils/package.json
+++ b/application/shared-webapp/utils/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "dev": "tsc -p . -w",
+    "dev:setup": "tsc -p .",
     "build": "rm -rf ./dist && tsc -p .",
     "check": "biome check",
     "lint": "biome lint --write",

--- a/application/turbo.json
+++ b/application/turbo.json
@@ -3,7 +3,7 @@
   "globalEnv": ["CERTIFICATE_PASSWORD"],
   "tasks": {
     "build": {
-      "outputs": ["dist/**", "storybook-static/**"],
+      "outputs": ["dist/**"],
       "dependsOn": ["^build"]
     },
     "check": {
@@ -12,7 +12,12 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "env": ["CERTIFICATE_PASSWORD"]
+      "env": ["CERTIFICATE_PASSWORD"],
+      "dependsOn": ["^dev:setup"]
+    },
+    "dev:setup": {
+      "dependsOn": ["^dev:setup"],
+      "outputs": ["dist/**"]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
### Summary & Motivation

We want users to choose what theme mode to use. This pr includes the initial infrastructure for enabling this.

We currently use local storage for persisting the user selected theme mode.

This pr also ensures packages to be build before starting the applications in development mode.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
