### PR TITLE
Download gravatar images to blob storage to prevent browser warnings

### DIFF
--- a/application/account-management/Core/Database/DatabaseMigrations.cs
+++ b/application/account-management/Core/Database/DatabaseMigrations.cs
@@ -53,7 +53,7 @@ public sealed class DatabaseMigrations : Migration
                 Title = table.Column<string>("nvarchar(50)", nullable: true),
                 Role = table.Column<string>("varchar(20)", nullable: false),
                 EmailConfirmed = table.Column<bool>("bit", nullable: false),
-                Avatar = table.Column<string>("varchar(200)", nullable: false),
+                Avatar = table.Column<string>("varchar(150)", nullable: false),
                 Locale = table.Column<string>("varchar(5)", nullable: false)
             },
             constraints: table =>

--- a/application/account-management/Core/DependencyConfiguration.cs
+++ b/application/account-management/Core/DependencyConfiguration.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using PlatformPlatform.AccountManagement.Database;
 using PlatformPlatform.AccountManagement.Features.Authentication.Services;
+using PlatformPlatform.AccountManagement.Features.Users.Avatars;
+using PlatformPlatform.AccountManagement.Integrations.Gravatar;
 using PlatformPlatform.SharedKernel;
 using PlatformPlatform.SharedKernel.Authentication;
 
@@ -32,6 +34,8 @@ public static class DependencyConfiguration
         services.AddScoped<AuthenticationTokenGenerator>();
         services.AddScoped<AuthenticationTokenService>();
 
+        services.AddScoped<AvatarUpdater>();
+        services.AddScoped<GravatarClient>();
         services.AddHttpClient("Gravatar").ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler());
 
         return services;

--- a/application/account-management/Core/Features/Users/Avatars/AvatarUpdater.cs
+++ b/application/account-management/Core/Features/Users/Avatars/AvatarUpdater.cs
@@ -1,0 +1,39 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.DependencyInjection;
+using PlatformPlatform.AccountManagement.Features.Users.Domain;
+using PlatformPlatform.SharedKernel.Services;
+
+namespace PlatformPlatform.AccountManagement.Features.Users.Avatars;
+
+public sealed class AvatarUpdater(IUserRepository userRepository, [FromKeyedServices("avatars-storage")] BlobStorage blobStorage)
+{
+    private const string ContainerName = "avatars";
+
+    public async Task<bool> UpdateAvatar(User user, bool isGravatar, string contentType, Stream stream, CancellationToken cancellationToken)
+    {
+        var fileHash = await GetFileHash(stream, cancellationToken);
+        var blobName = $"{user.TenantId}/{user.Id}/{fileHash}.jpg";
+        var avatarUrl = $"/{ContainerName}/{blobName}";
+
+        if (user.Avatar.Url == avatarUrl && user.Avatar.IsGravatar != isGravatar)
+        {
+            return false;
+        }
+
+        await blobStorage.UploadAsync(ContainerName, blobName, contentType, stream, cancellationToken);
+
+        user.UpdateAvatar(avatarUrl, isGravatar);
+        userRepository.Update(user);
+
+        return true;
+    }
+
+    private static async Task<string> GetFileHash(Stream fileStream, CancellationToken cancellationToken)
+    {
+        using var sha1 = SHA1.Create();
+        var hashBytes = await sha1.ComputeHashAsync(fileStream, cancellationToken);
+        fileStream.Position = 0;
+        // This just needs to be unique for one user, who likely will ever only have one avatar, so 16 chars should be enough
+        return BitConverter.ToString(hashBytes).Replace("-", "")[..16].ToUpper();
+    }
+}

--- a/application/account-management/Core/Features/Users/Commands/UpdateAvatar.cs
+++ b/application/account-management/Core/Features/Users/Commands/UpdateAvatar.cs
@@ -1,11 +1,9 @@
-using System.Security.Cryptography;
 using FluentValidation;
 using JetBrains.Annotations;
-using Microsoft.Extensions.DependencyInjection;
+using PlatformPlatform.AccountManagement.Features.Users.Avatars;
 using PlatformPlatform.AccountManagement.Features.Users.Domain;
 using PlatformPlatform.AccountManagement.TelemetryEvents;
 using PlatformPlatform.SharedKernel.Cqrs;
-using PlatformPlatform.SharedKernel.Services;
 using PlatformPlatform.SharedKernel.TelemetryEvents;
 
 namespace PlatformPlatform.AccountManagement.Features.Users.Commands;
