### PR TITLE
Allow specifying IP address range for virtual network

### DIFF
--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -12,7 +12,7 @@ param appGatewayVersion string
 param accountManagementVersion string
 param backOfficeVersion string
 param applicationInsightsConnectionString string
-param communicatoinServicesDataLocation string = 'europe'
+param communicationServicesDataLocation string = 'europe'
 param mailSenderDisplayName string = 'PlatformPlatform'
 
 var storageAccountUniquePrefix = replace(resourceGroupName, '-', '')
@@ -56,6 +56,7 @@ module virtualNetwork '../modules/virtual-network.bicep' = {
     location: location
     name: resourceGroupName
     tags: tags
+    address: '10.0.0.0'
   }
 }
 
@@ -93,7 +94,7 @@ module communicationService '../modules/communication-services.bicep' = {
   params: {
     name: resourceGroupName
     tags: tags
-    dataLocation: communicatoinServicesDataLocation
+    dataLocation: communicationServicesDataLocation
     mailSenderDisplayName: mailSenderDisplayName
     keyVaultName: keyVault.outputs.name
   }

--- a/cloud-infrastructure/modules/virtual-network.bicep
+++ b/cloud-infrastructure/modules/virtual-network.bicep
@@ -1,6 +1,7 @@
 param name string
 param location string
 param tags object
+param address string
 
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
   name: name
@@ -10,7 +11,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
     virtualNetworkPeerings: []
     enableDdosProtection: false
     addressSpace: {
-      addressPrefixes: ['10.0.0.0/16']
+      addressPrefixes: ['${address}/16']
     }
     dhcpOptions: {
       dnsServers: []
@@ -19,7 +20,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
       {
         name: 'subnet'
         properties: {
-          addressPrefix: '10.0.0.0/23'
+          addressPrefix: '${address}/23'
           serviceEndpoints: [
             {
               service: 'Microsoft.KeyVault'
@@ -37,5 +38,6 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
   }
 }
 
+output virtualNetworkName string = virtualNetwork.name
 output virtualNetworkId string = virtualNetwork.id
 output subnetId string = virtualNetwork.properties.subnets[0].id


### PR DESCRIPTION
### Summary & Motivation
Enable the specification of IP address ranges within the Bicep module file for a virtual network. This change allows the module to be used multiple times with different IP ranges. Without this enhancement, multiple virtual networks using the same IP range cannot be connected via peering.

### Atomic Changes
- Allow specifying IP address range for virtual network

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
