### PR TITLE
Add tenant isolation on aggregates that belongs to a tenant

### DIFF
--- a/application/account-management/Api/AccountManagement.Api.csproj
+++ b/application/account-management/Api/AccountManagement.Api.csproj
@@ -17,14 +17,15 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Core\AccountManagement.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.ApiDescription.Server">
             <IncludeAssets>runtime; build; native; contentFiles; analyzers; buildTransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Core\AccountManagement.csproj" />
-    </ItemGroup>
 
 </Project>

--- a/application/account-management/Api/Endpoints/UserEndpoints.cs
+++ b/application/account-management/Api/Endpoints/UserEndpoints.cs
@@ -38,14 +38,12 @@ public sealed class UserEndpoints : IEndpoints
             => await mediator.Send(new DeleteUserCommand(id))
         );
 
-        // The id should be inferred from the authenticated user
-        group.MapPost("/{id}/update-avatar", async Task<ApiResult> (UserId id, IFormFile file, IMediator mediator)
-            => await mediator.Send(new UpdateAvatarCommand(id, file.OpenReadStream(), file.ContentType))
+        group.MapPost("/update-avatar", async Task<ApiResult> (IFormFile file, IMediator mediator)
+            => await mediator.Send(new UpdateAvatarCommand(file.OpenReadStream(), file.ContentType))
         ).DisableAntiforgery(); // Disable anti-forgery until we implement it
 
-        // The id should be inferred from the authenticated user
-        group.MapPost("/{id}/remove-avatar", async Task<ApiResult> (UserId id, IMediator mediator)
-            => await mediator.Send(new RemoveAvatarCommand(id))
+        group.MapDelete("/remove-avatar", async Task<ApiResult> (IMediator mediator)
+            => await mediator.Send(new RemoveAvatarCommand())
         );
     }
 }

--- a/application/account-management/Core/Authentication/Commands/CompleteLogin.cs
+++ b/application/account-management/Core/Authentication/Commands/CompleteLogin.cs
@@ -63,7 +63,7 @@ public sealed class CompleteLoginHandler(
             return Result.BadRequest("The code is no longer valid, please request a new code.", true);
         }
 
-        var user = (await userRepository.GetByIdAsync(login.UserId, cancellationToken))!;
+        var user = (await userRepository.GetByIdGlobalAsync(login.UserId, cancellationToken))!;
 
         login.MarkAsCompleted();
         loginRepository.Update(login);

--- a/application/account-management/Core/Database/AccountManagementDbContext.cs
+++ b/application/account-management/Core/Database/AccountManagementDbContext.cs
@@ -5,11 +5,12 @@ using PlatformPlatform.AccountManagement.Tenants.Domain;
 using PlatformPlatform.AccountManagement.Users.Domain;
 using PlatformPlatform.SharedKernel.Domain;
 using PlatformPlatform.SharedKernel.EntityFramework;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 
 namespace PlatformPlatform.AccountManagement.Database;
 
