### PR TITLE
Set up kestrel to listen to localhost instead of any IP

### DIFF
--- a/application/account-management/Api/Program.cs
+++ b/application/account-management/Api/Program.cs
@@ -14,7 +14,7 @@ builder.Services
     .AddApiCoreServices(builder, Assembly.GetExecutingAssembly(), DomainConfiguration.Assembly)
     .AddConfigureStorage(builder)
     .AddSinglePageAppFallback()
-    .ServeOnPort(builder, 9100);
+    .ConfigureDevelopmentPort(builder, 9100);
 
 var app = builder.Build();
 

--- a/application/account-management/Workers/Program.cs
+++ b/application/account-management/Workers/Program.cs
@@ -12,7 +12,7 @@ builder.Services
     .AddApplicationServices()
     .AddInfrastructureServices()
     .AddConfigureStorage(builder)
-    .ServeOnPort(builder, 9199);
+    .ConfigureDevelopmentPort(builder, 9199);
 
 var host = builder.Build();
 

--- a/application/back-office/Api/Program.cs
+++ b/application/back-office/Api/Program.cs
@@ -14,7 +14,7 @@ builder.Services
     .AddApiCoreServices(builder, Assembly.GetExecutingAssembly(), DomainConfiguration.Assembly)
     .AddConfigureStorage(builder)
     .AddSinglePageAppFallback()
-    .ServeOnPort(builder, 9200);
+    .ConfigureDevelopmentPort(builder, 9200);
 
 var app = builder.Build();
 

--- a/application/back-office/Workers/Program.cs
+++ b/application/back-office/Workers/Program.cs
@@ -12,7 +12,7 @@ builder.Services
     .AddApplicationServices()
     .AddInfrastructureServices()
     .AddConfigureStorage(builder)
-    .ServeOnPort(builder, 9299);
+    .ConfigureDevelopmentPort(builder, 9299);
 
 var host = builder.Build();
 

--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -134,7 +134,7 @@ public static class ApiCoreConfiguration
 
                 serverOptions.ConfigureEndpointDefaults(listenOptions => listenOptions.UseHttps());
 
-                serverOptions.ListenAnyIP(port, listenOptions => listenOptions.UseHttps());
+                serverOptions.ListenLocalhost(port, listenOptions => listenOptions.UseHttps());
             }
         );
 

--- a/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
+++ b/application/shared-kernel/ApiCore/ApiCoreConfiguration.cs
@@ -126,7 +126,7 @@ public static class ApiCoreConfiguration
         return services;
     }
 
-    public static IServiceCollection ServeOnPort(this IServiceCollection services, WebApplicationBuilder builder, int port)
+    public static IServiceCollection ConfigureDevelopmentPort(this IServiceCollection services, WebApplicationBuilder builder, int port)
     {
         builder.WebHost.ConfigureKestrel((context, serverOptions) =>
             {


### PR DESCRIPTION
### Summary & Motivation

This pull request will configure kestrel to only listen to localhost and not any IP for the development environment. This change will also stop the firewall warnings popup from the APIs.

Also, rename ServerOnPort extension method to ConfigureDevelopmentPort to make it clear that this is only for development.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
