### PR TITLE
Fix tenant id issue in access token refresh and rename unfiltered repository methods

### DIFF
--- a/application/account-management/Core/Authentication/Commands/CompleteLogin.cs
+++ b/application/account-management/Core/Authentication/Commands/CompleteLogin.cs
@@ -63,7 +63,7 @@ public sealed class CompleteLoginHandler(
             return Result.BadRequest("The code is no longer valid, please request a new code.", true);
         }
 
-        var user = (await userRepository.GetByIdGlobalAsync(login.UserId, cancellationToken))!;
+        var user = (await userRepository.GetByIdUnfilteredAsync(login.UserId, cancellationToken))!;
 
         login.MarkAsCompleted();
         loginRepository.Update(login);

--- a/application/account-management/Core/Authentication/Commands/StartLogin.cs
+++ b/application/account-management/Core/Authentication/Commands/StartLogin.cs
@@ -36,7 +36,7 @@ public sealed class StartLoginCommandHandler(
 {
     public async Task<Result<StartLoginResponse>> Handle(StartLoginCommand command, CancellationToken cancellationToken)
     {
-        var user = await userRepository.GetUserByEmailAsync(command.Email, cancellationToken);
+        var user = await userRepository.GetUserByEmailUnfilteredAsync(command.Email, cancellationToken);
 
         if (user is null)
         {

--- a/application/account-management/Core/Authentication/Services/AuthenticationTokenGenerator.cs
+++ b/application/account-management/Core/Authentication/Services/AuthenticationTokenGenerator.cs
@@ -3,29 +3,29 @@ using System.Security.Claims;
 using Microsoft.IdentityModel.Tokens;
 using PlatformPlatform.AccountManagement.Users.Domain;
 using PlatformPlatform.SharedKernel.Authentication;
-using PlatformPlatform.SharedKernel.Domain;
 
 namespace PlatformPlatform.AccountManagement.Authentication.Services;
 
 public sealed class AuthenticationTokenGenerator(ITokenSigningService tokenSigningService)
 {
-    public string GenerateRefreshToken(UserId userId)
+    public string GenerateRefreshToken(User user)
     {
-        return GenerateRefreshToken(userId, Guid.NewGuid().ToString(), 1, TimeProvider.System.GetUtcNow().AddMonths(3));
+        return GenerateRefreshToken(user, Guid.NewGuid().ToString(), 1, TimeProvider.System.GetUtcNow().AddMonths(3));
     }
 
-    public string UpdateRefreshToken(UserId userId, string refreshTokenChainId, int currentRefreshTokenVersion, DateTimeOffset expires)
+    public string UpdateRefreshToken(User user, string refreshTokenChainId, int currentRefreshTokenVersion, DateTimeOffset expires)
     {
-        return GenerateRefreshToken(userId, refreshTokenChainId, currentRefreshTokenVersion + 1, expires);
+        return GenerateRefreshToken(user, refreshTokenChainId, currentRefreshTokenVersion + 1, expires);
     }
 
-    private string GenerateRefreshToken(UserId userId, string refreshTokenChainId, int refreshTokenVersion, DateTimeOffset expires)
+    private string GenerateRefreshToken(User user, string refreshTokenChainId, int refreshTokenVersion, DateTimeOffset expires)
     {
         var tokenDescriptor = new SecurityTokenDescriptor
         {
             Subject = new ClaimsIdentity([
                     new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
-                    new Claim(JwtRegisteredClaimNames.Sub, userId),
+                    new Claim(JwtRegisteredClaimNames.Sub, user.Id),
+                    new Claim("tenant_id", user.TenantId),
                     new Claim("rtid", refreshTokenChainId),
                     new Claim("rtv", refreshTokenVersion.ToString())
                 ]

--- a/application/account-management/Core/Authentication/Services/AuthenticationTokenService.cs
+++ b/application/account-management/Core/Authentication/Services/AuthenticationTokenService.cs
@@ -8,14 +8,14 @@ public sealed class AuthenticationTokenService(AuthenticationTokenGenerator toke
 {
     public void CreateAndSetAuthenticationTokens(User user)
     {
-        var refreshToken = tokenGenerator.GenerateRefreshToken(user.Id);
+        var refreshToken = tokenGenerator.GenerateRefreshToken(user);
         var accessToken = tokenGenerator.GenerateAccessToken(user);
         SetAuthenticationTokensOnHttpResponse(refreshToken, accessToken);
     }
 
     public void RefreshAuthenticationTokens(User user, string refreshTokenChainId, int currentRefreshTokenVersion, DateTimeOffset expires)
     {
-        var refreshToken = tokenGenerator.UpdateRefreshToken(user.Id, refreshTokenChainId, currentRefreshTokenVersion, expires);
+        var refreshToken = tokenGenerator.UpdateRefreshToken(user, refreshTokenChainId, currentRefreshTokenVersion, expires);
         var accessToken = tokenGenerator.GenerateAccessToken(user);
         SetAuthenticationTokensOnHttpResponse(refreshToken, accessToken);
     }

--- a/application/account-management/Core/Users/Commands/CreateUser.cs
+++ b/application/account-management/Core/Users/Commands/CreateUser.cs
@@ -35,9 +35,7 @@ public sealed class CreateUserValidator : AbstractValidator<CreateUserCommand>
             .When(x => !string.IsNullOrEmpty(x.Email));
 
         RuleFor(x => x)
-            .MustAsync((x, cancellationToken)
-                => userRepository.IsEmailFreeAsync(x.GetTenantId(), x.Email, cancellationToken)
-            )
+            .MustAsync((x, cancellationToken) => userRepository.IsEmailFreeAsync(x.Email, cancellationToken))
             .WithName("Email")
             .WithMessage(x => $"The email '{x.Email}' is already in use by another user on this tenant.")
             .When(x => !string.IsNullOrEmpty(x.Email));

--- a/application/account-management/Core/Users/Domain/UserRepository.cs
+++ b/application/account-management/Core/Users/Domain/UserRepository.cs
@@ -8,13 +8,13 @@ namespace PlatformPlatform.AccountManagement.Users.Domain;
 
 public interface IUserRepository : ICrudRepository<User, UserId>
 {
-    Task<User?> GetByIdGlobalAsync(UserId id, CancellationToken cancellationToken);
+    Task<User?> GetByIdUnfilteredAsync(UserId id, CancellationToken cancellationToken);
 
     Task<User?> GetLoggedInUserAsync(CancellationToken cancellationToken);
 
-    Task<User?> GetUserByEmailAsync(string email, CancellationToken cancellationToken);
+    Task<User?> GetUserByEmailUnfilteredAsync(string email, CancellationToken cancellationToken);
 
-    Task<bool> IsEmailFreeAsync(TenantId tenantId, string email, CancellationToken cancellationToken);
+    Task<bool> IsEmailFreeAsync(string email, CancellationToken cancellationToken);
 
     Task<int> CountTenantUsersAsync(TenantId tenantId, CancellationToken cancellationToken);
 
@@ -36,7 +36,7 @@ internal sealed class UserRepository(AccountManagementDbContext accountManagemen
     ///     Retrieves a user by ID without applying tenant query filters.
     ///     This method should only be used during authentication processes where tenant context is not yet established.
     /// </summary>
-    public async Task<User?> GetByIdGlobalAsync(UserId id, CancellationToken cancellationToken)
+    public async Task<User?> GetByIdUnfilteredAsync(UserId id, CancellationToken cancellationToken)
     {
         return await DbSet
             .IgnoreQueryFilters()
@@ -57,18 +57,16 @@ internal sealed class UserRepository(AccountManagementDbContext accountManagemen
     ///     Retrieves a user by email without applying tenant query filters.
     ///     This method should only be used during the login processes where tenant context is not yet established.
     /// </summary>
-    public async Task<User?> GetUserByEmailAsync(string email, CancellationToken cancellationToken)
+    public async Task<User?> GetUserByEmailUnfilteredAsync(string email, CancellationToken cancellationToken)
     {
         return await DbSet
             .IgnoreQueryFilters()
             .FirstOrDefaultAsync(u => u.Email == email.ToLowerInvariant(), cancellationToken);
     }
 
-    public async Task<bool> IsEmailFreeAsync(TenantId tenantId, string email, CancellationToken cancellationToken)
+    public async Task<bool> IsEmailFreeAsync(string email, CancellationToken cancellationToken)
     {
-        return !await DbSet
-            .IgnoreQueryFilters()
-            .AnyAsync(u => u.TenantId == tenantId && u.Email == email.ToLowerInvariant(), cancellationToken);
+        return !await DbSet.AnyAsync(u => u.Email == email.ToLowerInvariant(), cancellationToken);
     }
 
     public Task<int> CountTenantUsersAsync(TenantId tenantId, CancellationToken cancellationToken)


### PR DESCRIPTION
### Summary & Motivation

Fix issue with refreshing tokens after introducing tenant-scoped query filters. The `IExecutionContext` was missing the `TenantId` during access token refresh because the RefreshToken JWT did not include the `TenantId`. By adding the `TenantId` to the RefreshToken, the refresh process now correctly assigns a valid `TenantId`, allowing `GetUserByIdAsync` to function as expected.

Additionally, all repository methods using `.IgnoreQueryFilters()` have been renamed to `XxxUnfilteredAsync()` for clarity, and documentation has been added to these methods.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
