### PR TITLE
Fix blank web page when locale is invalid by improving language fallback logic

### DIFF
--- a/application/shared-kernel/SharedKernel/Authentication/UserInfo.cs
+++ b/application/shared-kernel/SharedKernel/Authentication/UserInfo.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using PlatformPlatform.SharedKernel.SinglePageApp;
 
 namespace PlatformPlatform.SharedKernel.Authentication;
 
@@ -8,13 +9,15 @@ namespace PlatformPlatform.SharedKernel.Authentication;
 /// </summary>
 public class UserInfo
 {
+    private const string DefaultLocale = "en-US";
+
     /// <summary>
     ///     Represents the system user, typically used for background tasks or where no user is directly authenticated.
     /// </summary>
     public static readonly UserInfo System = new()
     {
         IsAuthenticated = false,
-        Locale = "en-US"
+        Locale = DefaultLocale
     };
 
     public bool IsAuthenticated { get; init; }
@@ -37,14 +40,14 @@ public class UserInfo
 
     public string? AvatarUrl { get; init; }
 
-    public static UserInfo Create(ClaimsPrincipal? user, string defaultLocale)
+    public static UserInfo Create(ClaimsPrincipal? user, string? browserLocale)
     {
         if (user?.Identity?.IsAuthenticated != true)
         {
             return new UserInfo
             {
                 IsAuthenticated = user?.Identity?.IsAuthenticated ?? false,
-                Locale = defaultLocale
+                Locale = GetValidLocale(browserLocale)
             };
         }
 
@@ -59,7 +62,27 @@ public class UserInfo
             LastName = user.FindFirstValue(ClaimTypes.Surname),
             Title = user.FindFirstValue("title"),
             AvatarUrl = user.FindFirstValue("avatar_url"),
-            Locale = user.FindFirstValue("locale")
+            Locale = GetValidLocale(user.FindFirstValue("locale"))
         };
+    }
+
+    private static string GetValidLocale(string? locale)
+    {
+        if (string.IsNullOrEmpty(locale))
+        {
+            return DefaultLocale;
+        }
+
+        if (SinglePageAppConfiguration.SupportedLocalizations.Contains(locale, StringComparer.OrdinalIgnoreCase))
+        {
+            return locale;
+        }
+
+        // Fallback to base language. E.g. if locale is `en-UK` use `en` which would then return `en-US`
+        var baseLanguageCode = locale[..2];
+        var foundLocale = SinglePageAppConfiguration.SupportedLocalizations
+            .FirstOrDefault(sl => sl.StartsWith(baseLanguageCode, StringComparison.OrdinalIgnoreCase));
+
+        return foundLocale ?? DefaultLocale;
     }
 }

--- a/application/shared-kernel/SharedKernel/ExecutionContext/HttpExecutionContext.cs
+++ b/application/shared-kernel/SharedKernel/ExecutionContext/HttpExecutionContext.cs
@@ -35,9 +35,9 @@ public class HttpExecutionContext(IHttpContextAccessor httpContextAccessor) : IE
                 return _userInfo;
             }
 
-            var defaultLocale = httpContextAccessor.HttpContext?.Features.Get<IRequestCultureFeature>()?.RequestCulture.Culture.Name;
+            var browserLocale = httpContextAccessor.HttpContext?.Features.Get<IRequestCultureFeature>()?.RequestCulture.Culture.Name;
 
-            return _userInfo = UserInfo.Create(httpContextAccessor.HttpContext?.User, defaultLocale ?? "en-US");
+            return _userInfo = UserInfo.Create(httpContextAccessor.HttpContext?.User, browserLocale);
         }
     }
 }


### PR DESCRIPTION
### Summary & Motivation

Fix blank page being served where browser language settings like `en` or `en-UK` were uncritically used as the HTML Document language, even if translations weren't available for that exact locale. Now, the logic checks if a translation exists for the base language code (e.g., `en`), and if none is found, it falls back to `en-US`. This ensures that the document always has a valid locale that corresponds to available translations.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
