### PR TITLE
Do a reverse translation to confirm the accuracy of translated text

### DIFF
--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -15,11 +15,11 @@ msgstr ""
 
 #. js-lingui-explicit-id
 msgid "Email"
-msgstr "Email"
+msgstr "E-mail"
 
 #. js-lingui-explicit-id
 msgid "yourname@example.com"
-msgstr "ditnavn@example.com"
+msgstr "ditnavn@eksempel.com"
 
 #. js-lingui-explicit-id
 msgid "Subdomain"
@@ -35,15 +35,15 @@ msgstr "Region"
 
 #. js-lingui-explicit-id
 msgid "This is the region where your data is stored"
-msgstr ""
+msgstr "Dette er den region, hvor dine data er gemt"
 
 #. js-lingui-explicit-id
 msgid "Screenshots of the dashboard project showing mobile versions"
-msgstr "Skærmbilleder af dashboard-projektet, der viser mobile versioner"
+msgstr "Skærmbilleder af dashboardprojektet, der viser mobilversioner"
 
 #. js-lingui-explicit-id
 msgid "Screenshots of the dashboard project showing desktop and mobile versions"
-msgstr "Skærmbilleder af dashboard-projektet, der viser desktop- og mobile versioner"
+msgstr "Skærmbilleder af dashboardprojektet, der viser desktop- og mobilversioner"
 
 msgid "Active Users"
 msgstr "Aktive brugere"
@@ -52,31 +52,31 @@ msgid "Active users the past 30 days"
 msgstr "Aktive brugere de seneste 30 dage"
 
 msgid "Add more in the Users menu"
-msgstr "Tilføj flere i Bruger-menuen"
+msgstr "Tilføj flere i brugermenuen"
 
 msgid "Already have an account?"
 msgstr "Har du allerede en konto?"
 
 msgid "Can't find your code? Check your spam folder"
-msgstr "Kan du ikke finde din kode? Tjek din spam-mappe"
+msgstr "Kan du ikke finde din kode? Tjek din spammappe"
 
 msgid "Didn't receive the code? Resend"
-msgstr "Modtog ikke koden? Send igen"
+msgstr "Modtog du ikke koden? Send igen"
 
 msgid "Enter your verification code"
-msgstr "Indtast din verifikationskode"
+msgstr "Indtast din bekræftelseskode"
 
 msgid "Filters"
 msgstr "Filtre"
 
 msgid "Here’s your overview of what’s going on."
-msgstr "Her er en oversigt over, hvad der sker"
+msgstr "Her er dit overblik over, hvad der sker."
 
 msgid "Log in"
 msgstr "Log ind"
 
 msgid "Please check your email for a verification code sent to <0>{email}</0>"
-msgstr "Tjek venligst din e-mail for en verifikationskode sendt til <0>{email}</0>"
+msgstr "Tjek venligst din e-mail for en bekræftelseskode sendt til <0>{email}</0>"
 
 msgid "Total Users"
 msgstr "Totalt antal brugere"

--- a/developer-cli/Commands/DevCommand.cs
+++ b/developer-cli/Commands/DevCommand.cs
@@ -88,7 +88,7 @@ public class DevCommand : Command
                 Arguments = "ps",
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
-                CreateNoWindow = true,
+                CreateNoWindow = true
             };
 
             while (retriesLeft > 0)

--- a/developer-cli/Commands/TranslateCommand.cs
+++ b/developer-cli/Commands/TranslateCommand.cs
@@ -184,7 +184,7 @@ public class TranslateCommand : Command
                 }
             );
 
-            if (reverseTranslated.GetTranslation() == translated.Key.Id)
+            if (string.Equals(reverseTranslated.GetTranslation(), translated.Key.Id, StringComparison.OrdinalIgnoreCase))
             {
                 AnsiConsole.MarkupLine("[green]Reverse translation is matching.[/]");
                 return translated;

--- a/developer-cli/Commands/TranslateCommand.cs
+++ b/developer-cli/Commands/TranslateCommand.cs
@@ -211,6 +211,10 @@ public class TranslateCommand : Command
             return $"""
                     You are a translation service translating from {sourceLanguage} to {targetLanguage}.
                     Return only the translation, not the original text or any other information.
+                    If the original text contains punctuation or special characters, it is very important to replicate them. Do not try to correct bad grammar in the original text.
+
+                    E.g., if the original text is "enter **Your-Name* with no-more-than/#five%characters..!"
+                    Then a translation to, e.g., Danish should be "Indtast **Dit-Navn* med maksimalt/#fem%bogstaver..!"
                     """;
         }
     }