-public sealed class AccountManagementDbContext(DbContextOptions<AccountManagementDbContext> options)
-    : SharedKernelDbContext<AccountManagementDbContext>(options)
+public sealed class AccountManagementDbContext(DbContextOptions<AccountManagementDbContext> options, IExecutionContext executionContext)
+    : SharedKernelDbContext<AccountManagementDbContext>(options, executionContext)
 {
     public DbSet<Login> Logins => Set<Login>();
 

--- a/application/account-management/Core/Users/Commands/RemoveAvatar.cs
+++ b/application/account-management/Core/Users/Commands/RemoveAvatar.cs
@@ -2,21 +2,20 @@ using JetBrains.Annotations;
 using PlatformPlatform.AccountManagement.TelemetryEvents;
 using PlatformPlatform.AccountManagement.Users.Domain;
 using PlatformPlatform.SharedKernel.Cqrs;
-using PlatformPlatform.SharedKernel.Domain;
 using PlatformPlatform.SharedKernel.TelemetryEvents;
 
 namespace PlatformPlatform.AccountManagement.Users.Commands;
 
 [PublicAPI]
-public sealed record RemoveAvatarCommand(UserId Id) : ICommand, IRequest<Result>;
+public sealed record RemoveAvatarCommand : ICommand, IRequest<Result>;
 
 public sealed class RemoveAvatarCommandHandler(IUserRepository userRepository, ITelemetryEventsCollector events)
     : IRequestHandler<RemoveAvatarCommand, Result>
 {
     public async Task<Result> Handle(RemoveAvatarCommand command, CancellationToken cancellationToken)
     {
-        var user = await userRepository.GetByIdAsync(command.Id, cancellationToken);
-        if (user is null) return Result.NotFound($"User with id '{command.Id}' not found.");
+        var user = await userRepository.GetLoggedInUserAsync(cancellationToken);
+        if (user is null) return Result.BadRequest("User not found.");
 
         user.RemoveAvatar();
         userRepository.Update(user);

--- a/application/account-management/Core/Users/Commands/UpdateAvatar.cs
+++ b/application/account-management/Core/Users/Commands/UpdateAvatar.cs
@@ -5,14 +5,13 @@ using Microsoft.Extensions.DependencyInjection;
 using PlatformPlatform.AccountManagement.TelemetryEvents;
 using PlatformPlatform.AccountManagement.Users.Domain;
 using PlatformPlatform.SharedKernel.Cqrs;
-using PlatformPlatform.SharedKernel.Domain;
 using PlatformPlatform.SharedKernel.Services;
 using PlatformPlatform.SharedKernel.TelemetryEvents;
 
 namespace PlatformPlatform.AccountManagement.Users.Commands;
 
 [PublicAPI]
-public sealed record UpdateAvatarCommand(UserId Id, Stream FileSteam, string ContentType) : ICommand, IRequest<Result>;
+public sealed record UpdateAvatarCommand(Stream FileSteam, string ContentType) : ICommand, IRequest<Result>;
 
 public sealed class UpdateAvatarValidator : AbstractValidator<UpdateAvatarCommand>
 {
@@ -38,8 +37,8 @@ public sealed class UpdateAvatarHandler(
 
     public async Task<Result> Handle(UpdateAvatarCommand command, CancellationToken cancellationToken)
     {
-        var user = await userRepository.GetByIdAsync(command.Id, cancellationToken);
-        if (user is null) return Result.NotFound($"User with id '{command.Id}' not found.");
+        var user = await userRepository.GetLoggedInUserAsync(cancellationToken);
+        if (user is null) return Result.BadRequest("User not found.");
 
         var fileHash = await GetFileHash(command.FileSteam, cancellationToken);
         var blobName = $"{user.TenantId}/{user.Id}/{fileHash}.jpg";

--- a/application/account-management/Core/Users/Domain/User.cs
+++ b/application/account-management/Core/Users/Domain/User.cs
@@ -2,7 +2,7 @@ using PlatformPlatform.SharedKernel.Domain;
 
 namespace PlatformPlatform.AccountManagement.Users.Domain;
 
-public sealed class User : AggregateRoot<UserId>
+public sealed class User : AggregateRoot<UserId>, ITenantScopedEntity
 {
     private string _email = string.Empty;
 
@@ -14,8 +14,6 @@ public sealed class User : AggregateRoot<UserId>
         Role = role;
         EmailConfirmed = emailConfirmed;
     }
-
-    public TenantId TenantId { get; }
 
     public string Email
     {
@@ -34,6 +32,8 @@ public sealed class User : AggregateRoot<UserId>
     public bool EmailConfirmed { get; private set; }
 
     public Avatar Avatar { get; private set; } = default!;
+
+    public TenantId TenantId { get; }
 
     public static User Create(TenantId tenantId, string email, UserRole role, bool emailConfirmed, string? gravatarUrl)
     {

--- a/application/account-management/Tests/BaseTest.cs
+++ b/application/account-management/Tests/BaseTest.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using PlatformPlatform.AccountManagement.Authentication.Services;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.Services;
 using PlatformPlatform.SharedKernel.TelemetryEvents;
 using PlatformPlatform.SharedKernel.Tests.TelemetryEvents;
@@ -50,8 +51,13 @@ public abstract class BaseTest<TContext> : IDisposable where TContext : DbContex
         var telemetryChannel = Substitute.For<ITelemetryChannel>();
         Services.AddSingleton(new TelemetryClient(new TelemetryConfiguration { TelemetryChannel = telemetryChannel }));
 
+        Services.AddScoped<IExecutionContext, HttpExecutionContext>();
+
+        // Build the ServiceProvider
+        _provider = Services.BuildServiceProvider();
+
         // Make sure the database is created
-        using var serviceScope = Services.BuildServiceProvider().CreateScope();
+        using var serviceScope = Provider.CreateScope();
         serviceScope.ServiceProvider.GetRequiredService<TContext>().Database.EnsureCreated();
         DatabaseSeeder = serviceScope.ServiceProvider.GetRequiredService<DatabaseSeeder>();
 

--- a/application/account-management/Tests/DatabaseSeeder.cs
+++ b/application/account-management/Tests/DatabaseSeeder.cs
@@ -1,4 +1,3 @@
-using Bogus;
 using PlatformPlatform.AccountManagement.Database;
 using PlatformPlatform.AccountManagement.Tenants.Domain;
 using PlatformPlatform.AccountManagement.Users.Domain;
@@ -8,32 +7,15 @@ namespace PlatformPlatform.AccountManagement.Tests;
 
 public sealed class DatabaseSeeder
 {
-    private readonly Faker _faker = new();
     public readonly Tenant Tenant1;
-    public readonly Tenant TenantForSearching;
     public readonly User User1;
-    public readonly User User1ForSearching;
-    public readonly User User2ForSearching;
 
     public DatabaseSeeder(AccountManagementDbContext accountManagementDbContext)
     {
-        Tenant1 = Tenant.Create(new TenantId(_faker.Subdomain()), _faker.Internet.Email());
+        Tenant1 = Tenant.Create(new TenantId("tenant1"), "owner@tenant-1.com");
         accountManagementDbContext.Tenants.AddRange(Tenant1);
-
-        User1 = User.Create(Tenant1.Id, _faker.Internet.Email(), UserRole.Owner, true, null);
+        User1 = User.Create(Tenant1.Id, "owner@tenant-1.com", UserRole.Owner, true, null);
         accountManagementDbContext.Users.AddRange(User1);
-
-        TenantForSearching = Tenant.Create(new TenantId(_faker.Subdomain()), _faker.Internet.Email());
-        accountManagementDbContext.Tenants.AddRange(TenantForSearching);
-
-        User1ForSearching = User.Create(TenantForSearching.Id, "willgates@email.com", UserRole.Member, true, null);
-        User1ForSearching.Update("William Henry", "Gates", "Philanthropist & Innovator");
-
-        User2ForSearching = User.Create(TenantForSearching.Id, _faker.Internet.Email(), UserRole.Owner, true, null);
-
-        accountManagementDbContext.Users.AddRange(User1);
-        accountManagementDbContext.Users.AddRange(User1ForSearching);
-        accountManagementDbContext.Users.AddRange(User2ForSearching);
 
         accountManagementDbContext.SaveChanges();
     }

--- a/application/account-management/Tests/EndpointBaseTest.cs
+++ b/application/account-management/Tests/EndpointBaseTest.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.Services;
 using PlatformPlatform.SharedKernel.SinglePageApp;
 using PlatformPlatform.SharedKernel.TelemetryEvents;
@@ -34,6 +35,8 @@ public abstract class EndpointBaseTest<TContext> : BaseTest<TContext> where TCon
                         services.AddTransient<IEmailService>(_ => EmailService);
 
                         RegisterMockLoggers(services);
+
+                        services.AddScoped<IExecutionContext, HttpExecutionContext>();
                     }
                 );
             }

--- a/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
+++ b/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
@@ -512,23 +512,12 @@
         }
       }
     },
-    "/api/account-management/users/{id}/update-avatar": {
+    "/api/account-management/users/update-avatar": {
       "post": {
         "tags": [
           "Users"
         ],
         "operationId": "PostApiAccountManagementUsersUpdateAvatar",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/UserId"
-            },
-            "x-position": 1
-          }
-        ],
         "requestBody": {
           "content": {
             "multipart/form-data": {
@@ -552,23 +541,12 @@
         }
       }
     },
-    "/api/account-management/users/{id}/remove-avatar": {
-      "post": {
+    "/api/account-management/users/remove-avatar": {
+      "delete": {
         "tags": [
           "Users"
         ],
-        "operationId": "PostApiAccountManagementUsersRemoveAvatar",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/UserId"
-            },
-            "x-position": 1
-          }
-        ],
+        "operationId": "DeleteApiAccountManagementUsersRemoveAvatar",
         "responses": {
           "200": {
             "description": ""

--- a/application/account-management/Workers/Program.cs
+++ b/application/account-management/Workers/Program.cs
@@ -12,7 +12,9 @@ builder
     .AddAccountManagementInfrastructure();
 
 // Configure dependency injection services like Repositories, MediatR, Pipelines, FluentValidation validators, etc.
-builder.Services.AddAccountManagementServices();
+builder.Services
+    .AddApiServices()
+    .AddAccountManagementServices();
 
 builder.Services.AddTransient<DatabaseMigrationService<AccountManagementDbContext>>();
 

--- a/application/back-office/Api/BackOffice.Api.csproj
+++ b/application/back-office/Api/BackOffice.Api.csproj
@@ -17,14 +17,14 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Core\BackOffice.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.ApiDescription.Server">
             <IncludeAssets>runtime; build; native; contentFiles; analyzers; buildTransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\Core\BackOffice.csproj" />
     </ItemGroup>
 
 </Project>

--- a/application/back-office/Core/Database/BackOfficeDbContext.cs
+++ b/application/back-office/Core/Database/BackOfficeDbContext.cs
@@ -1,7 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using PlatformPlatform.SharedKernel.EntityFramework;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 
 namespace PlatformPlatform.BackOffice.Database;
 
-public sealed class BackOfficeDbContext(DbContextOptions<BackOfficeDbContext> options)
-    : SharedKernelDbContext<BackOfficeDbContext>(options);
+public sealed class BackOfficeDbContext(DbContextOptions<BackOfficeDbContext> options, IExecutionContext executionContext)
+    : SharedKernelDbContext<BackOfficeDbContext>(options, executionContext);

--- a/application/back-office/Tests/EndpointBaseTest.cs
+++ b/application/back-office/Tests/EndpointBaseTest.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.SinglePageApp;
 using PlatformPlatform.SharedKernel.TelemetryEvents;
 using PlatformPlatform.SharedKernel.Tests.TelemetryEvents;
@@ -24,11 +25,12 @@ public abstract class EndpointBaseTest<TContext> : BaseTest<TContext> where TCon
                         // Replace the default DbContext in the WebApplication to use an in-memory SQLite database
                         services.Remove(services.Single(d => d.ServiceType == typeof(DbContextOptions<TContext>)));
                         services.AddDbContext<TContext>(options => { options.UseSqlite(Connection); });
-
                         TelemetryEventsCollectorSpy = new TelemetryEventsCollectorSpy(new TelemetryEventsCollector());
                         services.AddScoped<ITelemetryEventsCollector>(_ => TelemetryEventsCollectorSpy);
 
                         RegisterMockLoggers(services);
+
+                        services.AddScoped<IExecutionContext, HttpExecutionContext>();
                     }
                 );
             }

--- a/application/back-office/Workers/Program.cs
+++ b/application/back-office/Workers/Program.cs
@@ -12,7 +12,9 @@ builder
     .AddBackOfficeInfrastructure();
 
 // Configure dependency injection services like Repositories, MediatR, Pipelines, FluentValidation validators, etc.
-builder.Services.AddBackOfficeServices();
+builder.Services
+    .AddApiServices()
+    .AddBackOfficeServices();
 
 builder.Services.AddTransient<DatabaseMigrationService<BackOfficeDbContext>>();
 

--- a/application/shared-kernel/SharedKernel/ApiDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/ApiDependencyConfiguration.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NJsonSchema.Generation;
 using PlatformPlatform.SharedKernel.Endpoints;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.Middleware;
 using PlatformPlatform.SharedKernel.SchemaProcessor;
 using PlatformPlatform.SharedKernel.SinglePageApp;
@@ -52,6 +53,7 @@ public static class ApiDependencyConfiguration
     public static IServiceCollection AddApiServices(this IServiceCollection services, Assembly apiAssembly, Assembly coreAssembly)
     {
         services
+            .AddApiExecutionContext()
             .AddExceptionHandler<TimeoutExceptionHandler>()
             .AddExceptionHandler<GlobalExceptionHandler>()
             .AddTransient<ModelBindingExceptionHandlerMiddleware>()
@@ -61,6 +63,14 @@ public static class ApiDependencyConfiguration
             .AddOpenApiConfiguration(coreAssembly)
             .AddAuthConfiguration()
             .AddHttpForwardHeaders();
+
+        return services;
+    }
+
+    private static IServiceCollection AddApiExecutionContext(this IServiceCollection services)
+    {
+        // Add the execution context service that will be used to make current user information available to the application
+        services.AddScoped<IExecutionContext, HttpExecutionContext>();
 
         return services;
     }

--- a/application/shared-kernel/SharedKernel/Authentication/UserInfo.cs
+++ b/application/shared-kernel/SharedKernel/Authentication/UserInfo.cs
@@ -2,52 +2,64 @@ using System.Security.Claims;
 
 namespace PlatformPlatform.SharedKernel.Authentication;
 
+/// <summary>
+///     Provides details about the authenticated user making the current request, including user identity, role,
+///     contact information, and additional profile details extracted from claims.
+/// </summary>
 public class UserInfo
 {
-    private UserInfo()
+    /// <summary>
+    ///     Represents the system user, typically used for background tasks or where no user is directly authenticated.
+    /// </summary>
+    public static readonly UserInfo System = new()
     {
-    }
+        IsAuthenticated = false,
+        Locale = "en-US"
+    };
 
     public bool IsAuthenticated { get; init; }
 
     public string? Locale { get; init; }
 
-    public string? UserId { get; private set; }
+    public string? UserId { get; init; }
 
-    public string? TenantId { get; private set; }
+    public string? TenantId { get; init; }
 
-    public string? UserRole { get; private set; }
+    public string? UserRole { get; init; }
 
-    public string? Email { get; private set; }
+    public string? Email { get; init; }
 
-    public string? FirstName { get; private set; }
+    public string? FirstName { get; init; }
 
-    public string? LastName { get; private set; }
+    public string? LastName { get; init; }
 
-    public string? Title { get; private set; }
+    public string? Title { get; init; }
 
-    public string? AvatarUrl { get; private set; }
+    public string? AvatarUrl { get; init; }
 
-    public static UserInfo Create(ClaimsPrincipal user, string defaultLocale)
+    public static UserInfo Create(ClaimsPrincipal? user, string defaultLocale)
     {
-        var userInfo = new UserInfo
+        if (user?.Identity?.IsAuthenticated != true)
         {
-            IsAuthenticated = user.Identity?.IsAuthenticated ?? false,
-            Locale = defaultLocale
-        };
-
-        if (userInfo.IsAuthenticated)
-        {
-            userInfo.UserId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-            userInfo.TenantId = user.FindFirst("tenant_id")?.Value;
-            userInfo.UserRole = user.FindFirst(ClaimTypes.Role)?.Value;
-            userInfo.Email = user.FindFirst(ClaimTypes.Email)?.Value;
-            userInfo.FirstName = user.FindFirst(ClaimTypes.GivenName)?.Value;
-            userInfo.LastName = user.FindFirst(ClaimTypes.Surname)?.Value;
-            userInfo.Title = user.FindFirst("title")?.Value;
-            userInfo.AvatarUrl = user.FindFirst("avatar_url")?.Value;
+            return new UserInfo
+            {
+                IsAuthenticated = user?.Identity?.IsAuthenticated ?? false,
+                Locale = defaultLocale
+            };
         }
 
-        return userInfo;
+        return new UserInfo
+        {
+            IsAuthenticated = true,
+            Locale = defaultLocale,
+            UserId = user.FindFirstValue(ClaimTypes.NameIdentifier),
+            TenantId = user.FindFirstValue("tenant_id"),
+            UserRole = user.FindFirstValue(ClaimTypes.Role),
+            Email = user.FindFirstValue(ClaimTypes.Email),
+            FirstName = user.FindFirstValue(ClaimTypes.GivenName),
+            LastName = user.FindFirstValue(ClaimTypes.Surname),
+            Title = user.FindFirstValue("title"),
+            AvatarUrl = user.FindFirstValue("avatar_url")
+        };
     }
 }

--- a/application/shared-kernel/SharedKernel/Domain/ITenantScopedEntity.cs
+++ b/application/shared-kernel/SharedKernel/Domain/ITenantScopedEntity.cs
@@ -1,0 +1,6 @@
+namespace PlatformPlatform.SharedKernel.Domain;
+
+public interface ITenantScopedEntity
+{
+    TenantId TenantId { get; }
+}

--- a/application/shared-kernel/SharedKernel/EntityFramework/SharedKernelDbContext.cs
+++ b/application/shared-kernel/SharedKernel/EntityFramework/SharedKernelDbContext.cs
@@ -1,5 +1,7 @@
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using PlatformPlatform.SharedKernel.Domain;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 
 namespace PlatformPlatform.SharedKernel.EntityFramework;
 
@@ -7,9 +9,11 @@ namespace PlatformPlatform.SharedKernel.EntityFramework;
 ///     The SharedKernelDbContext class represents the Entity Framework Core DbContext for managing data access to the
 ///     database, like creation, querying, and updating of <see cref="IAggregateRoot" /> entities.
 /// </summary>
-public abstract class SharedKernelDbContext<TContext>(DbContextOptions<TContext> options)
+public abstract class SharedKernelDbContext<TContext>(DbContextOptions<TContext> options, IExecutionContext executionContext)
     : DbContext(options) where TContext : DbContext
 {
+    protected TenantId? TenantId => executionContext.TenantId;
+
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
@@ -23,6 +27,30 @@ public abstract class SharedKernelDbContext<TContext>(DbContextOptions<TContext>
         // Ensures that all enum properties are stored as strings in the database.
         modelBuilder.UseStringForEnums();
 
+        ApplyGlobalTenantFilters(modelBuilder);
+
         base.OnModelCreating(modelBuilder);
+    }
+
+    private void ApplyGlobalTenantFilters(ModelBuilder modelBuilder)
+    {
+        var tenantScopedEntityTypes = modelBuilder.Model.GetEntityTypes()
+            .Where(t => typeof(ITenantScopedEntity).IsAssignableFrom(t.ClrType));
+
+        foreach (var entityType in tenantScopedEntityTypes)
+        {
+            var parameter = Expression.Parameter(entityType.ClrType, "e");
+            var tenantIdProperty = Expression.Property(parameter, nameof(ITenantScopedEntity.TenantId));
+            var tenantIdValue = Expression.Property(Expression.Constant(this), nameof(TenantId));
+
+            var tenantIdNotNull = Expression.NotEqual(tenantIdValue, Expression.Constant(null, typeof(TenantId)));
+            var tenantIdEqual = Expression.Equal(tenantIdProperty, tenantIdValue);
+
+            var body = Expression.AndAlso(tenantIdNotNull, tenantIdEqual);
+
+            var lambda = Expression.Lambda(body, parameter);
+
+            modelBuilder.Entity(entityType.ClrType).HasQueryFilter(lambda);
+        }
     }
 }

--- a/application/shared-kernel/SharedKernel/ExecutionContext/BackgroundWorkerExecutionContext.cs
+++ b/application/shared-kernel/SharedKernel/ExecutionContext/BackgroundWorkerExecutionContext.cs
@@ -1,0 +1,12 @@
+using PlatformPlatform.SharedKernel.Authentication;
+using PlatformPlatform.SharedKernel.Domain;
+
+namespace PlatformPlatform.SharedKernel.ExecutionContext;
+
+public class BackgroundWorkerExecutionContext(TenantId? tenantId = null, UserInfo? userInfo = null)
+    : IExecutionContext
+{
+    public TenantId? TenantId { get; } = tenantId;
+
+    public UserInfo UserInfo { get; } = userInfo ?? UserInfo.System;
+}

--- a/application/shared-kernel/SharedKernel/ExecutionContext/HttpExecutionContext.cs
+++ b/application/shared-kernel/SharedKernel/ExecutionContext/HttpExecutionContext.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using PlatformPlatform.SharedKernel.Authentication;
+using PlatformPlatform.SharedKernel.Domain;
+
+namespace PlatformPlatform.SharedKernel.ExecutionContext;
+
+public class HttpExecutionContext(IHttpContextAccessor httpContextAccessor) : IExecutionContext
+{
+    private TenantId? _tenantId;
+    private UserInfo? _userInfo;
+
+    public TenantId? TenantId
+    {
+        get
+        {
+            // The first time this property is accessed, _userInfo might be null, but when TenantId.TryParse() is called,
+            // it will be set. So even if _tenantId is null, we know if this property has been accessed before.
+            if (_userInfo is not null)
+            {
+                return _tenantId;
+            }
+
+            TenantId.TryParse(UserInfo.TenantId, out _tenantId);
+            return _tenantId;
+        }
+    }
+
+    public UserInfo UserInfo
+    {
+        get
+        {
+            if (_userInfo is not null)
+            {
+                return _userInfo;
+            }
+
+            var defaultLocale = httpContextAccessor.HttpContext?.Features.Get<IRequestCultureFeature>()?.RequestCulture.Culture.Name;
+
+            return _userInfo = UserInfo.Create(httpContextAccessor.HttpContext?.User, defaultLocale ?? "en-US");
+        }
+    }
+}

--- a/application/shared-kernel/SharedKernel/ExecutionContext/IExecutionContext.cs
+++ b/application/shared-kernel/SharedKernel/ExecutionContext/IExecutionContext.cs
@@ -1,0 +1,23 @@
+using PlatformPlatform.SharedKernel.Authentication;
+using PlatformPlatform.SharedKernel.Domain;
+
+namespace PlatformPlatform.SharedKernel.ExecutionContext;
+
+/// <summary>
+///     Represents the execution context of the current operation, providing information
+///     about the tenant and the authenticated user making the request.
+/// </summary>
+public interface IExecutionContext
+{
+    /// <summary>
+    ///     Gets the current tenant identifier. May be null if the operation is not tenant-scoped.
+    /// </summary>
+    TenantId? TenantId { get; }
+
+    /// <summary>
+    ///     Gets information about the current user making the request, including authentication status,
+    ///     user ID, and other identity-related details.
+    ///     If the user is not authenticated, it will be set to <see cref="Authentication.UserInfo.System" />.
+    /// </summary>
+    UserInfo UserInfo { get; }
+}

--- a/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppFallbackExtensions.cs
+++ b/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppFallbackExtensions.cs
@@ -3,12 +3,12 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Primitives;
 using PlatformPlatform.SharedKernel.Authentication;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 
 namespace PlatformPlatform.SharedKernel.SinglePageApp;
 
@@ -35,7 +35,7 @@ public static class SinglePageAppFallbackExtensions
             }
         );
 
