### PR TITLE
Add support for changing and uploading avatars

### DIFF
--- a/application/account-management/Core/Features/Users/Avatars/AvatarUpdater.cs
+++ b/application/account-management/Core/Features/Users/Avatars/AvatarUpdater.cs
@@ -16,7 +16,7 @@ public sealed class AvatarUpdater(IUserRepository userRepository, [FromKeyedServ
         var blobName = $"{user.TenantId}/{user.Id}/{fileHash}.{fileExtension}";
         var avatarUrl = $"/{ContainerName}/{blobName}";
 
-        if (user.Avatar.Url == avatarUrl && user.Avatar.IsGravatar != isGravatar)
+        if (user.Avatar.Url == avatarUrl && user.Avatar.IsGravatar == isGravatar)
         {
             return false;
         }

--- a/application/account-management/Core/Features/Users/Avatars/AvatarUpdater.cs
+++ b/application/account-management/Core/Features/Users/Avatars/AvatarUpdater.cs
@@ -12,7 +12,8 @@ public sealed class AvatarUpdater(IUserRepository userRepository, [FromKeyedServ
     public async Task<bool> UpdateAvatar(User user, bool isGravatar, string contentType, Stream stream, CancellationToken cancellationToken)
     {
         var fileHash = await GetFileHash(stream, cancellationToken);
-        var blobName = $"{user.TenantId}/{user.Id}/{fileHash}.jpg";
+        var fileExtension = contentType.Split('/')[1];
+        var blobName = $"{user.TenantId}/{user.Id}/{fileHash}.{fileExtension}";
         var avatarUrl = $"/{ContainerName}/{blobName}";
 
         if (user.Avatar.Url == avatarUrl && user.Avatar.IsGravatar != isGravatar)

--- a/application/account-management/Core/Features/Users/Commands/UpdateAvatar.cs
+++ b/application/account-management/Core/Features/Users/Commands/UpdateAvatar.cs
@@ -16,12 +16,12 @@ public sealed class UpdateAvatarValidator : AbstractValidator<UpdateAvatarComman
     public UpdateAvatarValidator()
     {
         RuleFor(x => x.ContentType)
-            .Must(x => x == "image/jpeg")
-            .WithMessage(_ => "Image must be of type Jpeg.");
+            .Must(x => x is "image/jpeg" or "image/png" or "image/gif" or "image/webp") // Align with frontend
+            .WithMessage(_ => "Image must be of type JPEG, PNG, GIF, or WebP.");
 
         RuleFor(x => x.FileSteam.Length)
             .LessThanOrEqualTo(1024 * 1024)
-            .WithMessage(_ => "Image must be less than 1MB.");
+            .WithMessage(_ => "Image must be smaller than 1 MB");
     }
 }
 

--- a/application/account-management/Core/Integrations/Gravatar/GravatarClient.cs
+++ b/application/account-management/Core/Integrations/Gravatar/GravatarClient.cs
@@ -23,6 +23,8 @@ public sealed class GravatarClient(
             var gravatarUrl = $"https://gravatar.com/avatar/{hash.ToLowerInvariant()}";
 
             var gravatarHttpClient = httpClientFactory.CreateClient("Gravatar");
+            gravatarHttpClient.Timeout = TimeSpan.FromSeconds(5);
+
             var response = await gravatarHttpClient.GetAsync(gravatarUrl, cancellationToken);
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
@@ -46,9 +48,9 @@ public sealed class GravatarClient(
                 events.CollectEvent(new GravatarUpdated(user.Id, imageStream.Length));
             }
         }
-        catch (Exception ex)
+        catch (TaskCanceledException ex)
         {
-            logger.LogError(ex, "Exception occurred while fetching Gravatar for user {UserId}", user.Id);
+            logger.LogError(ex, "Timeout when fetching gravatar  for user {UserId}", user.Id);
         }
     }
 }

--- a/application/account-management/Core/Integrations/Gravatar/GravatarClient.cs
+++ b/application/account-management/Core/Integrations/Gravatar/GravatarClient.cs
@@ -20,7 +20,7 @@ public sealed class GravatarClient(
         try
         {
             var hash = Convert.ToHexString(MD5.HashData(Encoding.ASCII.GetBytes(user.Email)));
-            var gravatarUrl = $"https://gravatar.com/avatar/{hash.ToLowerInvariant()}";
+            var gravatarUrl = $"https://gravatar.com/avatar/{hash.ToLowerInvariant()}?d=404";
 
             var gravatarHttpClient = httpClientFactory.CreateClient("Gravatar");
             gravatarHttpClient.Timeout = TimeSpan.FromSeconds(5);

--- a/application/account-management/Core/Integrations/Gravatar/GravatarClient.cs
+++ b/application/account-management/Core/Integrations/Gravatar/GravatarClient.cs
@@ -1,25 +1,19 @@
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
-using PlatformPlatform.AccountManagement.Features.Users.Avatars;
-using PlatformPlatform.AccountManagement.Features.Users.Domain;
-using PlatformPlatform.AccountManagement.TelemetryEvents;
-using PlatformPlatform.SharedKernel.TelemetryEvents;
+using PlatformPlatform.SharedKernel.Domain;
 
 namespace PlatformPlatform.AccountManagement.Integrations.Gravatar;
 
-public sealed class GravatarClient(
-    IHttpClientFactory httpClientFactory,
-    AvatarUpdater avatarUpdater,
-    ITelemetryEventsCollector events,
-    ILogger<GravatarClient> logger
-)
+public sealed record Gravatar(Stream Stream, string ContentType);
+
+public sealed class GravatarClient(IHttpClientFactory httpClientFactory, ILogger<GravatarClient> logger)
 {
-    public async Task DownloadGravatar(User user, CancellationToken cancellationToken)
+    public async Task<Gravatar?> GetGravatar(UserId userId, string email, CancellationToken cancellationToken)
     {
         try
         {
-            var hash = Convert.ToHexString(MD5.HashData(Encoding.ASCII.GetBytes(user.Email)));
+            var hash = Convert.ToHexString(MD5.HashData(Encoding.ASCII.GetBytes(email)));
             var gravatarUrl = $"https://gravatar.com/avatar/{hash.ToLowerInvariant()}?d=404";
 
             var gravatarHttpClient = httpClientFactory.CreateClient("Gravatar");
@@ -28,29 +22,25 @@ public sealed class GravatarClient(
             var response = await gravatarHttpClient.GetAsync(gravatarUrl, cancellationToken);
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
-                logger.LogInformation("No Gravatar found for user {UserId}", user.Id);
-                return;
+                logger.LogInformation("No Gravatar found for user {UserId}", userId);
+                return null;
             }
 
             if (!response.IsSuccessStatusCode)
             {
-                logger.LogError("Failed to fetch Gravatar for user {UserId}. Status Code: {StatusCode}", user.Id, response.StatusCode);
-                return;
+                logger.LogError("Failed to fetch Gravatar for user {UserId}. Status Code: {StatusCode}", userId, response.StatusCode);
+                return null;
             }
 
-            var imageStream = await response.Content.ReadAsStreamAsync(cancellationToken);
-
-            var contentType = response.Content.Headers.ContentType?.MediaType!;
-            if (await avatarUpdater.UpdateAvatar(user, true, contentType, imageStream, cancellationToken))
-            {
-                logger.LogInformation("Gravatar updated successfully for user {UserId}", user.Id);
-
-                events.CollectEvent(new GravatarUpdated(user.Id, imageStream.Length));
-            }
+            return new Gravatar(
+                await response.Content.ReadAsStreamAsync(cancellationToken),
+                response.Content.Headers.ContentType?.MediaType!
+            );
         }
         catch (TaskCanceledException ex)
         {
-            logger.LogError(ex, "Timeout when fetching gravatar  for user {UserId}", user.Id);
+            logger.LogError(ex, "Timeout when fetching gravatar for user {UserId}", userId);
+            return null;
         }
     }
 }

--- a/application/account-management/WebApp/shared/components/userModals/UserProfileModal.tsx
+++ b/application/account-management/WebApp/shared/components/userModals/UserProfileModal.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useFormState } from "react-dom";
 import { FileTrigger, Form, Heading, Label } from "react-aria-components";
-import { XIcon } from "lucide-react";
+import { XIcon, CameraIcon } from "lucide-react";
 import { Button } from "@repo/ui/components/Button";
 import { Dialog } from "@repo/ui/components/Dialog";
 import { FormErrorMessage } from "@repo/ui/components/FormErrorMessage";
@@ -104,8 +104,12 @@ export default function UserProfileModal({ isOpen, onOpenChange, userId }: Reado
                 <Trans>Photo</Trans>
               </Label>
               <FileTrigger onSelect={onFileSelect}>
-                <Button variant="icon" className="rounded-full w-16 h-16 mb-3">
-                  <img src={data.avatarUrl ?? ""} alt={t`User profile`} className="rounded-full" />
+                <Button variant="icon" className="rounded-full w-16 h-16 mb-3 bg-secondary hover:bg-secondary/80">
+                  {data.avatarUrl == null ? (
+                    <img src={data.avatarUrl ?? ""} className="rounded-full" alt={t`Change user avatar`} />
+                  ) : (
+                    <CameraIcon className="size-10 text-secondary-foreground" aria-label={t`Change user avatar`} />
+                  )}
                 </Button>
               </FileTrigger>
               {file}

--- a/application/account-management/WebApp/shared/components/userModals/UserProfileModal.tsx
+++ b/application/account-management/WebApp/shared/components/userModals/UserProfileModal.tsx
@@ -13,7 +13,7 @@ import { api } from "@/shared/lib/api/client";
 import { t, Trans } from "@lingui/macro";
 
 const MAX_FILE_SIZE = 1024 * 1024; // 1MB in bytes
-const ALLOWED_FILE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+const ALLOWED_FILE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"]; // Align with backend
 
 type ProfileModalProps = {
   isOpen: boolean;

--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -52,6 +52,9 @@ msgstr "Kan du ikke finde din kode? Tjek din spammappe."
 msgid "Cancel"
 msgstr "Annuller"
 
+msgid "Change user avatar"
+msgstr "Skift brugeravatar"
+
 msgid "Continue"
 msgstr "Fortsæt"
 

--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -31,6 +31,9 @@ msgstr "Aktive brugere"
 msgid "Active users in the past 30 days"
 msgstr "Aktive brugere i de sidste 30 dage"
 
+msgid "Add avatar"
+msgstr "Tilføj avatar"
+
 msgid "Add more in the Users menu"
 msgstr "Tilføj flere i brugermenuen"
 
@@ -52,8 +55,8 @@ msgstr "Kan du ikke finde din kode? Tjek din spammappe."
 msgid "Cancel"
 msgstr "Annuller"
 
-msgid "Change user avatar"
-msgstr "Skift brugeravatar"
+msgid "Change avatar options"
+msgstr "Skift avatarindstillinger"
 
 msgid "Continue"
 msgstr "Fortsæt"
@@ -71,7 +74,7 @@ msgid "Delete Account"
 msgstr "Slet konto"
 
 msgid "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."
-msgstr "Sletning af kontoen og alle tilknyttede data. Denne handling kan ikke fortrydes, så fortsæt venligst med forsigtighed."
+msgstr "Sletning af kontoen og alle tilknyttede data. Denne handling kan ikke fortrydes, så fortsæt med forsigtighed."
 
 msgid "Didn't receive the code? Resend"
 msgstr "Modtog du ikke koden? Send igen"
@@ -139,6 +142,9 @@ msgstr "Hej! Velkommen tilbage"
 msgid "Home"
 msgstr "Hjem"
 
+msgid "Image must be smaller than 1 MB."
+msgstr "Billedet skal være mindre end 1 MB."
+
 msgid "Invite User"
 msgstr "Inviter bruger"
 
@@ -194,10 +200,16 @@ msgid "Photo"
 msgstr "Foto"
 
 msgid "Please check your email for a verification code sent to <0>{email}</0>"
-msgstr "Tjek venligst din e-mail for en bekræftelseskode sendt til <0>{email}</0>"
+msgstr "Tjek din e-mail for en bekræftelseskode sendt til <0>{email}</0>"
+
+msgid "Please select a JPEG, PNG, GIF, or WebP image."
+msgstr "Vælg et JPEG-, PNG-, GIF- eller WebP-billede."
 
 msgid "Powered by"
 msgstr "Drevet af"
+
+msgid "Preview avatar"
+msgstr "Forhåndsvisning af avatar"
 
 msgid "Previous"
 msgstr "Forrige"
@@ -207,6 +219,9 @@ msgstr "Fortrolighedspolitikker"
 
 msgid "Region"
 msgstr "Region"
+
+msgid "Remove photo"
+msgstr "Fjern foto"
 
 msgid "Role"
 msgstr "Rolle"
@@ -258,6 +273,9 @@ msgstr "Prøv igen"
 
 msgid "Update your photo and personal details here."
 msgstr "Opdater dit foto og dine personlige oplysninger her."
+
+msgid "Upload photo"
+msgstr "Upload foto"
 
 msgid "User profile"
 msgstr "Brugerprofil"

--- a/application/account-management/WebApp/shared/translations/locale/en-US.po
+++ b/application/account-management/WebApp/shared/translations/locale/en-US.po
@@ -52,6 +52,9 @@ msgstr "Can't find your code? Check your spam folder."
 msgid "Cancel"
 msgstr "Cancel"
 
+msgid "Change user avatar"
+msgstr "Change user avatar"
+
 msgid "Continue"
 msgstr "Continue"
 

--- a/application/account-management/WebApp/shared/translations/locale/en-US.po
+++ b/application/account-management/WebApp/shared/translations/locale/en-US.po
@@ -31,6 +31,9 @@ msgstr "Active Users"
 msgid "Active users in the past 30 days"
 msgstr "Active users in the past 30 days"
 
+msgid "Add avatar"
+msgstr "Add avatar"
+
 msgid "Add more in the Users menu"
 msgstr "Add more in the Users menu"
 
@@ -52,8 +55,8 @@ msgstr "Can't find your code? Check your spam folder."
 msgid "Cancel"
 msgstr "Cancel"
 
-msgid "Change user avatar"
-msgstr "Change user avatar"
+msgid "Change avatar options"
+msgstr "Change avatar options"
 
 msgid "Continue"
 msgstr "Continue"
@@ -139,6 +142,9 @@ msgstr "Hi! Welcome back"
 msgid "Home"
 msgstr "Home"
 
+msgid "Image must be smaller than 1 MB."
+msgstr "Image must be smaller than 1 MB."
+
 msgid "Invite User"
 msgstr "Invite User"
 
@@ -196,8 +202,14 @@ msgstr "Photo"
 msgid "Please check your email for a verification code sent to <0>{email}</0>"
 msgstr "Please check your email for a verification code sent to <0>{email}</0>"
 
+msgid "Please select a JPEG, PNG, GIF, or WebP image."
+msgstr "Please select a JPEG, PNG, GIF, or WebP image."
+
 msgid "Powered by"
 msgstr "Powered by"
+
+msgid "Preview avatar"
+msgstr "Preview avatar"
 
 msgid "Previous"
 msgstr "Previous"
@@ -207,6 +219,9 @@ msgstr "Privacy Policies"
 
 msgid "Region"
 msgstr "Region"
+
+msgid "Remove photo"
+msgstr "Remove photo"
 
 msgid "Role"
 msgstr "Role"
@@ -258,6 +273,9 @@ msgstr "Try again"
 
 msgid "Update your photo and personal details here."
 msgstr "Update your photo and personal details here."
+
+msgid "Upload photo"
+msgstr "Upload photo"
 
 msgid "User profile"
 msgstr "User profile"

--- a/application/account-management/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/account-management/WebApp/shared/translations/locale/nl-NL.po
@@ -52,6 +52,9 @@ msgstr "Kun je je code niet vinden? Controleer je spammap."
 msgid "Cancel"
 msgstr "Annuleren"
 
+msgid "Change user avatar"
+msgstr "Gebruikersavatar wijzigen"
+
 msgid "Continue"
 msgstr "Verder"
 

--- a/application/account-management/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/account-management/WebApp/shared/translations/locale/nl-NL.po
@@ -31,6 +31,9 @@ msgstr "Actieve gebruikers"
 msgid "Active users in the past 30 days"
 msgstr "Actieve gebruikers in de afgelopen 30 dagen"
 
+msgid "Add avatar"
+msgstr "Avatar toevoegen"
+
 msgid "Add more in the Users menu"
 msgstr "Nieuwe toevoegen via het gebruikersmenu"
 
@@ -52,8 +55,8 @@ msgstr "Kun je je code niet vinden? Controleer je spammap."
 msgid "Cancel"
 msgstr "Annuleren"
 
-msgid "Change user avatar"
-msgstr "Gebruikersavatar wijzigen"
+msgid "Change avatar options"
+msgstr "Opties voor avatar wijzigen"
 
 msgid "Continue"
 msgstr "Verder"
@@ -139,6 +142,9 @@ msgstr "Hallo! Welkom terug"
 msgid "Home"
 msgstr "Home"
 
+msgid "Image must be smaller than 1 MB."
+msgstr "Afbeelding moet kleiner zijn dan 1 MB."
+
 msgid "Invite User"
 msgstr "Gebruiker uitnodigen"
 
@@ -196,8 +202,14 @@ msgstr "Foto"
 msgid "Please check your email for a verification code sent to <0>{email}</0>"
 msgstr "Controleer je e-mail voor een verificatiecode verzonden naar <0>{email}</0>"
 
+msgid "Please select a JPEG, PNG, GIF, or WebP image."
+msgstr "Selecteer een JPEG-, PNG-, GIF- of WebP-afbeelding."
+
 msgid "Powered by"
 msgstr "Mogelijk gemaakt door"
+
+msgid "Preview avatar"
+msgstr "Voorbeeld avatar"
 
 msgid "Previous"
 msgstr "Vorige"
@@ -207,6 +219,9 @@ msgstr "Privacybeleid"
 
 msgid "Region"
 msgstr "Regio"
+
+msgid "Remove photo"
+msgstr "Foto verwijderen"
 
 msgid "Role"
 msgstr "Rol"
@@ -258,6 +273,9 @@ msgstr "Probeer opnieuw"
 
 msgid "Update your photo and personal details here."
 msgstr "Werk je foto en persoonlijke gegevens hier bij."
+
+msgid "Upload photo"
+msgstr "Foto uploaden"
 
 msgid "User profile"
 msgstr "Gebruikersprofiel"

--- a/application/shared-kernel/SharedKernel/Persistence/RepositoryBase.cs
+++ b/application/shared-kernel/SharedKernel/Persistence/RepositoryBase.cs
@@ -41,17 +41,10 @@ public abstract class RepositoryBase<T, TId>(DbContext context)
     {
         ArgumentNullException.ThrowIfNull(aggregate);
 
-        var existingEntity = DbSet.Find(aggregate.Id);
+        var existingEntity = context.ChangeTracker.Entries<T>().SingleOrDefault(e => e.Entity.Id.Equals(aggregate.Id));
         if (existingEntity is not null)
         {
-            var entry = DbSet.Entry(existingEntity);
-
-            if (entry.State == EntityState.Detached)
-            {
-                DbSet.Attach(existingEntity);
-            }
-
-            entry.CurrentValues.SetValues(aggregate);
+            existingEntity.CurrentValues.SetValues(aggregate);
             return;
         }
 

--- a/application/shared-webapp/infrastructure/api/PlatformApiClient.ts
+++ b/application/shared-webapp/infrastructure/api/PlatformApiClient.ts
@@ -63,6 +63,15 @@ export function createPlatformApiClient<
               options as OperationRequestBody<Paths[Path]["post"]>
             );
           };
+        case "uploadFile":
+          return <Path extends PathsWithMethod<Paths, "post">>(url: Path, file: File) => {
+            const formData = new FormData();
+            formData.append("file", file);
+
+            return createClientMethodWithProblemDetails(client.POST)(url, { body: formData } as OperationRequestBody<
+              Paths[Path]["post"]
+            >);
+          };
         case "put":
           return <Path extends PathsWithMethod<Paths, "put">>(
             url: Path,
@@ -112,6 +121,11 @@ type PlatformApiClient<Paths extends {}, Media extends MediaType = MediaType> = 
   put: ClientMethodWithProblemDetails<Paths, "put", Media>;
   /** Call a POST endpoint */
   post: ClientMethodWithProblemDetails<Paths, "post", Media>;
+  /** Call a POST endpoint  that accepts multipart/form-data */
+  uploadFile: <Path extends PathsWithMethod<Paths, "post">>(
+    url: Path,
+    file: File
+  ) => ReturnType<ClientMethodWithProblemDetails<Paths, "post", Media>>;
   /** Call a DELETE endpoint */
   delete: ClientMethodWithProblemDetails<Paths, "delete", Media>;
   /** Call a OPTIONS endpoint */


### PR DESCRIPTION
### Summary & Motivation

Introduce functionality allowing users to change their avatars, with an option to upload a new avatar when saving their User Profile. Supported formats include JPEG, PNG, GIF, and WebP, providing users with flexibility in avatar choices.

Address several issues with Gravatar handling: users without Gravatars now correctly avoid default Gravatar images, and the system gracefully handles timeouts when fetching Gravatars, returning a `Not Found` status if an image is missing. Additionally, the user profile no longer displays a broken image for users without an avatar.

The recently introduced `GravatarClient` has been decoupled from the Users feature, enabling more modular use across the application.

To streamline avatar uploads, a strongly-typed `api.uploadFile` method has been implemented, enhancing type safety and usability.

Lastly, an issue in `RepositoryBase.Update` has been fixed to prevent unnecessary entity fetching during updates, improving efficiency.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