--- a/developer-cli/Commands/TranslateCommand.cs
+++ b/developer-cli/Commands/TranslateCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
+using System.Text;
 using Karambolo.PO;
 using OllamaSharp;
 using OllamaSharp.Models.Chat;
@@ -33,8 +34,9 @@ public class TranslateCommand : Command
 
     private async Task<int> Execute(string? language)
     {
-        Prerequisite.Ensure(Prerequisite.Dotnet,Prerequisite.Docker);
+        Prerequisite.Ensure(Prerequisite.Dotnet, Prerequisite.Docker);
 
+        // TODO: Use IDisposable
         var dockerServer = new DockerServer(DockerImageName, InstanceName, Port, "/root/.ollama");
         try
         {
@@ -57,7 +59,7 @@ public class TranslateCommand : Command
         }
     }
 
-    private string GetTranslationFile(string? language)
+    private static string GetTranslationFile(string? language)
     {
         var workingDirectory = new DirectoryInfo(Path.Combine(Configuration.GetSourceCodeFolder(), "..", "application"));
         var translationFiles = workingDirectory
@@ -85,7 +87,38 @@ public class TranslateCommand : Command
         return translationFiles[selection].FullName;
     }
 
-    private async Task RunTranslation(string translationFile)
+    private static async Task RunTranslation(string translationFile)
+    {
+        var ollamaApiClient = await GetTranslationClient();
+
+        var poCatalog = await ReadTranslationFile(translationFile);
+
+        AnsiConsole.MarkupLine($"Language detected: {poCatalog.Language}");
+
+        var translationEntries = poCatalog.Values
+            .Select(poEntry =>
+                {
+                    var translation = poCatalog.GetTranslation(poEntry.Key);
+                    TranslationEntry translationEntry = string.IsNullOrWhiteSpace(translation) ? new NonTranslatedEntry(poEntry.Key) : new TranslatedEntry(poEntry.Key, translation);
+
+                    return translationEntry;
+                }
+            )
+            .ToArray();
+
+        var translator = new Translator(new OllamaTranslationService(ollamaApiClient), poCatalog.Language);
+        var translated = await translator.Translate(translationEntries);
+        AnsiConsole.MarkupLine("[green]Translation completed.[/]");
+
+        foreach (var translatedEntry in translated)
+        {
+            UpdateCatalogTranslation(poCatalog, translatedEntry);
+        }
+
+        await WriteTranslationFile(translationFile, poCatalog);
+    }
+
+    private static async Task<OllamaApiClient> GetTranslationClient()
     {
         AnsiConsole.MarkupLine("[green]Connecting to Ollama API.[/]");
         var ollamaApiClient = new OllamaApiClient(
@@ -109,79 +142,10 @@ public class TranslateCommand : Command
                 }
             }
         );
-
-        var poParseResult = await ReadTranslationFile(translationFile);
-
-        var poCatalog = poParseResult.Catalog;
-        AnsiConsole.MarkupLine($"Language detected: {poCatalog.Language}");
-
-        await AnsiConsole.Status().StartAsync("Initialize translation...", async context =>
-            {
-                var missingTranslations = new List<POKey>();
-                var messages = new List<Message>
-                {
-                    new()
-                    {
-                        Role = "system",
-                        Content = $"""
-                                   You are a translation service translating from English to {poCatalog.Language}.
-                                   Return only the translation, not the original text or any other information.
-                                   """
-                    }
-                };
-
-                foreach (var key in poCatalog.Keys)
-                {
-                    var translation = poCatalog.GetTranslation(key);
-                    if (translation.Length == 0)
-                    {
-                        missingTranslations.Add(key);
-                    }
-                    else
-                    {
-                        messages.Add(new Message { Role = "user", Content = key.Id });
-                        messages.Add(new Message { Role = "assistant", Content = translation });
-                    }
-                }
-
-                AnsiConsole.MarkupLine($"Keys missing translation: {missingTranslations.Count}");
-                if (missingTranslations.Count == 0)
-                {
-                    AnsiConsole.MarkupLine("[green]Translation completed, nothing to translate.[/]");
-                    return;
-                }
-
-                for (var index = 0; index < missingTranslations.Count; index++)
-                {
-                    var key = missingTranslations[index];
-                    var content = "";
-
-                    AnsiConsole.MarkupLine($"[green]Translating {key.Id}[/]");
-                    context.Status($"Translating {index + 1}/{missingTranslations.Count} (thinking...)");
-
-                    messages.Add(new Message { Role = "user", Content = key.Id });
-
-                    messages = (await ollamaApiClient.SendChat(
-                        new ChatRequest { Model = ModelName, Messages = messages },
-                        status =>
-                        {
-                            content += status?.Message.Content ?? "";
-                            var percent = Math.Round(content.Length / (key.Id.Length * 1.2) * 100); // +20% is a guess
-                            context.Status($"Translating {index + 1}/{missingTranslations.Count} ({Math.Min(100, percent)}%)");
-                        }
-                    )).ToList();
-
-                    UpdateCatalogTranslation(poCatalog, key, messages.Last().Content!);
-                }
-
-                AnsiConsole.MarkupLine("[green]Translation completed.[/]");
-
-                await WriteTranslationFile(translationFile, poCatalog);
-            }
-        );
+        return ollamaApiClient;
     }
 
