### PR TITLE
Add external annotations to mark implicitly created types as used

### DIFF
--- a/application/account-management/Core/Authentication/Commands/CompleteLogin.cs
+++ b/application/account-management/Core/Authentication/Commands/CompleteLogin.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using PlatformPlatform.AccountManagement.Core.Authentication.Domain;
 using PlatformPlatform.AccountManagement.Core.Authentication.Services;
 using PlatformPlatform.AccountManagement.Core.TelemetryEvents;
@@ -8,6 +9,7 @@ using PlatformPlatform.SharedKernel.TelemetryEvents;
 
 namespace PlatformPlatform.AccountManagement.Core.Authentication.Commands;
 
+[PublicAPI]
 public sealed record CompleteLoginCommand(string OneTimePassword) : ICommand, IRequest<Result>
 {
     [JsonIgnore]

--- a/application/account-management/Core/Authentication/Commands/Logout.cs
+++ b/application/account-management/Core/Authentication/Commands/Logout.cs
@@ -14,7 +14,7 @@ public sealed class LogoutHandler(
     AuthenticationTokenService authenticationTokenService,
     IHttpContextAccessor httpContextAccessor,
     ITelemetryEventsCollector events,
-    ILogger<CompleteLoginHandler> logger
+    ILogger<LogoutHandler> logger
 ) : IRequestHandler<LogoutCommand, Result>
 {
     public Task<Result> Handle(LogoutCommand command, CancellationToken cancellationToken)

--- a/application/account-management/Core/Authentication/Commands/StartLogin.cs
+++ b/application/account-management/Core/Authentication/Commands/StartLogin.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using JetBrains.Annotations;
 using Microsoft.AspNetCore.Identity;
 using PlatformPlatform.AccountManagement.Core.Authentication.Domain;
 using PlatformPlatform.AccountManagement.Core.TelemetryEvents;
@@ -11,6 +12,7 @@ using PlatformPlatform.SharedKernel.Validation;
 
 namespace PlatformPlatform.AccountManagement.Core.Authentication.Commands;
 
+[PublicAPI]
 public sealed record StartLoginCommand(string Email) : ICommand, IRequest<Result<StartLoginResponse>>;
 
 public sealed class StartLoginValidator : AbstractValidator<StartLoginCommand>
@@ -21,6 +23,7 @@ public sealed class StartLoginValidator : AbstractValidator<StartLoginCommand>
     }
 }
 
+[PublicAPI]
 public sealed record StartLoginResponse(string LoginId, int ValidForSeconds);
 
 public sealed class StartLoginCommandHandler(

--- a/application/account-management/Core/Authentication/Domain/Login.cs
+++ b/application/account-management/Core/Authentication/Domain/Login.cs
@@ -61,6 +61,7 @@ public sealed class Login : AggregateRoot<LoginId>
     }
 }
 
+[PublicAPI]
 [IdPrefix("login")]
 [TypeConverter(typeof(StronglyTypedIdTypeConverter<string, LoginId>))]
 public sealed record LoginId(string Value) : StronglyTypedUlid<LoginId>(Value)

--- a/application/account-management/Core/Signups/Commands/StartSignup.cs
+++ b/application/account-management/Core/Signups/Commands/StartSignup.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using JetBrains.Annotations;
 using Microsoft.AspNetCore.Identity;
 using PlatformPlatform.AccountManagement.Core.Signups.Domain;
 using PlatformPlatform.AccountManagement.Core.TelemetryEvents;
@@ -19,6 +20,7 @@ public sealed record StartSignupCommand(string Subdomain, string Email) : IComma
     }
 }
 
+[PublicAPI]
 public sealed record StartSignupResponse(string SignupId, int ValidForSeconds);
 
 public sealed class StartSignupValidator : AbstractValidator<StartSignupCommand>

--- a/application/account-management/Core/Signups/Domain/Signup.cs
+++ b/application/account-management/Core/Signups/Domain/Signup.cs
@@ -60,6 +60,7 @@ public sealed class Signup : AggregateRoot<SignupId>
     }
 }
 
+[PublicAPI]
 [IdPrefix("signup")]
 [TypeConverter(typeof(StronglyTypedIdTypeConverter<string, SignupId>))]
 public sealed record SignupId(string Value) : StronglyTypedUlid<SignupId>(Value)

--- a/application/account-management/Core/Signups/Queries/IsSubdomainFree.cs
+++ b/application/account-management/Core/Signups/Queries/IsSubdomainFree.cs
@@ -1,8 +1,10 @@
+using JetBrains.Annotations;
 using PlatformPlatform.AccountManagement.Core.Tenants.Domain;
 using PlatformPlatform.SharedKernel.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Core.Signups.Queries;
 
+[PublicAPI]
 public sealed record IsSubdomainFreeQuery(string Subdomain) : IRequest<Result<bool>>;
 
 public sealed class IsSubdomainFreeHandler(ITenantRepository tenantRepository)

