### PR TITLE
Fix race condition leading to UnitOfWork not being committed

### DIFF
--- a/application/shared-kernel/SharedKernel/Behaviors/ConcurrentCommandCounter.cs
+++ b/application/shared-kernel/SharedKernel/Behaviors/ConcurrentCommandCounter.cs
@@ -10,7 +10,7 @@ namespace PlatformPlatform.SharedKernel.Behaviors;
 /// </summary>
 public sealed class ConcurrentCommandCounter
 {
-    private int _concurrentCount;
+    private long _concurrentCount;
 
     public void Increment()
     {
@@ -24,6 +24,6 @@ public sealed class ConcurrentCommandCounter
 
     public bool IsZero()
     {
-        return _concurrentCount == 0;
+        return Interlocked.Read(ref _concurrentCount) == 0;
     }
 }


### PR DESCRIPTION
### Summary & Motivation

In rare conditions, the code allows the unit of work and/or the events to not be published at the end of the request. 

Multiple threads can decrement the concurrent counter at the same time using Interlocked to ensure atomicity of the operation. However, when reading the data, Interlocked was not used, leading to potential race conditions.

### Checklist

- [ ] I have added a Label to the pull-request
- [ ] I have added tests, and done manual regression tests
- [ ] I have updated the documentation, if necessary