-    private static async Task<POParseResult> ReadTranslationFile(string translationFile)
+    private static async Task<POCatalog> ReadTranslationFile(string translationFile)
     {
         var translationContent = await File.ReadAllTextAsync(translationFile);
         var poParser = new POParser();
@@ -196,7 +160,7 @@ public class TranslateCommand : Command
             throw new InvalidOperationException($"Failed to parse PO file {translationFile}. Language not found.");
         }
 
-        return poParseResult;
+        return poParseResult.Catalog;
     }
 
     private static async Task WriteTranslationFile(string translationFile, POCatalog poCatalog)
@@ -211,19 +175,160 @@ public class TranslateCommand : Command
         AnsiConsole.MarkupLine("[yellow]WARNING: Please proofread to make sure the language is inclusive.[/]");
     }
 
-    private static void UpdateCatalogTranslation(POCatalog poCatalog, POKey key, string translation)
+    private static void UpdateCatalogTranslation(POCatalog poCatalog, TranslatedEntry translation)
     {
+        var key = translation.Key;
         var poEntry = poCatalog[key];
         if (poEntry is POSingularEntry)
         {
             AnsiConsole.MarkupLine($"Singular {key.Id}");
-            AnsiConsole.MarkupLine("Last message: " + translation);
+            AnsiConsole.MarkupLine("Last message: " + translation.Translation);
             poCatalog.Remove(key);
-            poCatalog.Add(new POSingularEntry(key) { Translation = translation });
+            poCatalog.Add(new POSingularEntry(key) { Translation = translation.Translation });
         }
         else
         {
             throw new InvalidOperationException($"Plural is currently not supported. Key: '{key.Id}'");
+        }
+    }
+
+    private record TranslatedEntry(POKey Key, string Translation) : TranslationEntry
+    {
+        public TranslatedEntry Reverse()
+        {
+            return new TranslatedEntry(new POKey(Translation, null, Key.ContextId), Key.Id);
+        }
+    }
+
+    private record NonTranslatedEntry(POKey Key) : TranslationEntry;
+
+    private record TranslationEntry;
+
+    private class Translator
+    {
+        private readonly string _englishToTargetLanguagePrompt;
+        private readonly string _targetLanguageToEnglishPrompt;
+        private readonly ITranslationService _translationService;
+
+        public Translator(ITranslationService translationService, string targetLanguage)
+        {
+            _translationService = translationService;
+            _englishToTargetLanguagePrompt = CreatePrompt("English", targetLanguage);
+            _targetLanguageToEnglishPrompt = CreatePrompt(targetLanguage, "English");
+        }
+
+        public async Task<IEnumerable<TranslatedEntry>> Translate(TranslationEntry[] translationEntries)
+        {
+            var translatedEntries = translationEntries.OfType<TranslatedEntry>().ToList();
+            var nonTranslatedEntries = translationEntries.OfType<NonTranslatedEntry>().ToArray();
+            AnsiConsole.MarkupLine($"Keys missing translation: {nonTranslatedEntries.Length}");
+            if (nonTranslatedEntries.Length == 0)
+            {
+                AnsiConsole.MarkupLine("[green]Translation completed, nothing to translate.[/]");
+            }
+
+            var toReturn = new List<TranslatedEntry>();
+            foreach (var nonTranslatedEntry in nonTranslatedEntries)
+            {
+                var translated = await TranslateSingleEntry(translatedEntries.AsReadOnly(), nonTranslatedEntry);
+                translatedEntries.Add(translated);
+                toReturn.Add(translated);
+            }
+
+            AnsiConsole.MarkupLine("[green]Translation completed.[/]");
+            return toReturn;
+        }
+
+        private async Task<TranslatedEntry> TranslateSingleEntry(IReadOnlyCollection<TranslatedEntry> translatedEntries, NonTranslatedEntry nonTranslatedEntry)
+        {
+            AnsiConsole.MarkupLine($"[green]Translating {nonTranslatedEntry.Key.Id}[/]");
+
+            TranslatedEntry translated = null!;
+            TranslatedEntry reverseTranslated = null!;
+            await AnsiConsole.Status().StartAsync("Initialize translation...", async context =>
+                {
+                    translated = await _translationService.Translate(_englishToTargetLanguagePrompt, translatedEntries, nonTranslatedEntry, context);
+
+                    // translate back into the original language and check if translation matches
+                    AnsiConsole.MarkupLine($"[yellow]Translated {nonTranslatedEntry.Key.Id} to {translated.Translation}. Checking translation..[/]");
+
+                    var reverseTranslations = translatedEntries.Select(x => x.Reverse()).ToArray();
+                    reverseTranslated = await _translationService.Translate(
+                        _targetLanguageToEnglishPrompt,
+                        reverseTranslations,
+                        new NonTranslatedEntry(new POKey(translated.Translation, translated.Key.PluralId, translated.Key.ContextId)),
+                        context
+                    );
+                }
+            );
+
+            if (reverseTranslated.Translation == translated.Key.Id)
+            {
+                AnsiConsole.MarkupLine("[yellow]Reverse translation is matching.[/]");
+                return translated;
+            }
+
+            AnsiConsole.MarkupLine("[yellow]Reverse translation is not matching. [/]");
+            if (AnsiConsole.Confirm($"Is translation {translated.Translation} acceptable?"))
+            {
+                AnsiConsole.MarkupLine("[yellow]Translation accepted.[/]");
+                return translated;
+            }
+
+            // TODO: Ask the user for input
+            throw new NotImplementedException();
+        }
+
+        private static string CreatePrompt(string sourceLanguage, string targetLanguage)
+        {
+            return $"""
+                    You are a translation service translating from {sourceLanguage} to {targetLanguage}.
+                    Return only the translation, not the original text or any other information.
+                    Only the last message should be translated. Use previous messages to understand the context.
+                    """;
+        }
+    }
+
+    private interface ITranslationService
+    {
+        public Task<TranslatedEntry> Translate(string systemPrompt, IEnumerable<TranslatedEntry> existingTranslations, NonTranslatedEntry nonTranslatedEntry, StatusContext context);
+    }
+
+    private class OllamaTranslationService(IOllamaApiClient ollamaApiClient)
+        : ITranslationService
+    {
+        public async Task<TranslatedEntry> Translate(string systemPrompt, IEnumerable<TranslatedEntry> existingTranslations, NonTranslatedEntry nonTranslatedEntry, StatusContext context)
+        {
+            var messages = new List<Message>
+            {
+                new()
+                {
+                    Role = ChatRole.System,
+                    Content = systemPrompt
+                }
+            };
+
+            foreach (var translation in existingTranslations)
+            {
+                messages.Add(new Message(ChatRole.User, translation.Key.Id));
+                messages.Add(new Message(ChatRole.Assistant, translation.Translation));
+            }
+
+            messages.Add(new Message { Role = ChatRole.User, Content = nonTranslatedEntry.Key.Id });
+            StringBuilder content = new();
+
+            var response = (await ollamaApiClient.SendChat(
+                new ChatRequest { Model = ModelName, Messages = messages },
+                status =>
+                {
+                    content.Append(status?.Message.Content ?? "");
+                    var percent = Math.Round(content.Length / (nonTranslatedEntry.Key.Id.Length * 1.2) * 100); // +20% is a guess
+                    context.Status($"Translating {Math.Min(100, percent)}%");
+                }
+            )).ToList();
+
+            var translated = response.Last();
+            return new TranslatedEntry(nonTranslatedEntry.Key, translated.Content!);
         }
     }
 }

