### PR TITLE
Enhance support for multiple projects, environment variables, and CSP in self-contained systems

### DIFF
--- a/application/AppHost/SslCertificateManager.cs
+++ b/application/AppHost/SslCertificateManager.cs
@@ -23,7 +23,7 @@ public static class SslCertificateManager
         var certificatePassword = config[certificatePasswordKey]
                                   ?? builder.CreateStablePassword(certificatePasswordKey).Resource.Value;
 
-        var certificateLocation = GetLocalhostCertificateLocation();
+        var certificateLocation = GetCertificateLocation("localhost");
         if (!IsValidCertificate(certificatePassword, certificateLocation))
         {
             CreateNewSelfSignedDeveloperCertificate(certificatePassword, certificateLocation);
@@ -32,10 +32,10 @@ public static class SslCertificateManager
         return certificatePassword;
     }
 
-    private static string GetLocalhostCertificateLocation()
+    private static string GetCertificateLocation(string domain)
     {
         var userFolder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        return $"{userFolder}/.aspnet/dev-certs/https/platformplatform.pfx";
+        return $"{userFolder}/.aspnet/dev-certs/https/{domain}.pfx";
     }
 
     private static bool IsValidCertificate(string? password, string certificateLocation)

--- a/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppConfiguration.cs
@@ -30,7 +30,7 @@ public class SinglePageAppConfiguration
     private string? _htmlTemplate;
     private string? _remoteEntryJsContent;
 
-    public SinglePageAppConfiguration(bool isDevelopment)
+    public SinglePageAppConfiguration(bool isDevelopment, params (string Key, string Value)[] environmentVariables)
     {
         // Environment variables are empty when generating EF Core migrations
         PublicUrl = Environment.GetEnvironmentVariable(PublicUrlKey) ?? string.Empty;
@@ -44,6 +44,10 @@ public class SinglePageAppConfiguration
             { ApplicationVersionKey, applicationVersion }
         };
 
+        foreach (var environmentVariable in environmentVariables)
+        {
+            StaticRuntimeEnvironment.Add(environmentVariable.Key, environmentVariable.Value);
+        }
 
         var staticRuntimeEnvironmentEncoded = JsonSerializer.Serialize(StaticRuntimeEnvironment, JsonHtmlEncodingOptions);
 

--- a/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppConfiguration.cs
@@ -164,8 +164,8 @@ public class SinglePageAppConfiguration
             $"script-src {trustedHosts} 'strict-dynamic' https:",
             $"script-src-elem {trustedHosts}",
             $"default-src {trustedHosts}",
-            $"connect-src {trustedHosts}",
-            $"img-src {trustedHosts} data:",
+            $"connect-src {trustedHosts} data:",
+            $"img-src {trustedHosts} data: blob:",
             "object-src 'none'",
             "base-uri 'none'"
             // "require-trusted-types-for 'script'"

--- a/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppFallbackExtensions.cs
+++ b/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppFallbackExtensions.cs
@@ -14,12 +14,15 @@ namespace PlatformPlatform.SharedKernel.SinglePageApp;
 
 public static class SinglePageAppFallbackExtensions
 {
-    public static IServiceCollection AddSinglePageAppFallback(this IServiceCollection services)
+    public static IServiceCollection AddSinglePageAppFallback(
+        this IServiceCollection services,
+        params (string Key, string Value)[] environmentVariables
+    )
     {
         return services.AddSingleton<SinglePageAppConfiguration>(serviceProvider =>
             {
                 var environment = serviceProvider.GetRequiredService<IWebHostEnvironment>();
-                return new SinglePageAppConfiguration(environment.IsDevelopment());
+                return new SinglePageAppConfiguration(environment.IsDevelopment(), environmentVariables);
             }
         );
     }


### PR DESCRIPTION
### Summary & Motivation

Enable self-contained systems to support multiple projects with repositories and MediatR commands and queries by updating `ApiDependencyConfiguration` and `SharedDependencyConfiguration` to accept `params Assembly[] assemblies`. This allows commands and queries from multiple projects to be seamlessly integrated within a single self-contained system.

Add support for injecting additional environment variables into the single-page application, enhancing customization and flexibility.

Update the Content Security Policy (CSP) to allow `data:` and `blob:` URLs, facilitating inline images and file uploads within the application.

Lastly, enhance `SslCertificateManager` in Aspire AppHost to support self-signed certificates for multiple domains, improving certificate management in development and testing environments.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
