### PR TITLE
Change DTOs to use Response/Request postfix instead of DTO

### DIFF
--- a/application/account-management/Api/Endpoints/TenantEndpoints.cs
+++ b/application/account-management/Api/Endpoints/TenantEndpoints.cs
@@ -14,9 +14,9 @@ public sealed class TenantEndpoints : IEndpoints
     {
         var group = routes.MapGroup(RoutesPrefix).WithTags("Tenants").RequireAuthorization();
 
-        group.MapGet("/{id}", async Task<ApiResult<TenantResponseDto>> (TenantId id, IMediator mediator)
+        group.MapGet("/{id}", async Task<ApiResult<TenantResponse>> (TenantId id, IMediator mediator)
             => await mediator.Send(new GetTenantQuery(id))
-        ).Produces<TenantResponseDto>();
+        ).Produces<TenantResponse>();
 
         group.MapPut("/{id}", async Task<ApiResult> (TenantId id, UpdateTenantCommand command, IMediator mediator)
             => await mediator.Send(command with { Id = id })

--- a/application/account-management/Api/Endpoints/UserEndpoints.cs
+++ b/application/account-management/Api/Endpoints/UserEndpoints.cs
@@ -14,13 +14,13 @@ public sealed class UserEndpoints : IEndpoints
     {
         var group = routes.MapGroup(RoutesPrefix).WithTags("Users").RequireAuthorization();
 
-        group.MapGet("/", async Task<ApiResult<GetUsersResponseDto>> ([AsParameters] GetUsersQuery query, IMediator mediator)
+        group.MapGet("/", async Task<ApiResult<GetUsersResponse>> ([AsParameters] GetUsersQuery query, IMediator mediator)
             => await mediator.Send(query)
-        ).Produces<GetUsersResponseDto>();
+        ).Produces<GetUsersResponse>();
 
-        group.MapGet("/{id}", async Task<ApiResult<UserResponseDto>> (UserId id, IMediator mediator)
+        group.MapGet("/{id}", async Task<ApiResult<UserResponse>> (UserId id, IMediator mediator)
             => await mediator.Send(new GetUserQuery(id))
-        ).Produces<UserResponseDto>();
+        ).Produces<UserResponse>();
 
         group.MapPost("/", async Task<ApiResult> (CreateUserCommand command, IMediator mediator)
             => (await mediator.Send(command)).AddResourceUri(RoutesPrefix)

--- a/application/account-management/Core/Tenants/Queries/GetTenant.cs
+++ b/application/account-management/Core/Tenants/Queries/GetTenant.cs
@@ -7,17 +7,17 @@ using PlatformPlatform.SharedKernel.Domain;
 namespace PlatformPlatform.AccountManagement.Tenants.Queries;
 
 [PublicAPI]
-public sealed record GetTenantQuery(TenantId Id) : IRequest<Result<TenantResponseDto>>;
+public sealed record GetTenantQuery(TenantId Id) : IRequest<Result<TenantResponse>>;
 
 [PublicAPI]
-public sealed record TenantResponseDto(string Id, DateTimeOffset CreatedAt, DateTimeOffset? ModifiedAt, string Name, TenantState State);
+public sealed record TenantResponse(string Id, DateTimeOffset CreatedAt, DateTimeOffset? ModifiedAt, string Name, TenantState State);
 
 public sealed class GetTenantHandler(ITenantRepository tenantRepository)
-    : IRequestHandler<GetTenantQuery, Result<TenantResponseDto>>
+    : IRequestHandler<GetTenantQuery, Result<TenantResponse>>
 {
-    public async Task<Result<TenantResponseDto>> Handle(GetTenantQuery request, CancellationToken cancellationToken)
+    public async Task<Result<TenantResponse>> Handle(GetTenantQuery request, CancellationToken cancellationToken)
     {
         var tenant = await tenantRepository.GetByIdAsync(request.Id, cancellationToken);
-        return tenant?.Adapt<TenantResponseDto>() ?? Result<TenantResponseDto>.NotFound($"Tenant with id '{request.Id}' not found.");
+        return tenant?.Adapt<TenantResponse>() ?? Result<TenantResponse>.NotFound($"Tenant with id '{request.Id}' not found.");
     }
 }

--- a/application/account-management/Core/Users/Queries/GetUser.cs
+++ b/application/account-management/Core/Users/Queries/GetUser.cs
@@ -7,10 +7,10 @@ using PlatformPlatform.SharedKernel.Domain;
 namespace PlatformPlatform.AccountManagement.Users.Queries;
 
 [PublicAPI]
-public sealed record GetUserQuery(UserId Id) : IRequest<Result<UserResponseDto>>;
+public sealed record GetUserQuery(UserId Id) : IRequest<Result<UserResponse>>;
 
 [PublicAPI]
-public sealed record UserResponseDto(
+public sealed record UserResponse(
     string Id,
     DateTimeOffset CreatedAt,
     DateTimeOffset? ModifiedAt,
@@ -23,11 +23,11 @@ public sealed record UserResponseDto(
 );
 
 public sealed class GetUserHandler(IUserRepository userRepository)
-    : IRequestHandler<GetUserQuery, Result<UserResponseDto>>
+    : IRequestHandler<GetUserQuery, Result<UserResponse>>
 {
-    public async Task<Result<UserResponseDto>> Handle(GetUserQuery request, CancellationToken cancellationToken)
+    public async Task<Result<UserResponse>> Handle(GetUserQuery request, CancellationToken cancellationToken)
     {
         var user = await userRepository.GetByIdAsync(request.Id, cancellationToken);
-        return user?.Adapt<UserResponseDto>() ?? Result<UserResponseDto>.NotFound($"User with id '{request.Id}' not found.");
+        return user?.Adapt<UserResponse>() ?? Result<UserResponse>.NotFound($"User with id '{request.Id}' not found.");
     }
 }

--- a/application/account-management/Core/Users/Queries/GetUsers.cs
+++ b/application/account-management/Core/Users/Queries/GetUsers.cs
@@ -15,13 +15,13 @@ public sealed record GetUsersQuery(
     SortOrder SortOrder = SortOrder.Ascending,
     int PageSize = 25,
     int? PageOffset = null
-) : IRequest<Result<GetUsersResponseDto>>;
+) : IRequest<Result<GetUsersResponse>>;
 
 [PublicAPI]
-public sealed record GetUsersResponseDto(int TotalCount, int PageSize, int TotalPages, int CurrentPageOffset, UsersResponseUserDto[] Users);
+public sealed record GetUsersResponse(int TotalCount, int PageSize, int TotalPages, int CurrentPageOffset, UserDetails[] Users);
 
 [PublicAPI]
-public sealed record UsersResponseUserDto(
+public sealed record UserDetails(
     string Id,
     DateTimeOffset CreatedAt,
     DateTimeOffset? ModifiedAt,
@@ -45,9 +45,9 @@ public sealed class GetUsersQueryValidator : AbstractValidator<GetUsersQuery>
 }
 
 public sealed class GetUsersHandler(IUserRepository userRepository)
-    : IRequestHandler<GetUsersQuery, Result<GetUsersResponseDto>>
+    : IRequestHandler<GetUsersQuery, Result<GetUsersResponse>>
 {
-    public async Task<Result<GetUsersResponseDto>> Handle(GetUsersQuery query, CancellationToken cancellationToken)
+    public async Task<Result<GetUsersResponse>> Handle(GetUsersQuery query, CancellationToken cancellationToken)
     {
         var (users, count, totalPages) = await userRepository.Search(
             query.Search,
@@ -61,10 +61,10 @@ public sealed class GetUsersHandler(IUserRepository userRepository)
 
         if (query.PageOffset.HasValue && query.PageOffset.Value >= totalPages)
         {
-            return Result<GetUsersResponseDto>.BadRequest($"The page offset {query.PageOffset.Value} is greater than the total number of pages.");
+            return Result<GetUsersResponse>.BadRequest($"The page offset {query.PageOffset.Value} is greater than the total number of pages.");
         }
 
-        var userResponseDtos = users.Adapt<UsersResponseUserDto[]>();
-        return new GetUsersResponseDto(count, query.PageSize, totalPages, query.PageOffset ?? 0, userResponseDtos);
+        var userResponses = users.Adapt<UserDetails[]>();
+        return new GetUsersResponse(count, query.PageSize, totalPages, query.PageOffset ?? 0, userResponses);
     }
 }

--- a/application/account-management/Tests/Users/GetUsersTests.cs
+++ b/application/account-management/Tests/Users/GetUsersTests.cs
@@ -62,7 +62,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
 
         // Assert
         response.ShouldBeSuccessfulGetRequest();
-        var userResponse = await response.DeserializeResponse<GetUsersResponseDto>();
+        var userResponse = await response.DeserializeResponse<GetUsersResponse>();
         userResponse.Should().NotBeNull();
         userResponse!.TotalCount.Should().Be(1);
         userResponse.Users.First().Email.Should().Be(Email);
@@ -79,7 +79,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
 
         // Assert
         response.ShouldBeSuccessfulGetRequest();
-        var userResponse = await response.DeserializeResponse<GetUsersResponseDto>();
+        var userResponse = await response.DeserializeResponse<GetUsersResponse>();
         userResponse.Should().NotBeNull();
         userResponse!.TotalCount.Should().Be(1);
         userResponse.Users.First().FirstName.Should().Be(FirstName);
@@ -97,7 +97,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
 
         // Assert
         response.ShouldBeSuccessfulGetRequest();
-        var userResponse = await response.DeserializeResponse<GetUsersResponseDto>();
+        var userResponse = await response.DeserializeResponse<GetUsersResponse>();
         userResponse.Should().NotBeNull();
         userResponse!.TotalCount.Should().Be(1);
         userResponse.Users.First().LastName.Should().Be(LastName);
@@ -112,7 +112,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
 
         // Assert
         response.ShouldBeSuccessfulGetRequest();
-        var userResponse = await response.DeserializeResponse<GetUsersResponseDto>();
+        var userResponse = await response.DeserializeResponse<GetUsersResponse>();
         userResponse.Should().NotBeNull();
         userResponse!.TotalCount.Should().Be(2);
         userResponse.Users.First().Role.Should().Be(UserRole);
@@ -126,7 +126,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
 
         // Assert
         response.ShouldBeSuccessfulGetRequest();
-        var userResponse = await response.DeserializeResponse<GetUsersResponseDto>();
+        var userResponse = await response.DeserializeResponse<GetUsersResponse>();
         userResponse.Should().NotBeNull();
         userResponse!.TotalCount.Should().Be(3);
         userResponse.Users.First().Role.Should().Be(UserRole.Member);

--- a/application/account-management/WebApp/shared/components/userModals/UserProfileModal.tsx
+++ b/application/account-management/WebApp/shared/components/userModals/UserProfileModal.tsx
@@ -18,7 +18,7 @@ type ProfileModalProps = {
 };
 
 export default function UserProfileModal({ isOpen, onOpenChange, userId }: Readonly<ProfileModalProps>) {
-  const [data, setData] = useState<Schemas["UserResponseDto"] | null>(null);
+  const [data, setData] = useState<Schemas["UserResponse"] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [file, setFile] = useState<string | null>(null);

--- a/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
+++ b/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
@@ -223,7 +223,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TenantResponseDto"
+                  "$ref": "#/components/schemas/TenantResponse"
                 }
               }
             }
@@ -358,7 +358,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetUsersResponseDto"
+                  "$ref": "#/components/schemas/GetUsersResponse"
                 }
               }
             }
@@ -412,7 +412,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserResponseDto"
+                  "$ref": "#/components/schemas/UserResponse"
                 }
               }
             }
