### PR TITLE
Change liveness and readiness health probes scheme from HTTPS to HTTP

### DIFF
--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -101,7 +101,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
                   httpGet: {
                     path: '/internal-api/live'
                     port: 8080
-                    scheme: 'HTTPS'
+                    scheme: 'HTTP'
                   }
                   initialDelaySeconds: 3
                   failureThreshold: 3
@@ -114,7 +114,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
                   httpGet: {
                     path: '/internal-api/ready'
                     port: 8080
-                    scheme: 'HTTPS'
+                    scheme: 'HTTP'
                   }
                   initialDelaySeconds: 3
                   failureThreshold: 3
@@ -125,7 +125,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
               ]
             : [
                 {
-                  type: 'liveness'
+                  type: 'Liveness'
                   failureThreshold: 3
                   periodSeconds: 10
                   successThreshold: 1
@@ -135,7 +135,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
                   timeoutSeconds: 1
                 }
                 {
-                  type: 'readiness'
+                  type: 'Readiness'
                   failureThreshold: 48
                   initialDelaySeconds: 3
                   periodSeconds: 5


### PR DESCRIPTION
### Summary & Motivation

Change liveness and readiness health probes scheme from HTTPS to HTTP. In a previous pull request, we switched from TCP to HTTP health probes for the API in Azure Container App. However, these failed to start because the scheme was set to HTTPS instead of HTTP. This PR corrects the scheme to HTTP, ensuring proper functionality.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