--- a/developer-cli/Commands/TranslateCommand.cs
+++ b/developer-cli/Commands/TranslateCommand.cs
@@ -160,12 +160,11 @@ public class TranslateCommand : Command
             POSingularEntry nonTranslatedEntry
         )
         {
-            AnsiConsole.MarkupLine($"Translating: [cyan]{nonTranslatedEntry.Key.Id}[/]");
-
             var currentPrompt = _englishToTargetLanguagePrompt;
 
             while (true)
             {
+                AnsiConsole.MarkupLine($"Translating: [cyan]{nonTranslatedEntry.Key.Id}[/]");
                 POSingularEntry translated = null!;
                 POSingularEntry reverseTranslated = null!;
                 await AnsiConsole.Status().StartAsync("Initialize translation...", async context =>
@@ -199,7 +198,7 @@ public class TranslateCommand : Command
                 var choice = AnsiConsole.Prompt(
                     new SelectionPrompt<string>()
                         .Title("What would you like to do?")
-                        .AddChoices("Accept translation", "Provide context for retranslation", "Input own translation")
+                        .AddChoices("Accept translation", "Try again", "Provide context for retranslation", "Input own translation")
                 );
 
                 switch (choice)
@@ -207,6 +206,9 @@ public class TranslateCommand : Command
                     case "Accept translation":
                         AnsiConsole.MarkupLine("[green]Translation accepted.[/]");
                         return translated;
+                    case "Try again":
+                        AnsiConsole.MarkupLine("[green]Trying translation again...[/]");
+                        continue;
                     case "Provide context for retranslation":
                         var context = AnsiConsole.Ask<string>("Please provide context for the translation:");
                         currentPrompt = _englishToTargetLanguagePrompt + $"\nAdditional context for translation: {context}";
@@ -221,6 +223,9 @@ public class TranslateCommand : Command
                         }
 
                         return translated.ApplyTranslation(userTranslation);
+                    case "Skip":
+                        AnsiConsole.MarkupLine("[yellow]Translation skipped.[/]");
+                        return translated.ApplyTranslation(string.Empty);
                 }
             }
         }