@@ -726,7 +726,7 @@
           }
         }
       },
-      "TenantResponseDto": {
+      "TenantResponse": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -787,7 +787,7 @@
           }
         }
       },
-      "GetUsersResponseDto": {
+      "GetUsersResponse": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -810,12 +810,12 @@
           "users": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UsersResponseUserDto"
+              "$ref": "#/components/schemas/UserDetails"
             }
           }
         }
       },
-      "UsersResponseUserDto": {
+      "UserDetails": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -899,7 +899,7 @@
           "Descending"
         ]
       },
-      "UserResponseDto": {
+      "UserResponse": {
         "type": "object",
         "additionalProperties": false,
         "properties": {

--- a/application/shared-kernel/SharedKernel/Endpoints/TrackEndpoints.cs
+++ b/application/shared-kernel/SharedKernel/Endpoints/TrackEndpoints.cs
@@ -24,32 +24,32 @@ public class TrackEndpoints : IEndpoints
     }
 
     [OpenApiIgnore]
-    private static TrackResponseSuccessDto Track(
+    private static TrackResponse Track(
         HttpContext context,
-        List<TrackRequestDto> trackRequests,
+        List<TrackRequest> trackRequests,
         TelemetryClient telemetryClient,
         ILogger<string> logger
     )
     {
         var ip = context.Connection.RemoteIpAddress?.ToString();
-        foreach (var trackRequestDto in trackRequests)
+        foreach (var trackRequest in trackRequests)
         {
-            switch (trackRequestDto.Data.BaseType)
+            switch (trackRequest.Data.BaseType)
             {
                 case "PageviewData":
                 {
                     var telemetry = new PageViewTelemetry
                     {
-                        Name = trackRequestDto.Data.BaseData.Name,
-                        Url = new Uri(trackRequestDto.Data.BaseData.Url),
-                        Duration = trackRequestDto.Data.BaseData.Duration,
-                        Timestamp = trackRequestDto.Time,
-                        Id = trackRequestDto.Data.BaseData.Id
+                        Name = trackRequest.Data.BaseData.Name,
+                        Url = new Uri(trackRequest.Data.BaseData.Url),
+                        Duration = trackRequest.Data.BaseData.Duration,
+                        Timestamp = trackRequest.Time,
+                        Id = trackRequest.Data.BaseData.Id
                     };
 
-                    CopyContextTags(telemetry.Context, trackRequestDto.Tags, ip);
-                    CopyDictionary(trackRequestDto.Data.BaseData.Properties, telemetry.Properties);
-                    CopyDictionary(trackRequestDto.Data.BaseData.Measurements, telemetry.Metrics);
+                    CopyContextTags(telemetry.Context, trackRequest.Tags, ip);
+                    CopyDictionary(trackRequest.Data.BaseData.Properties, telemetry.Properties);
+                    CopyDictionary(trackRequest.Data.BaseData.Measurements, telemetry.Metrics);
 
                     telemetryClient.TrackPageView(telemetry);
                     break;
@@ -58,58 +58,58 @@ public class TrackEndpoints : IEndpoints
                 {
                     var telemetry = new PageViewPerformanceTelemetry
                     {
-                        Name = trackRequestDto.Data.BaseData.Name,
-                        Url = new Uri(trackRequestDto.Data.BaseData.Url),
-                        Duration = trackRequestDto.Data.BaseData.Duration,
-                        Timestamp = trackRequestDto.Time,
-                        Id = trackRequestDto.Data.BaseData.Id,
-                        PerfTotal = trackRequestDto.Data.BaseData.PerfTotal,
-                        NetworkConnect = trackRequestDto.Data.BaseData.NetworkConnect,
-                        SentRequest = trackRequestDto.Data.BaseData.SentRequest,
-                        ReceivedResponse = trackRequestDto.Data.BaseData.ReceivedResponse,
-                        DomProcessing = trackRequestDto.Data.BaseData.DomProcessing
+                        Name = trackRequest.Data.BaseData.Name,
+                        Url = new Uri(trackRequest.Data.BaseData.Url),
+                        Duration = trackRequest.Data.BaseData.Duration,
+                        Timestamp = trackRequest.Time,
+                        Id = trackRequest.Data.BaseData.Id,
+                        PerfTotal = trackRequest.Data.BaseData.PerfTotal,
+                        NetworkConnect = trackRequest.Data.BaseData.NetworkConnect,
+                        SentRequest = trackRequest.Data.BaseData.SentRequest,
+                        ReceivedResponse = trackRequest.Data.BaseData.ReceivedResponse,
+                        DomProcessing = trackRequest.Data.BaseData.DomProcessing
                     };
 
-                    CopyContextTags(telemetry.Context, trackRequestDto.Tags, ip);
-                    CopyDictionary(trackRequestDto.Data.BaseData.Properties, telemetry.Properties);
-                    CopyDictionary(trackRequestDto.Data.BaseData.Measurements, telemetry.Metrics);
+                    CopyContextTags(telemetry.Context, trackRequest.Tags, ip);
+                    CopyDictionary(trackRequest.Data.BaseData.Properties, telemetry.Properties);
+                    CopyDictionary(trackRequest.Data.BaseData.Measurements, telemetry.Metrics);
 
                     telemetryClient.Track(telemetry);
                     break;
                 }
                 case "ExceptionData":
                 {
-                    var exceptionDetailsInfos = GetExceptionDetailsInfos(trackRequestDto);
+                    var exceptionDetailsInfos = GetExceptionDetailsInfos(trackRequest);
                     var telemetry = new ExceptionTelemetry(exceptionDetailsInfos,
-                        trackRequestDto.Data.BaseData.SeverityLevel, trackRequestDto.Data.BaseType,
-                        trackRequestDto.Data.BaseData.Properties, new Dictionary<string, double>()
+                        trackRequest.Data.BaseData.SeverityLevel, trackRequest.Data.BaseType,
+                        trackRequest.Data.BaseData.Properties, new Dictionary<string, double>()
                     )
                     {
-                        SeverityLevel = trackRequestDto.Data.BaseData.SeverityLevel,
-                        Timestamp = trackRequestDto.Time
+                        SeverityLevel = trackRequest.Data.BaseData.SeverityLevel,
+                        Timestamp = trackRequest.Time
                     };
 
-                    CopyContextTags(telemetry.Context, trackRequestDto.Tags, ip);
-                    CopyDictionary(trackRequestDto.Data.BaseData.Properties, telemetry.Properties);
-                    CopyDictionary(trackRequestDto.Data.BaseData.Measurements, telemetry.Metrics);
+                    CopyContextTags(telemetry.Context, trackRequest.Tags, ip);
+                    CopyDictionary(trackRequest.Data.BaseData.Properties, telemetry.Properties);
+                    CopyDictionary(trackRequest.Data.BaseData.Measurements, telemetry.Metrics);
 
                     telemetryClient.TrackException(telemetry);
                     break;
                 }
                 case "MetricData":
                 {
-                    foreach (var metric in trackRequestDto.Data.BaseData.Metrics)
+                    foreach (var metric in trackRequest.Data.BaseData.Metrics)
                     {
                         var telemetry = new MetricTelemetry
                         {
                             Name = metric.Name,
                             Sum = metric.Value,
                             Count = metric.Count,
-                            Timestamp = trackRequestDto.Time
+                            Timestamp = trackRequest.Time
                         };
 
-                        CopyContextTags(telemetry.Context, trackRequestDto.Tags, ip);
-                        CopyDictionary(trackRequestDto.Data.BaseData.Properties, telemetry.Properties);
+                        CopyContextTags(telemetry.Context, trackRequest.Tags, ip);
+                        CopyDictionary(trackRequest.Data.BaseData.Properties, telemetry.Properties);
 
                         telemetryClient.TrackMetric(telemetry);
                     }
@@ -123,18 +123,18 @@ public class TrackEndpoints : IEndpoints
                 }
                 default:
                 {
-                    logger.LogWarning("Unsupported telemetry type: {BaseType}", trackRequestDto.Data.BaseType);
+                    logger.LogWarning("Unsupported telemetry type: {BaseType}", trackRequest.Data.BaseType);
                     break;
                 }
             }
         }
 
-        return new TrackResponseSuccessDto(true, "Telemetry sent.");
+        return new TrackResponse(true, "Telemetry sent.");
     }
 
-    private static IEnumerable<ExceptionDetailsInfo> GetExceptionDetailsInfos(TrackRequestDto trackRequestDto)
+    private static IEnumerable<ExceptionDetailsInfo> GetExceptionDetailsInfos(TrackRequest trackRequest)
     {
-        var exceptionDetailsInfos = trackRequestDto.Data.BaseData.Exceptions
+        var exceptionDetailsInfos = trackRequest.Data.BaseData.Exceptions
             .Select(exception => new ExceptionDetailsInfo(
                     0,
                     0,
@@ -199,23 +199,23 @@ public class TrackEndpoints : IEndpoints
 }
 
 [PublicAPI]
-public record TrackResponseSuccessDto(bool Success, string Message);
+public record TrackResponse(bool Success, string Message);
 
 [PublicAPI]
-public record TrackRequestDto(
+public record TrackRequest(
     DateTimeOffset Time,
     // ReSharper disable once InconsistentNaming
     string IKey,
     string Name,
     Dictionary<string, string> Tags,
-    TrackRequestDataDto Data
+    TrackData Data
 );
 
 [PublicAPI]
-public record TrackRequestDataDto(string BaseType, TrackRequestBaseDataDto BaseData);
+public record TrackData(string BaseType, TrackBaseData BaseData);
 
 [PublicAPI]
-public record TrackRequestBaseDataDto(
+public record TrackBaseData(
     string Name,
     string Url,
     TimeSpan Duration,
@@ -226,23 +226,17 @@ public record TrackRequestBaseDataDto(
     TimeSpan DomProcessing,
     Dictionary<string, string> Properties,
     Dictionary<string, double> Measurements,
-    List<TrackRequestMetricsDto> Metrics,
-    List<TrackRequestExceptionDto> Exceptions,
+    List<TrackMetric> Metrics,
+    List<TrackException> Exceptions,
     SeverityLevel SeverityLevel,
     string Id
 );
 
 [PublicAPI]
-public record TrackRequestMetricsDto(string Name, int Kind, double Value, int Count);
+public record TrackMetric(string Name, int Kind, double Value, int Count);
 
 [PublicAPI]
-public record TrackRequestExceptionDto(
-    string TypeName,
-    string Message,
-    bool HasFullStack,
-    string Stack,
-    List<TrackRequestParsedStackDto> ParsedStack
-);
+public record TrackException(string TypeName, string Message, bool HasFullStack, string Stack, List<TrackExceptionParsedStack> ParsedStack);
 
 [PublicAPI]
-public record TrackRequestParsedStackDto(string Assembly, string FileName, string Method, int Line, int Level);
+public record TrackExceptionParsedStack(string Assembly, string FileName, string Method, int Line, int Level);


### PR DESCRIPTION
### Summary & Motivation

Rename all DTOs to use the `Response` or `Request` postfix instead of `DTO`. This change standardizes naming conventions across the project, making it clearer whether a data structure represents an incoming request or an outgoing response. Additionally, this update avoids using the `DTO` term in the frontend code.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
