### PR TITLE
Ensure updating an entity marks it as tracked in Entity Framework change tracker

### DIFF
--- a/application/shared-kernel/SharedKernel/Persistence/RepositoryBase.cs
+++ b/application/shared-kernel/SharedKernel/Persistence/RepositoryBase.cs
@@ -40,6 +40,21 @@ public abstract class RepositoryBase<T, TId>(DbContext context)
     public void Update(T aggregate)
     {
         ArgumentNullException.ThrowIfNull(aggregate);
+
+        var existingEntity = DbSet.Find(aggregate.Id);
+        if (existingEntity is not null)
+        {
+            var entry = DbSet.Entry(existingEntity);
+
+            if (entry.State == EntityState.Detached)
+            {
+                DbSet.Attach(existingEntity);
+            }
+
+            entry.CurrentValues.SetValues(aggregate);
+            return;
+        }
+
         DbSet.Update(aggregate);
     }
 

--- a/application/shared-kernel/Tests/Persistence/RepositoryTests.cs
+++ b/application/shared-kernel/Tests/Persistence/RepositoryTests.cs
@@ -94,6 +94,26 @@ public sealed class RepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task Update_WhenAlreadyTracked_ShouldUpdateDatabase()
+    {
+        // Arrange
+        var testAggregateAdd = TestAggregate.Create("TestAggregate");
+        _testDbContext.TestAggregates.Add(testAggregateAdd);
+        var initialName = testAggregateAdd.Name;
+
+        // Act
+        var testAggregateUpdate = new TestAggregate("UpdatedName") { Id = testAggregateAdd.Id };
+        _testAggregateRepository.Update(testAggregateUpdate);
+        await _testDbContext.SaveChangesAsync();
+
+        // Assert
+        var updatedAggregate = await _testAggregateRepository.GetByIdAsync(testAggregateUpdate.Id, CancellationToken.None);
+        updatedAggregate.Should().NotBeNull();
+        updatedAggregate!.Name.Should().NotBe(initialName);
+        updatedAggregate.Name.Should().Be("UpdatedName");
+    }
+
+    [Fact]
     public async Task Remove_WhenExistingAggregate_ShouldRemoveFromDatabase()
     {
         // Arrange


### PR DESCRIPTION
### Summary & Motivation

Resolve issues with updating entities within the `RepositoryBase` class in Entity Framework where changes were not persisting to the database if the entity was both created and updated within the same scope. By explicitly marking the entity as tracked upon update, this change ensures that Entity Framework’s change tracker recognizes the modifications, facilitating accurate change detection and persistence within the database.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
