### PR TITLE
Fix bug with BlobStorage in local environment not using KeyedService

### DIFF
--- a/application/shared-kernel/SharedKernel/SharedInfrastructureConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/SharedInfrastructureConfiguration.cs
@@ -108,7 +108,12 @@ public static class SharedInfrastructureConfiguration
         else
         {
             var connectionString = builder.Configuration.GetConnectionString("blob-storage");
-            builder.Services.AddSingleton(new BlobStorage(new BlobServiceClient(connectionString)));
+            foreach (var connection in connections)
+            {
+                builder.Services.AddKeyedSingleton(connection.ConnectionName,
+                    (_, _) => new BlobStorage(new BlobServiceClient(connectionString))
+                );
+            }
         }
 
         return builder;


### PR DESCRIPTION
### Summary & Motivation
With the upgrade to a newer version of .NET, a bug was exposed in the `PlatformPlatform` code, specifically affecting the avatars blob storage setup. The issue surfaced because the BlobStorage account was registered as a normal service rather than a keyed service in the local environment configuration (when not running in Azure). While this was not a problem in the previous .NET version, the upgrade made the bug evident. This PR resolves the issue by registering the BlobStorage account as a keyed service in the local environment, aligning the behavior with the intended configuration and fixing the bug in `PlatformPlatform`.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