-        app.MapFallback((HttpContext context, SinglePageAppConfiguration singlePageAppConfiguration) =>
+        app.MapFallback((HttpContext context, IExecutionContext executionContext, SinglePageAppConfiguration singlePageAppConfiguration) =>
             {
                 if (context.Request.Path.Value?.Contains("/api/", StringComparison.OrdinalIgnoreCase) == true ||
                     context.Request.Path.Value?.Contains("/internal-api/", StringComparison.OrdinalIgnoreCase) == true)
@@ -47,9 +47,7 @@ public static class SinglePageAppFallbackExtensions
 
                 SetResponseHttpHeaders(singlePageAppConfiguration, context.Response.Headers, "text/html; charset=utf-8");
 
-                var defaultLocale = context.Features.Get<IRequestCultureFeature>()?.RequestCulture.Culture.Name ?? "en-US";
-                var userInfo = UserInfo.Create(context.User, defaultLocale);
-                var html = GetHtmlWithEnvironment(singlePageAppConfiguration, userInfo);
+                var html = GetHtmlWithEnvironment(singlePageAppConfiguration, executionContext.UserInfo);
                 return context.Response.WriteAsync(html);
             }
         );

--- a/application/shared-kernel/SharedKernel/WorkerDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/WorkerDependencyConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+using PlatformPlatform.SharedKernel.ExecutionContext;
+
+namespace PlatformPlatform.SharedKernel;
+
+public static class WorkerDependencyConfiguration
+{
+    public static IServiceCollection AddApiServices(this IServiceCollection services)
+    {
+        services.AddWorkerExecutionContext();
+
+        return services;
+    }
+
+    private static IServiceCollection AddWorkerExecutionContext(this IServiceCollection services)
+    {
+        // Add the execution context service that will be used to make current user information available to the application
+        services.AddScoped<IExecutionContext, BackgroundWorkerExecutionContext>();
+
+        return services;
+    }
+}

--- a/application/shared-kernel/Tests/EntityFramework/SaveChangesInterceptorTests.cs
+++ b/application/shared-kernel/Tests/EntityFramework/SaveChangesInterceptorTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.Tests.TestEntities;
 using Xunit;
 
@@ -11,7 +12,8 @@ public sealed class SaveChangesInterceptorTests : IDisposable
 
     public SaveChangesInterceptorTests()
     {
-        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>();
+        var executionContext = new BackgroundWorkerExecutionContext();
+        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext);
         _testDbContext = _sqliteInMemoryDbContextFactory.CreateContext();
     }
 

