### PR TITLE
Ensure Aspire is using the the latest version of the Azurite image

### DIFF
--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -19,6 +19,13 @@ var azureStorage = builder
             resourceBuilder.WithBlobPort(10000);
         }
     )
+    .WithAnnotation(new ContainerImageAnnotation
+        {
+            Registry = "mcr.microsoft.com",
+            Image = "azure-storage/azurite",
+            Tag = "latest"
+        }
+    )
     .AddBlobs("blobs");
 
 builder


### PR DESCRIPTION
### Summary & Motivation
Ensure Azurite is using the latest image to prevent application startup failures on local machines. Aspire sometimes does not use the latest version of the Docker image for Azurite, which causes issues due to hard dependencies in the .NET Azure Storage SDK on newer versions of Azurite. If Aspire starts with an older version, exceptions are thrown indicating that Azurite does not support the specific API version used in the SDK. This update ensures compatibility and prevents these exceptions, enhancing development reliability and performance.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
