### PR TITLE
Update Bicep infrastructure to grant Account Management sign permissions in Key Vault Access

### DIFF
--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -144,6 +144,7 @@ module accountManagementIdentity '../modules/user-assigned-managed-identity.bice
     containerRegistryName: containerRegistryName
     environmentResourceGroupName: environmentResourceGroupName
     keyVaultName: keyVault.outputs.name
+    grantKeyVaultWritePermissions: true
   }
 }
 

--- a/cloud-infrastructure/modules/user-assigned-managed-identity.bicep
+++ b/cloud-infrastructure/modules/user-assigned-managed-identity.bicep
@@ -4,6 +4,7 @@ param tags object
 param containerRegistryName string
 param environmentResourceGroupName string
 param keyVaultName string
+param grantKeyVaultWritePermissions bool = false
 
 resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: name
@@ -24,8 +25,21 @@ resource keyVault 'Microsoft.KeyVault/vaults@2021-10-01' existing = {
   name: keyVaultName
 }
 
-var keyVaultCryptoServiceEncryptionUserRoleDefinitionId = 'e147488a-f6f5-4113-8e2d-b22465e65bf6' // Key Vault Crypto Service Encryption User 
+var keyVaultSecretsUserRoleDefinitionId = '4633458b-17de-408a-b874-0445c86b69e6' // Key Vault Secrets User role
+resource readKeyVaultSecretsRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVaultName, name, keyVaultSecretsUserRoleDefinitionId)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      keyVaultSecretsUserRoleDefinitionId
+    )
+    principalType: 'ServicePrincipal'
+    principalId: userAssignedIdentity.properties.principalId
+  }
+}
 
+var keyVaultCryptoServiceEncryptionUserRoleDefinitionId = 'e147488a-f6f5-4113-8e2d-b22465e65bf6' // Key Vault Crypto Service Encryption User 
 resource readKeyVaultKeysRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(keyVaultName, name, keyVaultCryptoServiceEncryptionUserRoleDefinitionId)
   scope: keyVault
@@ -39,14 +53,14 @@ resource readKeyVaultKeysRoleAssignment 'Microsoft.Authorization/roleAssignments
   }
 }
 
-var keyVaultSecretsUserRoleDefinitionId = '4633458b-17de-408a-b874-0445c86b69e6' // Key Vault Secrets User role
-resource readKeyVaultSecretsRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(keyVaultName, name, keyVaultSecretsUserRoleDefinitionId)
+var keyVaultCryptoOfficerRoleDefinitionId = '14b46e9e-c2b7-41b4-b07b-48a6ebf60603' // Key Vault Crypto Officer
+resource signKeyVaultKeysRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (grantKeyVaultWritePermissions) {
+  name: guid(keyVaultName, name, keyVaultCryptoOfficerRoleDefinitionId)
   scope: keyVault
   properties: {
     roleDefinitionId: subscriptionResourceId(
       'Microsoft.Authorization/roleDefinitions',
-      keyVaultSecretsUserRoleDefinitionId
+      keyVaultCryptoOfficerRoleDefinitionId
     )
     principalType: 'ServicePrincipal'
     principalId: userAssignedIdentity.properties.principalId


### PR DESCRIPTION
### Summary & Motivation

Update Bicep infrastructure to ensure the Account Management managed identity is granted the Key Vault Crypto Officer role, allowing it to sign access tokens.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