--- a/application/account-management/Core/Tenants/Commands/DeleteTenant.cs
+++ b/application/account-management/Core/Tenants/Commands/DeleteTenant.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using JetBrains.Annotations;
 using PlatformPlatform.AccountManagement.Core.TelemetryEvents;
 using PlatformPlatform.AccountManagement.Core.Tenants.Domain;
 using PlatformPlatform.AccountManagement.Core.Users.Domain;
@@ -7,6 +8,7 @@ using PlatformPlatform.SharedKernel.TelemetryEvents;
 
 namespace PlatformPlatform.AccountManagement.Core.Tenants.Commands;
 
+[PublicAPI]
 public sealed record DeleteTenantCommand(TenantId Id) : ICommand, IRequest<Result>;
 
 public sealed class DeleteTenantValidator : AbstractValidator<DeleteTenantCommand>

--- a/application/account-management/Core/Tenants/Queries/GetTenant.cs
+++ b/application/account-management/Core/Tenants/Queries/GetTenant.cs
@@ -1,11 +1,14 @@
+using JetBrains.Annotations;
 using Mapster;
 using PlatformPlatform.AccountManagement.Core.Tenants.Domain;
 using PlatformPlatform.SharedKernel.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Core.Tenants.Queries;
 
+[PublicAPI]
 public sealed record GetTenantQuery(TenantId Id) : IRequest<Result<TenantResponseDto>>;
 
+[PublicAPI]
 public sealed record TenantResponseDto(string Id, DateTimeOffset CreatedAt, DateTimeOffset? ModifiedAt, string Name, TenantState State);
 
 public sealed class GetTenantHandler(ITenantRepository tenantRepository)

--- a/application/account-management/Core/Users/Commands/ChangeUserRole.cs
+++ b/application/account-management/Core/Users/Commands/ChangeUserRole.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using PlatformPlatform.AccountManagement.Core.TelemetryEvents;
 using PlatformPlatform.AccountManagement.Core.Users.Domain;
 using PlatformPlatform.SharedKernel.Cqrs;
@@ -5,6 +6,7 @@ using PlatformPlatform.SharedKernel.TelemetryEvents;
 
 namespace PlatformPlatform.AccountManagement.Core.Users.Commands;
 