@@ -29,36 +27,23 @@ public sealed class UpdateAvatarValidator : AbstractValidator<UpdateAvatarComman
 
 public sealed class UpdateAvatarHandler(
     IUserRepository userRepository,
-    [FromKeyedServices("avatars-storage")] BlobStorage blobStorage,
+    AvatarUpdater avatarUpdater,
     ITelemetryEventsCollector events
 ) : IRequestHandler<UpdateAvatarCommand, Result>
 {
-    private const string ContainerName = "avatars";
-
     public async Task<Result> Handle(UpdateAvatarCommand command, CancellationToken cancellationToken)
     {
         var user = await userRepository.GetLoggedInUserAsync(cancellationToken);
-        if (user is null) return Result.BadRequest("User not found.");
+        if (user is null)
+        {
+            return Result.BadRequest("User not found.");
+        }
 
-        var fileHash = await GetFileHash(command.FileSteam, cancellationToken);
-        var blobName = $"{user.TenantId}/{user.Id}/{fileHash}.jpg";
-        await blobStorage.UploadAsync(ContainerName, blobName, command.ContentType, command.FileSteam, cancellationToken);
-
-        var avatarUrl = $"/{ContainerName}/{blobName}";
-        user.UpdateAvatar(avatarUrl);
-
-        userRepository.Update(user);
-
-        events.CollectEvent(new UserAvatarUpdated(command.ContentType, command.FileSteam.Length));
+        if (await avatarUpdater.UpdateAvatar(user, false, command.ContentType, command.FileSteam, cancellationToken))
+        {
+            events.CollectEvent(new UserAvatarUpdated(command.ContentType, command.FileSteam.Length));
+        }
 
         return Result.Success();
-    }
-
-    private static async Task<string> GetFileHash(Stream fileStream, CancellationToken cancellationToken)
-    {
-        var hashBytes = await SHA1.Create().ComputeHashAsync(fileStream, cancellationToken);
-        fileStream.Position = 0;
-        // This just need to be unique for one user, who likely will ever have one avatar, so 16 chars should be enough
-        return BitConverter.ToString(hashBytes).Replace("-", "")[..16].ToUpper();
     }
 }

--- a/application/account-management/Core/Features/Users/Domain/User.cs
+++ b/application/account-management/Core/Features/Users/Domain/User.cs
@@ -13,6 +13,7 @@ public sealed class User : AggregateRoot<UserId>, ITenantScopedEntity
         TenantId = tenantId;
         Role = role;
         EmailConfirmed = emailConfirmed;
+        Avatar = new Avatar();
     }
 
     public string Email
@@ -31,16 +32,15 @@ public sealed class User : AggregateRoot<UserId>, ITenantScopedEntity
 
     public bool EmailConfirmed { get; private set; }
 
-    public Avatar Avatar { get; private set; } = default!;
+    public Avatar Avatar { get; private set; }
 
     public string Locale { get; private set; } = string.Empty;
 
     public TenantId TenantId { get; }
 
-    public static User Create(TenantId tenantId, string email, UserRole role, bool emailConfirmed, string? gravatarUrl)
+    public static User Create(TenantId tenantId, string email, UserRole role, bool emailConfirmed)
     {
-        var avatar = new Avatar(gravatarUrl, IsGravatar: gravatarUrl is not null);
-        return new User(tenantId, email, role, emailConfirmed) { Avatar = avatar };
+        return new User(tenantId, email, role, emailConfirmed);
     }
 
     public void Update(string firstName, string lastName, string title)
@@ -65,9 +65,9 @@ public sealed class User : AggregateRoot<UserId>, ITenantScopedEntity
         Role = userRole;
     }
 
-    public void UpdateAvatar(string avatarUrl)
+    public void UpdateAvatar(string avatarUrl, bool isGravatar)
     {
-        Avatar = new Avatar(avatarUrl, Avatar.Version + 1);
+        Avatar = new Avatar(avatarUrl, Avatar.Version + 1, isGravatar);
     }
 
     public void RemoveAvatar()

