### PR TITLE
Update API endpoint for updating user and create separate endpoint for changing user role

### DIFF
--- a/application/account-management/Api/Users/UserEndpoints.cs
+++ b/application/account-management/Api/Users/UserEndpoints.cs
@@ -28,6 +28,10 @@ public class UserEndpoints : IEndpoints
             => await mediator.Send(command with { Id = id })
         );
 
+        group.MapPut("/{id}/change-user-role", async Task<ApiResult> (UserId id, ChangeUserRoleCommand command, ISender mediator)
+            => await mediator.Send(command with { Id = id })
+        );
+
         group.MapDelete("/{id}", async Task<ApiResult> ([AsParameters] DeleteUserCommand command, ISender mediator)
             => await mediator.Send(command)
         );

--- a/application/account-management/Application/TelemetryEvents/TelemetryEvents.cs
+++ b/application/account-management/Application/TelemetryEvents/TelemetryEvents.cs
@@ -40,6 +40,9 @@ public sealed class UserDeleted()
 public sealed class UserUpdated()
     : TelemetryEvent(nameof(UserUpdated));
 
+public sealed class UserRoleChanged(UserRole fromRole, UserRole toRole)
+    : TelemetryEvent(nameof(UserUpdated), ("FromRole", fromRole.ToString()), ("ToRole", toRole.ToString()));
+
 public sealed class UserAvatarUpdated(string contentType, long size)
     : TelemetryEvent(nameof(UserAvatarUpdated), ("ContentType", contentType), ("Size", size.ToString()));
 

--- a/application/account-management/Application/Users/ChangeUserRole.cs
+++ b/application/account-management/Application/Users/ChangeUserRole.cs
@@ -1,0 +1,31 @@
+using PlatformPlatform.AccountManagement.Application.TelemetryEvents;
+using PlatformPlatform.SharedKernel.ApplicationCore.Cqrs;
+using PlatformPlatform.SharedKernel.ApplicationCore.TelemetryEvents;
+
+namespace PlatformPlatform.AccountManagement.Application.Users;
+
+public sealed record ChangeUserRoleCommand : ICommand, IRequest<Result>
+{
+    [JsonIgnore] // Removes the Id from the API contract
+    public UserId Id { get; init; } = null!;
+
+    public required UserRole UserRole { get; init; }
+}
+
+public sealed class ChangeUserRoleHandler(IUserRepository userRepository, ITelemetryEventsCollector events)
+    : IRequestHandler<ChangeUserRoleCommand, Result>
+{
+    public async Task<Result> Handle(ChangeUserRoleCommand command, CancellationToken cancellationToken)
+    {
+        var user = await userRepository.GetByIdAsync(command.Id, cancellationToken);
+        if (user is null) return Result.NotFound($"User with id '{command.Id}' not found.");
+
+        var oldUserRole = user.Role;
+        user.ChangeUserRole(command.UserRole);
+        userRepository.Update(user);
+
+        events.CollectEvent(new UserRoleChanged(oldUserRole, command.UserRole));
+
+        return Result.Success();
+    }
+}

--- a/application/account-management/Application/Users/UpdateUser.cs
+++ b/application/account-management/Application/Users/UpdateUser.cs
@@ -11,9 +11,13 @@ public sealed record UpdateUserCommand : ICommand, IRequest<Result>
     [JsonIgnore] // Removes the Id from the API contract
     public UserId Id { get; init; } = null!;
 
-    public required UserRole UserRole { get; init; }
-
     public required string Email { get; init; }
+
+    public required string FirstName { get; init; }
+
+    public required string LastName { get; init; }
+
+    public required string Title { get; init; }
 }
 
 public sealed class UpdateUserValidator : AbstractValidator<UpdateUserCommand>
@@ -21,6 +25,9 @@ public sealed class UpdateUserValidator : AbstractValidator<UpdateUserCommand>
     public UpdateUserValidator()
     {
         RuleFor(x => x.Email).NotEmpty().SetValidator(new SharedValidations.Email());
+        RuleFor(x => x.FirstName).MaximumLength(30).WithMessage("First name must be no longer than 30 characters.");
+        RuleFor(x => x.LastName).MaximumLength(30).WithMessage("Last name must be no longer than 30 characters.");
+        RuleFor(x => x.Title).MaximumLength(50).WithMessage("Title must be no longer than 50 characters.");
     }
 }
 