--- a/application/shared-kernel/Tests/Persistence/RepositoryTests.cs
+++ b/application/shared-kernel/Tests/Persistence/RepositoryTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.IdGenerators;
 using PlatformPlatform.SharedKernel.Tests.TestEntities;
 using Xunit;
@@ -14,7 +15,8 @@ public sealed class RepositoryTests : IDisposable
 
     public RepositoryTests()
     {
-        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>();
+        var executionContext = new BackgroundWorkerExecutionContext();
+        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext);
         _testDbContext = _sqliteInMemoryDbContextFactory.CreateContext();
         _testAggregateRepository = new TestAggregateRepository(_testDbContext);
     }

--- a/application/shared-kernel/Tests/Persistence/UnitOfWorkTests.cs
+++ b/application/shared-kernel/Tests/Persistence/UnitOfWorkTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.Persistence;
 using PlatformPlatform.SharedKernel.Tests.TestEntities;
 using Xunit;
@@ -14,7 +15,8 @@ public sealed class UnitOfWorkTests : IDisposable
 
     public UnitOfWorkTests()
     {
-        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>();
+        var executionContext = new BackgroundWorkerExecutionContext();
+        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext);
         _testDbContext = _sqliteInMemoryDbContextFactory.CreateContext();
         _unitOfWork = new UnitOfWork(_testDbContext);
     }

