### PR TITLE
Change OpenAPI aggregation to use hardcoded clusters to add flexibility and resolve issue in Azure

### DIFF
--- a/application/AppGateway/ApiAggregation/ApiAggregationEndpoints.cs
+++ b/application/AppGateway/ApiAggregation/ApiAggregationEndpoints.cs
@@ -1,5 +1,3 @@
-using Microsoft.OpenApi.Writers;
-
 namespace PlatformPlatform.AppGateway.ApiAggregation;
 
 public static class Endpoints
@@ -20,16 +18,9 @@ public static class Endpoints
             }
         );
 
-        app.MapGet("/openapi/v1.json", async (ApiAggregationService openApiAggregationService) =>
-                {
-                    var openApiDocument = await openApiAggregationService.GetAggregatedSpecificationAsync();
-                    await using var stringWriter = new StringWriter();
-                    var jsonWriter = new OpenApiJsonWriter(stringWriter);
-                    openApiDocument.SerializeAsV3(jsonWriter);
-                    return Results.Content(stringWriter.ToString(), "application/json");
-                }
-            )
-            .CacheOutput(c => c.Expire(TimeSpan.FromMinutes(5)));
+        app.MapGet("/openapi/v1.json", async (ApiAggregationService apiAggregationService)
+            => Results.Content(await apiAggregationService.GetAggregatedOpenApiJson(), "application/json")
+        ).CacheOutput(c => c.Expire(TimeSpan.FromMinutes(5)));
 
         return app;
     }


### PR DESCRIPTION
### Summary & Motivation

Follow-up to the recent change for aggregating OpenAPI specifications. The aggregation was not working correctly in production because URLs for the self-contained systems were not fetched properly from the YARP configuration, leading to empty API contracts.

To resolve this, the list of YARP clusters to include in the aggregated OpenAPI specification is now hardcoded, rather than relying on conventions for clusters with an `-api` postfix. This adjustment provides more flexibility in configuring the setup.


### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
