### PR TITLE
Aggregate OpenAPI for all self-contained systems using Scalar

### DIFF
--- a/application/AppGateway/ApiAggregation/ApiAggregationEndpoints.cs
+++ b/application/AppGateway/ApiAggregation/ApiAggregationEndpoints.cs
@@ -6,6 +6,20 @@ public static class Endpoints
 {
     public static WebApplication ApiAggregationEndpoints(this WebApplication app)
     {
+        app.MapGet("/swagger", context =>
+            {
+                context.Response.Redirect("/openapi/v1");
+                return Task.CompletedTask;
+            }
+        );
+
+        app.MapGet("/openapi", context =>
+            {
+                context.Response.Redirect("/openapi/v1");
+                return Task.CompletedTask;
+            }
+        );
+
         app.MapGet("/openapi/v1.json", async (ApiAggregationService openApiAggregationService) =>
                 {
                     var openApiDocument = await openApiAggregationService.GetAggregatedSpecificationAsync();

--- a/application/AppGateway/ApiAggregation/ApiAggregationEndpoints.cs
+++ b/application/AppGateway/ApiAggregation/ApiAggregationEndpoints.cs
@@ -1,0 +1,22 @@
+using Microsoft.OpenApi.Writers;
+
+namespace PlatformPlatform.AppGateway.ApiAggregation;
+
+public static class Endpoints
+{
+    public static WebApplication ApiAggregationEndpoints(this WebApplication app)
+    {
+        app.MapGet("/openapi/v1.json", async (ApiAggregationService openApiAggregationService) =>
+                {
+                    var openApiDocument = await openApiAggregationService.GetAggregatedSpecificationAsync();
+                    await using var stringWriter = new StringWriter();
+                    var jsonWriter = new OpenApiJsonWriter(stringWriter);
+                    openApiDocument.SerializeAsV3(jsonWriter);
+                    return Results.Content(stringWriter.ToString(), "application/json");
+                }
+            )
+            .CacheOutput(c => c.Expire(TimeSpan.FromMinutes(5)));
+
+        return app;
+    }
+}

--- a/application/AppGateway/ApiAggregation/ApiAggregationService.cs
+++ b/application/AppGateway/ApiAggregation/ApiAggregationService.cs
@@ -1,0 +1,92 @@
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers;
+using Yarp.ReverseProxy.Configuration;
+
+namespace PlatformPlatform.AppGateway.ApiAggregation;
+
+public class ApiAggregationService(ILogger<ApiAggregationService> logger, IConfiguration configuration, IHttpClientFactory httpClientFactory)
+{
+    public async Task<OpenApiDocument> GetAggregatedSpecificationAsync()
+    {
+        var aggregatedSpecification = new OpenApiDocument
+        {
+            Info = new OpenApiInfo { Title = "PlatformPlatform API", Version = "v1" },
+            Paths = new OpenApiPaths(),
+            Components = new OpenApiComponents
+            {
+                Schemas = new Dictionary<string, OpenApiSchema>()
+            }
+        };
+
+        var clusters = configuration.GetSection("ReverseProxy:Clusters").Get<Dictionary<string, ClusterConfig>>()!;
+
+        foreach (var cluster in clusters!.Where(c => c.Key.EndsWith("-api")))
+        {
+            try
+            {
+                var url = $"{cluster.Value.Destinations!.Single().Value.Address}/swagger/v1/swagger.json";
+                var specification = await FetchSpecificationAsync(url);
+                CombineOpenApiDocuments(aggregatedSpecification, specification);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to fetch or merge specification for cluster {ClusterKey}", cluster.Key);
+            }
+        }
+
+        FilterInternalEndpoints(aggregatedSpecification);
+        return aggregatedSpecification;
+    }
+
+    private async Task<OpenApiDocument> FetchSpecificationAsync(string url)
+    {
+        using var httpClient = httpClientFactory.CreateClient();
+        var response = await httpClient.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        var reader = new OpenApiStreamReader();
+        return reader.Read(stream, out _);
+    }
+
+    private static void CombineOpenApiDocuments(OpenApiDocument aggregatedOpenApiDocument, OpenApiDocument openApiDocument)
+    {
+        // Merge paths
+        foreach (var path in openApiDocument.Paths)
+        {
+            if (!aggregatedOpenApiDocument.Paths.ContainsKey(path.Key))
+            {
+                aggregatedOpenApiDocument.Paths.Add(path.Key, path.Value);
+            }
+        }
+
+        // Merge schemas
+        if (openApiDocument.Components?.Schemas is not null)
+        {
+            foreach (var schema in openApiDocument.Components.Schemas)
+            {
+                if (aggregatedOpenApiDocument.Components.Schemas.ContainsKey(schema.Key))
+                {
+                    Console.Error.WriteLine($"Duplicate schema for {schema.Key}");
+                }
+                else
+                {
+                    aggregatedOpenApiDocument.Components.Schemas.Add(schema.Key, schema.Value);
+                }
+            }
+        }
+    }
+
+    private static void FilterInternalEndpoints(OpenApiDocument openApiDocument)
+    {
+        var internalPaths = openApiDocument.Paths
+            .Where(p => p.Key.StartsWith("/internal-api/"))
+            .Select(p => p.Key)
+            .ToArray();
+
+        foreach (var path in internalPaths)
+        {
+            openApiDocument.Paths.Remove(path);
+        }
+    }
+}

--- a/application/AppGateway/ApiAggregation/ApiAggregationService.cs
+++ b/application/AppGateway/ApiAggregation/ApiAggregationService.cs
@@ -24,7 +24,7 @@ public class ApiAggregationService(ILogger<ApiAggregationService> logger, IConfi
         {
             try
             {
-                var url = $"{cluster.Value.Destinations!.Single().Value.Address}/swagger/v1/swagger.json";
+                var url = $"{cluster.Value.Destinations!.Single().Value.Address}/openapi/v1.json";
                 var specification = await FetchSpecificationAsync(url);
                 CombineOpenApiDocuments(aggregatedSpecification, specification);
             }

--- a/application/AppGateway/ApiAggregation/ApiExplorerRouteFilter.cs
+++ b/application/AppGateway/ApiAggregation/ApiExplorerRouteFilter.cs
@@ -1,0 +1,22 @@
+using Yarp.ReverseProxy.Configuration;
+
+namespace PlatformPlatform.AppGateway.ApiAggregation;
+
+public class ApiExplorerRouteFilter : IProxyConfigFilter
+{
+    public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel)
+    {
+        return new ValueTask<ClusterConfig>(cluster);
+    }
+
+    public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig? cluster, CancellationToken cancel)
+    {
+        if (route.RouteId == "openapi")
+        {
+            // Create a new RouteConfig with the updated ClusterId
+            return new ValueTask<RouteConfig>(route with { ClusterId = "app-gateway" });
+        }
+
+        return new ValueTask<RouteConfig>(route);
+    }
+}

--- a/application/AppGateway/AppGateway.csproj
+++ b/application/AppGateway/AppGateway.csproj
@@ -10,6 +10,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.OpenApi" />
+        <PackageReference Include="Microsoft.OpenApi.Readers" />
+        <PackageReference Include="Scalar.AspNetCore" />
         <PackageReference Include="Yarp.ReverseProxy" />
     </ItemGroup>
 

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -39,6 +39,9 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EfCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="1.6.3" />
+    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.3" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="1.2.10" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />
     <!-- PlatformPlatform dependencies - Tests -->
     <PackageVersion Include="Bogus" Version="35.6.0" />

--- a/application/shared-kernel/SharedKernel/ApiDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/ApiDependencyConfiguration.cs
@@ -96,9 +96,8 @@ public static class ApiDependencyConfiguration
         app.UseAuthentication();
         app.UseAuthorization();
 
-        // Enable Swagger UI
-        app.UseOpenApi();
-        app.UseSwaggerUi();
+        // Adds the OpenAPI generator that uses the ASP. NET Core API Explorer
+        app.UseOpenApi(options => options.Path = "/openapi/v1.json");
 
         app.UseMiddleware<ModelBindingExceptionHandlerMiddleware>();
 


### PR DESCRIPTION
### Summary & Motivation

Aggregate OpenAPI specifications for all self-contained systems into a unified UI. Previously, each system had its own SwaggerUI, accessible only on internal endpoints and not in production. The YARP AppGateway now fetches `OpenAPI.json` from each self-contained system and combines them into a single OpenAPI contract.

With the upcoming removal of Swagger in .NET 9, the UI for the aggregated API uses Scalar, an open-source alternative (https://github.com/scalar/scalar), accessible at `/openapi/v1`.

Because self-contained systems can be deployed independently of the AppGateway, the aggregation cannot occur during AppGateway startup. Instead, the OpenAPI contracts are fetched dynamically from each system. For performance optimization, the contract is cached for 5 minutes using standard .NET output caching, which only impacts the UI. API updates are applied immediately upon deployment of the self-contained systems.

As part of the aggregation, all endpoints under `/internal-api/` are removed since they are not publicly available.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
