### PR TITLE
Fix model binding issue when TenantId contains a hyphen

### DIFF
--- a/application/account-management/Core/Users/Commands/CreateUser.cs
+++ b/application/account-management/Core/Users/Commands/CreateUser.cs
@@ -14,7 +14,7 @@ using PlatformPlatform.SharedKernel.Validation;
 namespace PlatformPlatform.AccountManagement.Users.Commands;
 
 [PublicAPI]
-public sealed record CreateUserCommand(string TenantId, string Email, UserRole UserRole, bool EmailConfirmed)
+public sealed record CreateUserCommand(TenantId TenantId, string Email, UserRole UserRole, bool EmailConfirmed)
     : ICommand, IRequest<Result<UserId>>
 {
     public TenantId GetTenantId()

--- a/application/account-management/Tests/DatabaseSeeder.cs
+++ b/application/account-management/Tests/DatabaseSeeder.cs
@@ -12,7 +12,7 @@ public sealed class DatabaseSeeder
 
     public DatabaseSeeder(AccountManagementDbContext accountManagementDbContext)
     {
-        Tenant1 = Tenant.Create(new TenantId("tenant1"), "owner@tenant-1.com");
+        Tenant1 = Tenant.Create(new TenantId("tenant-1"), "owner@tenant-1.com");
         accountManagementDbContext.Tenants.AddRange(Tenant1);
         User1 = User.Create(Tenant1.Id, "owner@tenant-1.com", UserRole.Owner, true, null);
         accountManagementDbContext.Users.AddRange(User1);

--- a/application/account-management/Tests/Signups/StartSignupTests.cs
+++ b/application/account-management/Tests/Signups/StartSignupTests.cs
@@ -58,6 +58,8 @@ public sealed class StartSignupTests : EndpointBaseTest<AccountManagementDbConte
     [InlineData("Subdomain with uppercase", "Tenant2")]
     [InlineData("Subdomain special characters", "tenant%2")]
     [InlineData("Subdomain with spaces", "tenant 2")]
+    [InlineData("Subdomain ends with hyphen", "tenant-")]
+    [InlineData("Subdomain starts with hyphen", "-tenant")]
     public async Task StartSignupCommand_WhenSubdomainInvalid_ShouldFail(string scenario, string subdomain)
     {
         // Arrange

--- a/application/account-management/Tests/Tenants/GetTenantTests.cs
+++ b/application/account-management/Tests/Tenants/GetTenantTests.cs
@@ -26,7 +26,7 @@ public sealed class GetTenantTests : EndpointBaseTest<AccountManagementDbContext
             {
                 'type': 'object',
                 'properties': {
-                    'id': {'type': 'string', 'pattern': '^[a-z0-9]{3,30}$'},
+                    'id': {'type': 'string', 'pattern': '^(?=.{3,30}$)(?!-)[a-z0-9-]*(?<!-)$'},
                     'createdAt': {'type': 'string', 'format': 'date-time'},
                     'modifiedAt': {'type': ['null', 'string'], 'format': 'date-time'},
                     'name': {'type': 'string', 'minLength': 1, 'maxLength': 30},

--- a/application/account-management/Tests/Users/CreateUserTests.cs
+++ b/application/account-management/Tests/Users/CreateUserTests.cs
@@ -70,7 +70,7 @@ public sealed class CreateUserTests : EndpointBaseTest<AccountManagementDbContex
     public async Task CreateUser_WhenTenantDoesNotExists_ShouldReturnBadRequest()
     {
         // Arrange
-        var unknownTenantId = Faker.Subdomain();
+        var unknownTenantId = new TenantId(Faker.Subdomain());
         var command = new CreateUserCommand(unknownTenantId, Faker.Internet.Email(), UserRole.Member, false);
 
         // Act

--- a/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
+++ b/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
@@ -918,7 +918,7 @@
         "additionalProperties": false,
         "properties": {
           "tenantId": {
-            "type": "string"
+            "$ref": "#/components/schemas/TenantId"
           },
           "email": {
             "type": "string"

--- a/application/shared-kernel/SharedKernel/Domain/TenantId.cs
+++ b/application/shared-kernel/SharedKernel/Domain/TenantId.cs
@@ -20,7 +20,7 @@ public sealed record TenantId(string Value) : StronglyTypedId<string, TenantId>(
             return false;
         }
 
-        if (!value.All(c => char.IsLower(c) || char.IsDigit(c) || char.IsDigit('-')))
+        if (!value.All(c => char.IsLower(c) || char.IsDigit(c) || c == '-'))
         {
             result = null;
             return false;


### PR DESCRIPTION
### Summary & Motivation

Fixes a bug where TenantId containing a hyphen caused model binding to fail. Updates tests to use `tenant-1` as seed data and add coverage for hyphenated TenantId. Changes `CreateUserCommand.TenantId` from a string to a `TenantId` type for consistency.


### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
