### PR TITLE
Ensure GitHub deployment fails if database migrations time out

### DIFF
--- a/application/shared-kernel/SharedKernel/Database/DatabaseMigrationService.cs
+++ b/application/shared-kernel/SharedKernel/Database/DatabaseMigrationService.cs
@@ -37,13 +37,8 @@ public class DatabaseMigrationService<T>(T dbContext, ILogger<DatabaseMigrationS
                 // Known error in Aspire, when SQL Server is not ready
                 Thread.Sleep(TimeSpan.FromSeconds(1));
             }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error occurred while applying database migrations.");
-                return;
-            }
         }
 
-        logger.LogError(" Migration failed after {MaxRetryCount} retries.", maxRetryCount);
+        throw new TimeoutException($"Database migration failed after {maxRetryCount} retries.");
     }
 }


### PR DESCRIPTION
### Summary & Motivation

Improve deployment reliability by ensuring that GitHub deployments to Azure fail if database migrations do not complete successfully. Previously, if a database migration failed, it only logged an error without impacting the deployment status. With this change, an exception is now thrown if a migration fails. This ensures that the GitHub Action deploying to Azure will fail, as it waits for the migration Worker to start up successfully before proceeding.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