--- a/application/account-management/Core/Integrations/Gravatar/GravatarClient.cs
+++ b/application/account-management/Core/Integrations/Gravatar/GravatarClient.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using PlatformPlatform.AccountManagement.Features.Users.Avatars;
+using PlatformPlatform.AccountManagement.Features.Users.Domain;
+using PlatformPlatform.AccountManagement.TelemetryEvents;
+using PlatformPlatform.SharedKernel.TelemetryEvents;
+
+namespace PlatformPlatform.AccountManagement.Integrations.Gravatar;
+
+public sealed class GravatarClient(
+    IHttpClientFactory httpClientFactory,
+    AvatarUpdater avatarUpdater,
+    ITelemetryEventsCollector events,
+    ILogger<GravatarClient> logger
+)
+{
+    public async Task DownloadGravatar(User user, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var hash = Convert.ToHexString(MD5.HashData(Encoding.ASCII.GetBytes(user.Email)));
+            var gravatarUrl = $"https://gravatar.com/avatar/{hash.ToLowerInvariant()}";
+
+            var gravatarHttpClient = httpClientFactory.CreateClient("Gravatar");
+            var response = await gravatarHttpClient.GetAsync(gravatarUrl, cancellationToken);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                logger.LogInformation("No Gravatar found for user {UserId}", user.Id);
+                return;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogError("Failed to fetch Gravatar for user {UserId}. Status Code: {StatusCode}", user.Id, response.StatusCode);
+                return;
+            }
+
+            var imageStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+
+            var contentType = response.Content.Headers.ContentType?.MediaType!;
+            if (await avatarUpdater.UpdateAvatar(user, true, contentType, imageStream, cancellationToken))
+            {
+                logger.LogInformation("Gravatar updated successfully for user {UserId}", user.Id);
+
+                events.CollectEvent(new GravatarUpdated(user.Id, imageStream.Length));
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Exception occurred while fetching Gravatar for user {UserId}", user.Id);
+        }
+    }
+}

--- a/application/account-management/Core/TelemetryEvents/TelemetryEvents.cs
+++ b/application/account-management/Core/TelemetryEvents/TelemetryEvents.cs
@@ -62,6 +62,9 @@ public sealed class UserAvatarRemoved()
 public sealed class UserAvatarUpdated(string contentType, long size)
     : TelemetryEvent(nameof(UserAvatarUpdated), ("ContentType", contentType), ("Size", size));
 
+public sealed class GravatarUpdated(UserId userId, long size)
+    : TelemetryEvent(nameof(UserAvatarUpdated), ("UserId", userId), ("Size", size));
+
 public sealed class UserCreated(TenantId tenantId, bool gravatarProfileFound)
     : TelemetryEvent(nameof(UserCreated), ("TenantId", tenantId), ("GravatarProfileFound", gravatarProfileFound));
 

--- a/application/account-management/Tests/Authentication/CompleteLoginTests.cs
+++ b/application/account-management/Tests/Authentication/CompleteLoginTests.cs
@@ -120,7 +120,7 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
             .PostAsJsonAsync($"/api/account-management/authentication/login/{loginId}/complete", command);
 
         // Assert
-        await response.ShouldHaveErrorStatusCode(HttpStatusCode.Forbidden, "To many attempts, please request a new code.");
+        await response.ShouldHaveErrorStatusCode(HttpStatusCode.Forbidden, "Too many attempts, please request a new code.");
 
         // Verify retry count increment and event collection
         var loginCompleted = Connection.ExecuteScalar("SELECT Completed FROM Logins WHERE Id = @id", new { id = loginId });

--- a/application/account-management/Tests/DatabaseSeeder.cs
+++ b/application/account-management/Tests/DatabaseSeeder.cs
@@ -14,7 +14,7 @@ public sealed class DatabaseSeeder
     {
         Tenant1 = Tenant.Create(new TenantId("tenant-1"), "owner@tenant-1.com");
         accountManagementDbContext.Tenants.AddRange(Tenant1);
-        User1 = User.Create(Tenant1.Id, "owner@tenant-1.com", UserRole.Owner, true, null);
+        User1 = User.Create(Tenant1.Id, "owner@tenant-1.com", UserRole.Owner, true);
         accountManagementDbContext.Users.AddRange(User1);
 
         accountManagementDbContext.SaveChanges();


### PR DESCRIPTION
### Summary & Motivation

Add logic to download Gravatar images to blob storage, addressing browser console warnings about "Tracking Prevention blocked" when loading assets from external sites. The Gravatar image is downloaded when a user is created and refreshed each time the user logs in.

To support this functionality, the logic for saving an avatar to blob storage has been refactored into a new, shared `AvatarUpdater` class. Additionally, a new `GravatarClient` has been created in a new `Infrastructure` namespace. This update demonstrates a method for extracting shared logic within a vertical-sliced architecture while adhering to the single responsibility principle.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
