### PR TITLE
Update OpenAPI and autogenerated TypeScript API contract with return types

### DIFF
--- a/application/account-management/Api/AccountRegistrations/AccountRegistrationsEndpoints.cs
+++ b/application/account-management/Api/AccountRegistrations/AccountRegistrationsEndpoints.cs
@@ -15,7 +15,7 @@ public class AccountRegistrationsEndpoints : IEndpoints
 
         group.MapGet("/is-subdomain-free", async Task<ApiResult<bool>> ([AsParameters] IsSubdomainFreeQuery query, ISender mediator)
             => await mediator.Send(query)
-        );
+        ).Produces<bool>();
 
         group.MapPost("/start", async Task<ApiResult> (StartAccountRegistrationCommand command, ISender mediator)
             => (await mediator.Send(command)).AddResourceUri(RoutesPrefix)

--- a/application/account-management/Api/Tenants/TenantEndpoints.cs
+++ b/application/account-management/Api/Tenants/TenantEndpoints.cs
@@ -14,7 +14,7 @@ public class TenantEndpoints : IEndpoints
 
         group.MapGet("/{id}", async Task<ApiResult<TenantResponseDto>> ([AsParameters] GetTenantQuery query, ISender mediator)
             => await mediator.Send(query)
-        );
+        ).Produces<TenantResponseDto>();
 
         group.MapPut("/{id}", async Task<ApiResult> (TenantId id, UpdateTenantCommand command, ISender mediator)
             => await mediator.Send(command with { Id = id })

--- a/application/account-management/Api/Users/UserEndpoints.cs
+++ b/application/account-management/Api/Users/UserEndpoints.cs
@@ -14,11 +14,11 @@ public class UserEndpoints : IEndpoints
 
         group.MapGet("/", async Task<ApiResult<GetUsersResponseDto>> ([AsParameters] GetUsersQuery query, ISender mediator)
             => await mediator.Send(query)
-        );
+        ).Produces<GetUsersResponseDto>();
 
         group.MapGet("/{id}", async Task<ApiResult<UserResponseDto>> ([AsParameters] GetUserQuery query, ISender mediator)
             => await mediator.Send(query)
-        );
+        ).Produces<UserResponseDto>();
 
         group.MapPost("/", async Task<ApiResult> (CreateUserCommand command, ISender mediator)
             => (await mediator.Send(command)).AddResourceUri(RoutesPrefix)

--- a/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
+++ b/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
@@ -74,7 +74,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetUsersResponseDto"
+                }
+              }
+            }
           }
         }
       },
@@ -121,7 +128,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponseDto"
+                }
+              }
+            }
           }
         }
       },
@@ -265,7 +279,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantResponseDto"
+                }
+              }
+            }
           }
         }
       },
@@ -346,7 +367,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
           }
         }
       }
@@ -415,6 +443,70 @@
   },
   "components": {
     "schemas": {
+      "GetUsersResponseDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "currentPageOffset": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserResponseDto"
+            }
+          }
+        }
+      },
+      "UserResponseDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "email": {
+            "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/UserRole"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "emailConfirmed": {
+            "type": "boolean"
+          },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
       "UserRole": {
         "type": "string",
         "description": "",
@@ -546,6 +638,44 @@
             "type": "string"
           }
         }
+      },
+      "TenantResponseDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/components/schemas/TenantState"
+          }
+        }
+      },
+      "TenantState": {
+        "type": "string",
+        "description": "",
+        "x-enumNames": [
+          "Trial",
+          "Active",
+          "Suspended"
+        ],
+        "enum": [
+          "Trial",
+          "Active",
+          "Suspended"
+        ]
       },
       "UpdateTenantCommand": {
         "type": "object",


### PR DESCRIPTION
### Summary & Motivation

Update OpenAPI contract and autogenerated TypeScript API contract to include return types. This is achieved by adding a `.Produces<<FooDto>()` call to all minimal API endpoints that return a type.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