+[PublicAPI]
 public sealed record ChangeUserRoleCommand : ICommand, IRequest<Result>
 {
     [JsonIgnore] // Removes the Id from the API contract

--- a/application/account-management/Core/Users/Commands/DeleteUser.cs
+++ b/application/account-management/Core/Users/Commands/DeleteUser.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using PlatformPlatform.AccountManagement.Core.TelemetryEvents;
 using PlatformPlatform.AccountManagement.Core.Users.Domain;
 using PlatformPlatform.SharedKernel.Cqrs;
@@ -5,6 +6,7 @@ using PlatformPlatform.SharedKernel.TelemetryEvents;
 
 namespace PlatformPlatform.AccountManagement.Core.Users.Commands;
 
+[PublicAPI]
 public sealed record DeleteUserCommand(UserId Id) : ICommand, IRequest<Result>;
 
 public sealed class DeleteUserHandler(IUserRepository userRepository, ITelemetryEventsCollector events)

--- a/application/account-management/Core/Users/Commands/RemoveAvatar.cs
+++ b/application/account-management/Core/Users/Commands/RemoveAvatar.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using PlatformPlatform.AccountManagement.Core.TelemetryEvents;
 using PlatformPlatform.AccountManagement.Core.Users.Domain;
 using PlatformPlatform.SharedKernel.Cqrs;
@@ -5,6 +6,7 @@ using PlatformPlatform.SharedKernel.TelemetryEvents;
 
 namespace PlatformPlatform.AccountManagement.Core.Users.Commands;
 
+[PublicAPI]
 public sealed record RemoveAvatarCommand(UserId Id) : ICommand, IRequest<Result>;
 
 public sealed class RemoveAvatarCommandHandler(IUserRepository userRepository, ITelemetryEventsCollector events)

--- a/application/account-management/Core/Users/Domain/UserTypes.cs
+++ b/application/account-management/Core/Users/Domain/UserTypes.cs
@@ -1,7 +1,9 @@
+using JetBrains.Annotations;
 using PlatformPlatform.SharedKernel.IdGenerators;
 
 namespace PlatformPlatform.AccountManagement.Core.Users.Domain;
 
+[PublicAPI]
 [IdPrefix("usr")]
 [TypeConverter(typeof(StronglyTypedIdTypeConverter<string, UserId>))]
 public sealed record UserId(string Value) : StronglyTypedUlid<UserId>(Value)

--- a/application/account-management/Core/Users/Queries/GetUser.cs
+++ b/application/account-management/Core/Users/Queries/GetUser.cs
@@ -1,11 +1,14 @@
+using JetBrains.Annotations;
 using Mapster;
 using PlatformPlatform.AccountManagement.Core.Users.Domain;
 using PlatformPlatform.SharedKernel.Cqrs;
 
 namespace PlatformPlatform.AccountManagement.Core.Users.Queries;
 
+[PublicAPI]
 public sealed record GetUserQuery(UserId Id) : IRequest<Result<UserResponseDto>>;
 
+[PublicAPI]
 public sealed record UserResponseDto(
     string Id,
     DateTimeOffset CreatedAt,

--- a/application/account-management/Core/Users/Queries/GetUsers.cs
+++ b/application/account-management/Core/Users/Queries/GetUsers.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using JetBrains.Annotations;
 using Mapster;
 using PlatformPlatform.AccountManagement.Core.Users.Domain;
 using PlatformPlatform.SharedKernel.Cqrs;
@@ -6,6 +7,7 @@ using PlatformPlatform.SharedKernel.Persistence;
 
 namespace PlatformPlatform.AccountManagement.Core.Users.Queries;
 
+[PublicAPI]
 public sealed record GetUsersQuery(
     string? Search = null,
     UserRole? UserRole = null,
@@ -15,8 +17,10 @@ public sealed record GetUsersQuery(
     int? PageOffset = null
 ) : IRequest<Result<GetUsersResponseDto>>;
 
+[PublicAPI]
 public sealed record GetUsersResponseDto(int TotalCount, int PageSize, int TotalPages, int CurrentPageOffset, UsersResponseUserDto[] Users);
 
+[PublicAPI]
 public sealed record UsersResponseUserDto(
     string Id,
     DateTimeOffset CreatedAt,

--- a/application/shared-kernel/SharedKernel/Endpoints/IEndpoints.cs
+++ b/application/shared-kernel/SharedKernel/Endpoints/IEndpoints.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Routing;
 
 namespace PlatformPlatform.SharedKernel.Endpoints;
 
+[UsedImplicitly(ImplicitUseTargetFlags.WithInheritors)]
 public interface IEndpoints
 {
     public void MapEndpoints(IEndpointRouteBuilder routes);

--- a/application/shared-kernel/SharedKernel/Endpoints/TrackEndpoints.cs
+++ b/application/shared-kernel/SharedKernel/Endpoints/TrackEndpoints.cs
@@ -198,8 +198,10 @@ public class TrackEndpoints : IEndpoints
     }
 }
 
+[PublicAPI]
 public record TrackResponseSuccessDto(bool Success, string Message);
 
+[PublicAPI]
 public record TrackRequestDto(
     DateTimeOffset Time,
     // ReSharper disable once InconsistentNaming
@@ -228,6 +230,7 @@ public record TrackRequestBaseDataDto(
     string Id
 );
 
+[PublicAPI]
 public record TrackRequestMetricsDto(string Name, int Kind, double Value, int Count);
 
 public record TrackRequestExceptionDto(

--- a/application/shared-kernel/SharedKernel/ExternalAnnotations/FluentValidation.xml
+++ b/application/shared-kernel/SharedKernel/ExternalAnnotations/FluentValidation.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly name="FluentValidation">
+    <member name="T:FluentValidation.AbstractValidator`1">
+        <attribute
+            ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+            <argument>4</argument>
+        </attribute>
+    </member>
+</assembly>

--- a/application/shared-kernel/SharedKernel/ExternalAnnotations/MediatR.xml
+++ b/application/shared-kernel/SharedKernel/ExternalAnnotations/MediatR.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly name="MediatR">
+    <member name="T:MediatR.IRequestHandler`2">
+        <attribute
+            ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+            <argument>4</argument>
+        </attribute>
+    </member>
+    <member name="T:MediatR.IRequestHandler`1">
+        <attribute
+            ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+            <argument>4</argument>
+        </attribute>
+    </member>
+</assembly>

--- a/application/shared-kernel/SharedKernel/ExternalAnnotations/README.md
+++ b/application/shared-kernel/SharedKernel/ExternalAnnotations/README.md
@@ -1,0 +1,12 @@
+# Annotations for external libraries
+
+This folder contains JetBrains code annotations in XML format, that apply to external libraries that we use.
+
+An example for where this is very useful is to guide code analysis to not consider implicitly used types as unused,
+such as for validators built using FluentValidation.
+
+For info on how to write annotations,
+see [the Rider documentation](https://www.jetbrains.com/help/rider/Code_Analysis__External_Annotations.html).
+
+For a lot of examples of annotations
+see [JetBrains standard collection of annotations](https://github.com/JetBrains/ExternalAnnotations)


### PR DESCRIPTION
### Summary & Motivation

Mark `MediatR.IRequestHandler`, `FluentValidation.AbstractValidator`, and `SharedKernel.IEndpoints` as being used implicitly, resolving incorrect warnings about unused code like the one shown in the screenshot:

<img width="449" alt="Screenshot 2024-09-05 at 09 55 45" src="https://github.com/user-attachments/assets/2d8ad6c5-a768-4f82-9e05-5f0528090c4a">

The change is implemented using JetBrains External Annotations, which are XML files stored in an ExternalAnnotations folder alongside the solution or project file. These annotations prevent misleading warnings in JetBrains IDEs. For more details, refer to [Rider documentation](https://www.jetbrains.com/help/rider/Code_Analysis__External_Annotations.html) and [JetBrains’ standard annotations](https://github.com/JetBrains/ExternalAnnotations).

Additionally, all Request and Command classes have been marked with the [PublicAPI] attribute to avoid similar warnings about unused code.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
