### PR TITLE
Fix federated module loading on production and align localhost to fetch static files through YARP

### DIFF
--- a/application/AppGateway/Filters/ClusterDestinationConfigFilter.cs
+++ b/application/AppGateway/Filters/ClusterDestinationConfigFilter.cs
@@ -9,8 +9,10 @@ public class ClusterDestinationConfigFilter : IProxyConfigFilter
         return cluster.ClusterId switch
         {
             "account-management-api" => ReplaceDestinationAddress(cluster, "ACCOUNT_MANAGEMENT_API_URL"),
+            "account-management-static" => ReplaceDestinationAddress(cluster, "ACCOUNT_MANAGEMENT_API_URL"),
             "avatars-storage" => ReplaceDestinationAddress(cluster, "AVATARS_STORAGE_URL"),
             "back-office-api" => ReplaceDestinationAddress(cluster, "BACK_OFFICE_API_URL"),
+            "back-office-static" => ReplaceDestinationAddress(cluster, "BACK_OFFICE_API_URL"),
             _ => throw new InvalidOperationException($"Unknown Cluster ID {cluster.ClusterId}")
         };
     }

--- a/application/AppGateway/appsettings.json
+++ b/application/AppGateway/appsettings.json
@@ -28,6 +28,17 @@
           "Path": "/{**catch-all}"
         }
       },
+      "account-management-static": {
+        "ClusterId": "account-management-static",
+        "Match": {
+          "Path": "/account-management/{**catch-all}"
+        },
+        "Transforms": [
+          {
+            "PathPattern": "{**catch-all}"
+          }
+        ]
+      },
       "back-office-api": {
         "ClusterId": "back-office-api",
         "Match": {
@@ -47,6 +58,17 @@
         "Transforms": [
           {
             "PathPattern": "{**catch-all}"
+          }
+        ]
+      },
+      "back-office-static": {
+        "ClusterId": "back-office-static",
+        "Match": {
+          "Path": "/back-office/static/{**catch-all}"
+        },
+        "Transforms": [
+          {
+            "PathPattern": "static/{**catch-all}"
           }
         ]
       },
@@ -74,10 +96,24 @@
           }
         }
       },
+      "account-management-static": {
+        "Destinations": {
+          "destination": {
+            "Address": "https://localhost:9101"
+          }
+        }
+      },
       "back-office-api": {
         "Destinations": {
           "destination": {
             "Address": "https://localhost:9200"
+          }
+        }
+      },
+      "back-office-static": {
+        "Destinations": {
+          "destination": {
+            "Address": "https://localhost:9201"
           }
         }
       },

--- a/application/account-management/Api/Properties/launchSettings.json
+++ b/application/account-management/Api/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",
         "PUBLIC_URL": "https://localhost:9000",
-        "CDN_URL": "https://localhost:9101"
+        "CDN_URL": "https://localhost:9000/account-management"
       }
     }
   }

--- a/application/account-management/Tests/EndpointBaseTest.cs
+++ b/application/account-management/Tests/EndpointBaseTest.cs
@@ -16,7 +16,7 @@ public abstract class EndpointBaseTest<TContext> : BaseTest<TContext> where TCon
     protected EndpointBaseTest()
     {
         Environment.SetEnvironmentVariable(SinglePageAppConfiguration.PublicUrlKey, "https://localhost:9000");
-        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.CdnUrlKey, "https://localhost:9101");
+        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.CdnUrlKey, "https://localhost:9000/account-management");
 
         _webApplicationFactory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
             {

--- a/application/account-management/WebApp/shared/components/AvatarButton.tsx
+++ b/application/account-management/WebApp/shared/components/AvatarButton.tsx
@@ -17,7 +17,7 @@ export default function AvatarButton() {
 
   if (!userInfo) return null;
 
-  async function logut() {
+  async function logout() {
     await api.post("/api/account-management/authentication/logout");
     window.location.reload();
   }
@@ -48,7 +48,7 @@ export default function AvatarButton() {
             Account settings
           </MenuItem>
           <MenuSeparator />
-          <MenuItem id="logout" onAction={logut}>
+          <MenuItem id="logout" onAction={logout}>
             <LogOutIcon size={16} /> Log out
           </MenuItem>
         </Menu>

--- a/application/back-office/Api/Properties/launchSettings.json
+++ b/application/back-office/Api/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",
         "PUBLIC_URL": "https://localhost:9000",
-        "CDN_URL": "https://localhost:9201"
+        "CDN_URL": "https://localhost:9000/back-office"
       }
     }
   }

--- a/application/back-office/Tests/EndpointBaseTest.cs
+++ b/application/back-office/Tests/EndpointBaseTest.cs
@@ -15,7 +15,7 @@ public abstract class EndpointBaseTest<TContext> : BaseTest<TContext> where TCon
     protected EndpointBaseTest()
     {
         Environment.SetEnvironmentVariable(SinglePageAppConfiguration.PublicUrlKey, "https://localhost:9000");
-        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.CdnUrlKey, "https://localhost:9201");
+        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.CdnUrlKey, "https://localhost:9000/back-office");
 
         _webApplicationFactory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
             {

--- a/application/shared-webapp/build/plugin/MFPlugin.ts
+++ b/application/shared-webapp/build/plugin/MFPlugin.ts
@@ -8,7 +8,6 @@ const applicationRoot = path.resolve(process.cwd(), "..", "..");
 const systemRoot = path.resolve(process.cwd(), "..");
 const applicationPackageJson = path.join(applicationRoot, "package.json");
 const mfTypesPath = path.join(applicationRoot, "shared-webapp", "build", "mf-types");
-const isDevelopment = process.env.NODE_ENV !== "production";
 
 if (!fs.existsSync(applicationPackageJson)) {
   throw new Error(`Cannot find package.json in the application root: ${applicationRoot}`);
@@ -81,7 +80,7 @@ function snakeCase(str: string) {
 function getAllRemotes(currentSystem: string, remotes: Record<string, { port: number }>) {
   const result: Record<string, string> = {};
   const everySystem = getEverySystem();
-  for (const [system, config] of Object.entries(remotes)) {
+  for (const [system] of Object.entries(remotes)) {
     if (system === currentSystem) {
       throw new Error(`Cannot add self as remote: ${system}`);
     }
@@ -89,10 +88,7 @@ function getAllRemotes(currentSystem: string, remotes: Record<string, { port: nu
       throw new Error(`Cannot find system: ${system}`);
     }
 
-    result[system] =
-      isDevelopment && config.port
-        ? `${snakeCase(system)}@https://localhost:${config.port}/${manifestFile}`
-        : `${snakeCase(system)}@/${system}/${manifestFile}`;
+    result[system] =`${snakeCase(system)}@/${system}/${manifestFile}`;
 
     logger.info(`[Module Federation] Remote: "${system}" => ${result[system]}`);
   }


### PR DESCRIPTION
### Summary & Motivation

Update YARP configuration to fix the issue where federated modules were not loading in production. All communication for static files on localhost is now routed through the YARP gateway, rather than directly to the self-contained systems, which run as separate processes on localhost for hot reloading.

Added new YARP routes for static files and changed the loading of federated modules to always use /[self-contained system]/remoteEntry.js for both localhost and production. The federated module configuration has been simplified, as the same approach is now used for both environments.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
