### PR TITLE
Ensure .sln file format consistency with Visual Studio 2022

### DIFF
--- a/application/PlatformPlatform.sln
+++ b/application/PlatformPlatform.sln
@@ -15,7 +15,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedKernel.ApiCore", "sha
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{9E2EF0B0-2A92-489B-8910-070C871197B0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "shared-kernel\Tests\SharedKernel.Tests.csproj", "{B232D7BB-396A-46FE-B6D2-95041412C835}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedKernel.Tests", "shared-kernel\Tests\SharedKernel.Tests.csproj", "{B232D7BB-396A-46FE-B6D2-95041412C835}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "account-management", "account-management", "{EEA1463E-71F8-44E6-8055-787DAA5E62D2}"
 EndProject

--- a/application/PlatformPlatform.sln
+++ b/application/PlatformPlatform.sln
@@ -1,57 +1,57 @@
 ﻿Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppHost", "AppHost\AppHost.csproj", "{2D6D4E5B-983A-4AAB-A91E-5492F7FD52E8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AppHost", "AppHost\AppHost.csproj", "{2D6D4E5B-983A-4AAB-A91E-5492F7FD52E8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppGateway", "AppGateway\AppGateway.csproj", "{8A9E566E-2DE4-4A60-9030-615C939BC05C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AppGateway", "AppGateway\AppGateway.csproj", "{8A9E566E-2DE4-4A60-9030-615C939BC05C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared-kernel", "shared-kernel", "{F01E4DC8-2A8B-4CB9-893A-B3B8FF2EFE22}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedKernel.DomainCore", "shared-kernel\DomainCore\SharedKernel.DomainCore.csproj", "{9781DA05-517E-46D7-9F8B-2C01AA74F1E4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedKernel.DomainCore", "shared-kernel\DomainCore\SharedKernel.DomainCore.csproj", "{9781DA05-517E-46D7-9F8B-2C01AA74F1E4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedKernel.ApplicationCore", "shared-kernel\ApplicationCore\SharedKernel.ApplicationCore.csproj", "{9F41C6BD-7DF5-46AD-B0E7-4E4CECA2B9BF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedKernel.ApplicationCore", "shared-kernel\ApplicationCore\SharedKernel.ApplicationCore.csproj", "{9F41C6BD-7DF5-46AD-B0E7-4E4CECA2B9BF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedKernel.InfrastructureCore", "shared-kernel\InfrastructureCore\SharedKernel.InfrastructureCore.csproj", "{2B5B1AC7-7254-4527-B0F0-8F0A203CB625}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedKernel.InfrastructureCore", "shared-kernel\InfrastructureCore\SharedKernel.InfrastructureCore.csproj", "{2B5B1AC7-7254-4527-B0F0-8F0A203CB625}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedKernel.ApiCore", "shared-kernel\ApiCore\SharedKernel.ApiCore.csproj", "{836ABCEF-C16B-4331-B8D5-0EA75E4101FE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedKernel.ApiCore", "shared-kernel\ApiCore\SharedKernel.ApiCore.csproj", "{836ABCEF-C16B-4331-B8D5-0EA75E4101FE}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{9E2EF0B0-2A92-489B-8910-070C871197B0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedKernel.Tests", "shared-kernel\Tests\SharedKernel.Tests.csproj", "{B232D7BB-396A-46FE-B6D2-95041412C835}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedKernel.Tests", "shared-kernel\Tests\SharedKernel.Tests.csproj", "{B232D7BB-396A-46FE-B6D2-95041412C835}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "account-management", "account-management", "{EEA1463E-71F8-44E6-8055-787DAA5E62D2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AccountManagement.Domain", "account-management\Domain\AccountManagement.Domain.csproj", "{32C5BCAB-FC18-4C32-B008-E0FD125C5E98}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccountManagement.Domain", "account-management\Domain\AccountManagement.Domain.csproj", "{32C5BCAB-FC18-4C32-B008-E0FD125C5E98}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AccountManagement.Application", "account-management\Application\AccountManagement.Application.csproj", "{B155D1D9-4F6E-42AE-A8F0-92CD50BF182D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccountManagement.Application", "account-management\Application\AccountManagement.Application.csproj", "{B155D1D9-4F6E-42AE-A8F0-92CD50BF182D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AccountManagement.Infrastructure", "account-management\Infrastructure\AccountManagement.Infrastructure.csproj", "{CB9BAD74-4362-4646-B653-3CB5FCAC74BD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccountManagement.Infrastructure", "account-management\Infrastructure\AccountManagement.Infrastructure.csproj", "{CB9BAD74-4362-4646-B653-3CB5FCAC74BD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AccountManagement.Workers", "account-management\Workers\AccountManagement.Workers.csproj", "{25F28E3C-84F0-44D6-8EB2-259398C2D14A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccountManagement.Workers", "account-management\Workers\AccountManagement.Workers.csproj", "{25F28E3C-84F0-44D6-8EB2-259398C2D14A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AccountManagement.Api", "account-management\Api\AccountManagement.Api.csproj", "{4AF4767C-1BF5-4B86-9050-F05ABF6AF4BE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccountManagement.Api", "account-management\Api\AccountManagement.Api.csproj", "{4AF4767C-1BF5-4B86-9050-F05ABF6AF4BE}"
 EndProject
 Project("{54A90642-561A-4BB1-A94E-469ADEE60C69}") = "AccountManagement.WebApp", "account-management\WebApp\AccountManagement.WebApp.esproj", "{8292F35B-F0F6-4DB1-90E2-4707DB8C7104}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{92101687-8181-4543-84F9-E702DD874619}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AccountManagement.Tests", "account-management\Tests\AccountManagement.Tests.csproj", "{ABEB4337-3606-4730-8ABE-94DF98C2C348}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccountManagement.Tests", "account-management\Tests\AccountManagement.Tests.csproj", "{ABEB4337-3606-4730-8ABE-94DF98C2C348}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "back-office", "back-office", "{E6B8D5DB-DA05-42EA-8DD0-EAE366870126}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackOffice.Domain", "back-office\Domain\BackOffice.Domain.csproj", "{81B7EAFF-E5FA-481D-8C8B-CFD419DC0A21}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BackOffice.Domain", "back-office\Domain\BackOffice.Domain.csproj", "{81B7EAFF-E5FA-481D-8C8B-CFD419DC0A21}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackOffice.Application", "back-office\Application\BackOffice.Application.csproj", "{1C858857-C5E6-41C6-AFA9-E845F6DDBDF0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BackOffice.Application", "back-office\Application\BackOffice.Application.csproj", "{1C858857-C5E6-41C6-AFA9-E845F6DDBDF0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackOffice.Infrastructure", "back-office\Infrastructure\BackOffice.Infrastructure.csproj", "{82FDD188-D4FC-43B6-B74E-EA6A1D1D2161}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BackOffice.Infrastructure", "back-office\Infrastructure\BackOffice.Infrastructure.csproj", "{82FDD188-D4FC-43B6-B74E-EA6A1D1D2161}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackOffice.Workers", "back-office\Workers\BackOffice.Workers.csproj", "{B165AE99-0B83-4EDC-8BBF-99FB726E5634}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BackOffice.Workers", "back-office\Workers\BackOffice.Workers.csproj", "{B165AE99-0B83-4EDC-8BBF-99FB726E5634}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackOffice.Api", "back-office\Api\BackOffice.Api.csproj", "{0E54670F-1D0C-4753-B5AC-CA618780925D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BackOffice.Api", "back-office\Api\BackOffice.Api.csproj", "{0E54670F-1D0C-4753-B5AC-CA618780925D}"
 EndProject
 Project("{54A90642-561A-4BB1-A94E-469ADEE60C69}") = "BackOffice.WebApp", "back-office\WebApp\BackOffice.WebApp.esproj", "{B1C5EFF3-B6EF-4B8F-B392-0E1AA2D81533}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{045A7336-D89B-493E-9C2C-92DCC2CC4D0E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackOffice.Tests", "back-office\Tests\BackOffice.Tests.csproj", "{62DB02EA-D720-46DC-BB78-13771E6D9A12}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BackOffice.Tests", "back-office\Tests\BackOffice.Tests.csproj", "{62DB02EA-D720-46DC-BB78-13771E6D9A12}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -144,6 +144,9 @@ Global
 		{62DB02EA-D720-46DC-BB78-13771E6D9A12}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{62DB02EA-D720-46DC-BB78-13771E6D9A12}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9781DA05-517E-46D7-9F8B-2C01AA74F1E4} = {F01E4DC8-2A8B-4CB9-893A-B3B8FF2EFE22}
 		{9F41C6BD-7DF5-46AD-B0E7-4E4CECA2B9BF} = {F01E4DC8-2A8B-4CB9-893A-B3B8FF2EFE22}
@@ -167,9 +170,6 @@ Global
 		{B1C5EFF3-B6EF-4B8F-B392-0E1AA2D81533} = {E6B8D5DB-DA05-42EA-8DD0-EAE366870126}
 		{045A7336-D89B-493E-9C2C-92DCC2CC4D0E} = {E6B8D5DB-DA05-42EA-8DD0-EAE366870126}
 		{62DB02EA-D720-46DC-BB78-13771E6D9A12} = {045A7336-D89B-493E-9C2C-92DCC2CC4D0E}
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 	EndGlobalSection


### PR DESCRIPTION
### Summary & Motivation

Ensure that working with Visual Studio 2022 on Windows does not change the format of the `.sln` file.

- Change .NET Projects types from `FAE04EC0-301F-11D3-BF4B-00C04F79EFBC` (old .NET Framework) to `9A19103F-16F7-4668-BE54-9A1E7A4F7556` (new .NET Core)
- Move `GlobalSection(SolutionProperties)` above `GlobalSection(NestedProjects)`
- Fix naming of `SharedKernel.Tests`

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
