### PR TITLE
Fix tenantId is null bug when UserInfo has not been accessed

### DIFF
--- a/application/shared-kernel/SharedKernel/ExecutionContext/HttpExecutionContext.cs
+++ b/application/shared-kernel/SharedKernel/ExecutionContext/HttpExecutionContext.cs
@@ -7,6 +7,7 @@ namespace PlatformPlatform.SharedKernel.ExecutionContext;
 
 public class HttpExecutionContext(IHttpContextAccessor httpContextAccessor) : IExecutionContext
 {
+    private bool _isTenantIdCalculated;
     private TenantId? _tenantId;
     private UserInfo? _userInfo;
 
@@ -14,14 +15,13 @@ public class HttpExecutionContext(IHttpContextAccessor httpContextAccessor) : IE
     {
         get
         {
-            // The first time this property is accessed, _userInfo might be null, but when TenantId.TryParse() is called,
-            // it will be set. So even if _tenantId is null, we know if this property has been accessed before.
-            if (_userInfo is not null)
+            if (_isTenantIdCalculated)
             {
                 return _tenantId;
             }
 
             TenantId.TryParse(UserInfo.TenantId, out _tenantId);
+            _isTenantIdCalculated = true;
             return _tenantId;
         }
     }


### PR DESCRIPTION
### Summary & Motivation

This fix resolves a bug where the `TenantId` in `HttpExecutionContext` would always be null if `UserInfo` was the first property accessed. The issue stemmed from internal logic in `HttpExecutionContext`, which only set the `TenantId` when `UserInfo` was accessed first. The fix ensures that both `UserInfo` and `TenantId` are correctly set, regardless of which property is accessed first on `HttpExecutionContext`.

### Atomic Changes

- Fix tenantId is null bug when UserInfo has not been accessed

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