--- a/application/shared-kernel/Tests/TestEntities/SqliteInMemoryDbContextFactory.cs
+++ b/application/shared-kernel/Tests/TestEntities/SqliteInMemoryDbContextFactory.cs
@@ -1,14 +1,17 @@
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 
 namespace PlatformPlatform.SharedKernel.Tests.TestEntities;
 
 public sealed class SqliteInMemoryDbContextFactory<T> : IDisposable where T : DbContext
 {
+    private readonly IExecutionContext _executionContext;
     private readonly SqliteConnection _sqliteConnection;
 
-    public SqliteInMemoryDbContextFactory()
+    public SqliteInMemoryDbContextFactory(IExecutionContext executionContext)
     {
+        _executionContext = executionContext;
         _sqliteConnection = new SqliteConnection("DataSource=:memory:");
         _sqliteConnection.Open();
     }
@@ -22,7 +25,7 @@ public sealed class SqliteInMemoryDbContextFactory<T> : IDisposable where T : Db
     {
         var options = CreateOptions();
 
-        var context = (T)Activator.CreateInstance(typeof(T), options)!;
+        var context = (T)Activator.CreateInstance(typeof(T), options, _executionContext)!;
         context.Database.EnsureCreated();
 
         return context;

--- a/application/shared-kernel/Tests/TestEntities/TestDbContext.cs
+++ b/application/shared-kernel/Tests/TestEntities/TestDbContext.cs
@@ -1,10 +1,11 @@
 using Microsoft.EntityFrameworkCore;
 using PlatformPlatform.SharedKernel.EntityFramework;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 
 namespace PlatformPlatform.SharedKernel.Tests.TestEntities;
 
-public sealed class TestDbContext(DbContextOptions<TestDbContext> options)
-    : SharedKernelDbContext<TestDbContext>(options)
+public sealed class TestDbContext(DbContextOptions<TestDbContext> options, IExecutionContext executionContext)
+    : SharedKernelDbContext<TestDbContext>(options, executionContext)
 {
     public DbSet<TestAggregate> TestAggregates => Set<TestAggregate>();
 


### PR DESCRIPTION
### Summary & Motivation

Introduce tenant isolation for Domain-Driven Design (DDD) Aggregates by adding a new `ITenantScopedEntity` interface. This ensures that only users logged into a tenant can fetch aggregates that belong to that specific tenant.

The implementation leverages Entity Framework query filters, automatically scoping all queries and commands to the current tenant. A new `IExecutionContext` concept has been introduced, with `HttpExecutionContext` for APIs and `BackgroundWorkerExecutionContext` for workers. The execution context carries the `TenantId` and `UserInfo` from the Access Token JWT, ensuring tenant-specific data handling throughout the system.

This tenant-scoping mechanism is now a dependency of the `SharedKernel DBContext`, used by all self-contained systems, ensuring all database communication is scoped to the current tenant in the execution context.

Certain user-related operations, like fetching a user by email when a user logs in, require bypassing the global tenant filter. To handle this, `UserRepository.GetUserByEmailAsync()` and other methods like `.IsEmailFreeAsync()` have been updated to use `.IgnoreQueryFilters()`. A new `.GetByIdGlobalAsync()` method has also been added for globally-scoped user lookups.

Significant updates have been made to the test suite to accommodate these changes. The `DataBaseSeeder` has been simplified to create only one tenant and user for authenticated endpoint testing. Seed data for other tests is now injected directly into the tests using `SqliteConnectionExtensions`.

Additionally, the `UseSinglePageAppFallback` has been updated to use the `ExecutionContext` for injecting environment data into index.html.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