@@ -33,7 +40,7 @@ public sealed class UpdateUserHandler(IUserRepository userRepository, ITelemetry
         if (user is null) return Result.NotFound($"User with id '{command.Id}' not found.");
 
         user.UpdateEmail(command.Email);
-        user.ChangeUserRole(command.UserRole);
+        user.Update(command.FirstName, command.LastName, command.Title);
         userRepository.Update(user);
 
         events.CollectEvent(new UserUpdated());

--- a/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
+++ b/application/account-management/Tests/Api/Users/UserEndpointsTests.cs
@@ -234,7 +234,13 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
     {
         // Arrange
         var existingUserId = DatabaseSeeder.User1.Id;
-        var command = new UpdateUserCommand { Email = Faker.Internet.Email(), UserRole = UserRole.Owner };
+        var command = new UpdateUserCommand
+        {
+            Email = Faker.Internet.Email(),
+            FirstName = Faker.Name.FirstName(),
+            LastName = Faker.Name.LastName(),
+            Title = Faker.Name.JobTitle()
+        };
 
         // Act
         var response = await TestHttpClient.PutAsJsonAsync($"/api/account-management/users/{existingUserId}", command);
@@ -248,8 +254,13 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
     {
         // Arrange
         var existingUserId = DatabaseSeeder.User1.Id;
-        var invalidEmail = Faker.InvalidEmail();
-        var command = new UpdateUserCommand { Email = invalidEmail, UserRole = UserRole.Admin };
+        var command = new UpdateUserCommand
+        {
+            Email = Faker.InvalidEmail(),
+            FirstName = Faker.Random.String(31),
+            LastName = Faker.Random.String(31),
+            Title = Faker.Random.String(51)
+        };
 
         // Act
         var response = await TestHttpClient.PutAsJsonAsync($"/api/account-management/users/{existingUserId}", command);
@@ -257,7 +268,10 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
         // Assert
         var expectedErrors = new[]
         {
-            new ErrorDetail("Email", "Email must be in a valid format and no longer than 100 characters.")
+            new ErrorDetail("Email", "Email must be in a valid format and no longer than 100 characters."),
+            new ErrorDetail("FirstName", "First name must be no longer than 30 characters."),
+            new ErrorDetail("LastName", "Last name must be no longer than 30 characters."),
+            new ErrorDetail("Title", "Title must be no longer than 50 characters.")
         };
         await EnsureErrorStatusCode(response, HttpStatusCode.BadRequest, expectedErrors);
     }
@@ -267,7 +281,13 @@ public sealed class UserEndpointsTests : BaseApiTests<AccountManagementDbContext
     {
         // Arrange
         var unknownUserId = UserId.NewId();
-        var command = new UpdateUserCommand { Email = Faker.Internet.Email(), UserRole = UserRole.Admin };
+        var command = new UpdateUserCommand
+        {
+            Email = Faker.Internet.Email(),
+            FirstName = Faker.Name.FirstName(),
+            LastName = Faker.Name.LastName(),
+            Title = Faker.Name.JobTitle()
+        };
 
         // Act
         var response = await TestHttpClient.PutAsJsonAsync($"/api/account-management/users/{unknownUserId}", command);

--- a/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
+++ b/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
@@ -631,10 +631,16 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "userRole": {
-            "$ref": "#/components/schemas/UserRole"
-          },
           "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "title": {
             "type": "string"
           }
         }

--- a/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
+++ b/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
@@ -196,6 +196,42 @@
         }
       }
     },
+    "/api/account-management/users/{id}/change-user-role": {
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "PutApiAccountManagementUsersChangeUserRole",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/UserId"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "command",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangeUserRoleCommand"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
     "/api/account-management/users/{id}/update-avatar": {
       "post": {
         "tags": [
@@ -642,6 +678,15 @@
           },
           "title": {
             "type": "string"
+          }
+        }
+      },
+      "ChangeUserRoleCommand": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "userRole": {
+            "$ref": "#/components/schemas/UserRole"
           }
         }
       },


### PR DESCRIPTION
### Summary & Motivation

Add option to update `FirstName`, `LastName`, and `Title` when calling `UpdateUserCommand`. Introduce a new endpoint and command for changing user roles.

Changing user roles is implemented as a separate endpoint, intended for Admin use only.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
