### PR TITLE
Fix delay issue in serving SinglePageApp index.html on Windows

### DIFF
--- a/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppConfiguration.cs
@@ -99,13 +99,13 @@ public class SinglePageAppConfiguration
         while (stopwatch.Elapsed < TimeSpan.FromSeconds(30))
         {
             // A new index.html is created when starting, so we ensure the index.html is not from an old build
-            if (new FileInfo(_htmlTemplatePath).CreationTimeUtc > StartupTime.AddSeconds(-10)) break;
+            if (new FileInfo(_htmlTemplatePath).LastWriteTimeUtc > StartupTime.AddSeconds(-10)) break;
 
             Thread.Sleep(TimeSpan.FromMilliseconds(100));
         }
 
         // If the index.html was just created, the Web App Dev server needs a few moments to warm up
-        if (new FileInfo(_htmlTemplatePath).CreationTimeUtc > DateTime.UtcNow.AddSeconds(-1))
+        if (new FileInfo(_htmlTemplatePath).LastWriteTimeUtc > DateTime.UtcNow.AddSeconds(-1))
         {
             Thread.Sleep(TimeSpan.FromMilliseconds(500));
         }


### PR DESCRIPTION
### Summary & Motivation
This PR resolves an issue where the backend experienced delays when serving the `index.html` file of a SinglePageApp. The delay occurred because the backend was waiting for the `index.html` file to regenerate before serving it, ensuring the file included references to newly generated JavaScript bundles. The logic now checks for updates using the `LastWriteTime` to confirm when the new file is ready.

The delay primarily affected Windows due to differences in how file timestamps are handled across operating systems. On Windows, the `CreationTime` doesn't update when a file is modified, unlike on MacOS where both `CreationTime` and `LastWriteTime` are updated. The fix ensures consistent behavior across platforms by relying on the `LastWriteTime`.

### Atomic Changes
- Fix issue when waiting extensively on generation of SinglePageApp files

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