--- a/developer-cli/Commands/TranslateCommand.cs
+++ b/developer-cli/Commands/TranslateCommand.cs
@@ -117,7 +117,7 @@ public class TranslateCommand : Command
 
     private static async Task WriteTranslationFile(string translationFile, POCatalog poCatalog)
     {
-        var poGenerator = new POGenerator(new POGeneratorSettings { IgnoreEncoding = true });
+        var poGenerator = new POGenerator(new POGeneratorSettings { IgnoreEncoding = true, IgnoreLongLines = true });
         var fileStream = File.OpenWrite(translationFile);
         poGenerator.Generate(fileStream, poCatalog);
         await fileStream.FlushAsync();

--- a/developer-cli/DeveloperCli.csproj
+++ b/developer-cli/DeveloperCli.csproj
@@ -8,6 +8,7 @@
         <RootNamespace>PlatformPlatform.DeveloperCli</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <UserSecretsId>platformplatform-f817f2a1-ac57-4756-aef2-a57ca864bbd3</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
@@ -15,7 +16,8 @@
         <PackageReference Include="Azure.ResourceManager" Version="1.13.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
         <PackageReference Include="Karambolo.PO" Version="1.11.1" />
-        <PackageReference Include="OllamaSharp" Version="2.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+        <PackageReference Include="OpenAI" Version="2.0.0" />
         <PackageReference Include="Spectre.Console" Version="0.49.1" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />

--- a/developer-cli/Utilities/SecretHelper.cs
+++ b/developer-cli/Utilities/SecretHelper.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.UserSecrets;
+
+namespace PlatformPlatform.DeveloperCli.Utilities;
+
+public static class SecretHelper
+{
+    private static string UserSecretsId => Assembly.GetEntryAssembly()!.GetCustomAttribute<UserSecretsIdAttribute>()!.UserSecretsId;
+
+    public static void SetSecret(string key, string value)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", $"user-secrets set {key} {value} --id {UserSecretsId}")
+        {
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(startInfo)!;
+        process.WaitForExit();
+    }
+
+    public static string? GetSecret(string key)
+    {
+        var config = new ConfigurationBuilder().AddUserSecrets(UserSecretsId).Build();
+        return config[key];
+    }
+}


### PR DESCRIPTION
### Summary & Motivation

Replace the Ollama LLM model running locally on Docker with the OpenAI GPT-4o model to improve translation speed and quality.

Other changes include:

- Re-translate back to English to confirm the accuracy of translations.
- Add an option to provide additional context to the translator.
- Add an option to use a custom translation.
- Fix an issue where translations would appear on a new line in the `.po` file.
- Maintain translations in their original position in the `.po` file for easier review.
- Prompt the user for an OpenAI key.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
