### PR TITLE
Show the User Profile dialog when any information is missing

### DIFF
--- a/application/account-management/WebApp/routes/__root.tsx
+++ b/application/account-management/WebApp/routes/__root.tsx
@@ -1,11 +1,9 @@
 import { createRootRoute, Outlet, useNavigate } from "@tanstack/react-router";
 import { ErrorPage } from "@repo/infrastructure/errorComponents/ErrorPage";
 import { NotFound } from "@repo/infrastructure/errorComponents/NotFoundPage";
-import { AuthenticationContext, AuthenticationProvider } from "@repo/infrastructure/auth/AuthenticationProvider";
+import { AuthenticationProvider } from "@repo/infrastructure/auth/AuthenticationProvider";
 import { ReactAriaRouterProvider } from "@repo/infrastructure/router/ReactAriaRouterProvider";
 import { ThemeModeProvider } from "@repo/ui/theme/mode/ThemeMode";
-import { useContext, useEffect, useState } from "react";
-import UserProfileModal from "@/shared/components/userModals/UserProfileModal";
 
 export const Route = createRootRoute({
   component: Root,
@@ -15,27 +13,12 @@ export const Route = createRootRoute({
 
 function Root() {
   const navigate = useNavigate();
-  const { userInfo } = useContext(AuthenticationContext);
-  const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
-
-  useEffect(() => {
-    if (userInfo?.isAuthenticated && (!userInfo.firstName || !userInfo.lastName)) {
-      setIsProfileModalOpen(true);
-    }
-  }, [userInfo]);
 
   return (
     <ThemeModeProvider>
       <ReactAriaRouterProvider>
         <AuthenticationProvider navigate={(options) => navigate(options)}>
           <Outlet />
-          {userInfo?.isAuthenticated && (
-            <UserProfileModal
-              isOpen={isProfileModalOpen}
-              onOpenChange={setIsProfileModalOpen}
-              userId={userInfo.userId ?? ""}
-            />
-          )}
         </AuthenticationProvider>
       </ReactAriaRouterProvider>
     </ThemeModeProvider>

--- a/application/account-management/WebApp/shared/components/AvatarButton.tsx
+++ b/application/account-management/WebApp/shared/components/AvatarButton.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@repo/ui/components/Button";
 import { Menu, MenuHeader, MenuItem, MenuSeparator, MenuTrigger } from "@repo/ui/components/Menu";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { LogOutIcon, SettingsIcon, UserIcon } from "lucide-react";
 import AccountModal from "@/shared/components/accountModals/AccountSettingsModal";
 import UserProfileModal from "@/shared/components/userModals/UserProfileModal";
@@ -15,6 +15,12 @@ export default function AvatarButton() {
   const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
   const [isDeleteAccountModalOpen, setIsDeleteAccountModalOpen] = useState(false);
   const userInfo = useUserInfo();
+
+  useEffect(() => {
+    if (userInfo?.isAuthenticated && (!userInfo.firstName || !userInfo.lastName)) {
+      setIsProfileModalOpen(true);
+    }
+  }, [userInfo]);
 
   if (!userInfo) return null;
 
@@ -69,6 +75,14 @@ export default function AvatarButton() {
         userId={userInfo.userId ?? ""}
       />
       <DeleteAccountModal isOpen={isDeleteAccountModalOpen} onOpenChange={setIsDeleteAccountModalOpen} />
+
+      {userInfo?.isAuthenticated && (
+        <UserProfileModal
+          isOpen={isProfileModalOpen}
+          onOpenChange={setIsProfileModalOpen}
+          userId={userInfo.userId ?? ""}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
### Summary & Motivation

Move the check for missing user profile information to the Avatar Button federated module, ensuring that the User Profile dialog is displayed whenever required information is missing, regardless of the self-contained system the user is attempting to access. This change centralizes the profile completeness check, so any self-contained system that includes the Avatar Button module will automatically prompt users to complete their profile if needed.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
