### PR TITLE
Enhance Application Insights tracking with user-specific properties and simplified event naming

### DIFF
--- a/application/account-management/Core/Features/Authentication/Commands/Logout.cs
+++ b/application/account-management/Core/Features/Authentication/Commands/Logout.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Http;
 using PlatformPlatform.AccountManagement.Features.Authentication.Services;
 using PlatformPlatform.AccountManagement.TelemetryEvents;
 using PlatformPlatform.SharedKernel.Cqrs;
-using PlatformPlatform.SharedKernel.Domain;
 using PlatformPlatform.SharedKernel.TelemetryEvents;
 
 namespace PlatformPlatform.AccountManagement.Features.Authentication.Commands;
@@ -27,13 +26,13 @@ public sealed class LogoutHandler(
 
         authenticationTokenService.Logout();
 
-        if (userIdentifier is null || !UserId.TryParse(userIdentifier.Value, out var userId))
+        if (userIdentifier is null)
         {
             logger.LogWarning("No user identifier found in claims.");
         }
         else
         {
-            events.CollectEvent(new Logout(userId));
+            events.CollectEvent(new Logout());
         }
 
         return Task.FromResult(Result.Success());

--- a/application/account-management/Core/Features/Authentication/Commands/RefreshAuthenticationTokens.cs
+++ b/application/account-management/Core/Features/Authentication/Commands/RefreshAuthenticationTokens.cs
@@ -54,7 +54,7 @@ public sealed class RefreshAuthenticationTokensCommandHandler(
         // TODO: Check if the refreshChainTokenId exists in the database and if the refreshTokenId and version are valid
 
         authenticationTokenService.RefreshAuthenticationTokens(user, refreshChainTokenId, refreshTokenVersion, refreshTokenExpires);
-        events.CollectEvent(new AuthenticationTokensRefreshed(user.Id));
+        events.CollectEvent(new AuthenticationTokensRefreshed());
 
         return Result.Success();
     }

--- a/application/account-management/Core/Features/Signups/Commands/CompleteSignup.cs
+++ b/application/account-management/Core/Features/Signups/Commands/CompleteSignup.cs
@@ -46,7 +46,7 @@ public sealed class CompleteSignupHandler(
         {
             signup.RegisterInvalidPasswordAttempt();
             signupRepository.Update(signup);
-            events.CollectEvent(new SignupBlocked(signup.RetryCount));
+            events.CollectEvent(new SignupBlocked(signup.TenantId, signup.RetryCount));
             return Result.Forbidden("To many attempts, please request a new code.", true);
         }
 
@@ -54,14 +54,14 @@ public sealed class CompleteSignupHandler(
         {
             signup.RegisterInvalidPasswordAttempt();
             signupRepository.Update(signup);
-            events.CollectEvent(new SignupFailed(signup.RetryCount));
+            events.CollectEvent(new SignupFailed(signup.TenantId, signup.RetryCount));
             return Result.BadRequest("The code is wrong or no longer valid.", true);
         }
 
         var signupTimeInSeconds = (TimeProvider.System.GetUtcNow() - signup.CreatedAt).TotalSeconds;
         if (signup.HasExpired())
         {
-            events.CollectEvent(new SignupExpired((int)signupTimeInSeconds));
+            events.CollectEvent(new SignupExpired(signup.TenantId, (int)signupTimeInSeconds));
             return Result.BadRequest("The code is no longer valid, please request a new code.", true);
         }
 

--- a/application/account-management/Core/Features/Tenants/Commands/UpdateTenant.cs
+++ b/application/account-management/Core/Features/Tenants/Commands/UpdateTenant.cs
@@ -39,7 +39,7 @@ public sealed class UpdateTenantHandler(ITenantRepository tenantRepository, ITel
         tenant.Update(command.Name);
         tenantRepository.Update(tenant);
 
-        events.CollectEvent(new TenantUpdated(tenant.Id));
+        events.CollectEvent(new TenantUpdated());
 
         return Result.Success();
     }

--- a/application/account-management/Core/Features/Users/Commands/ChangeLocale.cs
+++ b/application/account-management/Core/Features/Users/Commands/ChangeLocale.cs
@@ -33,7 +33,7 @@ public sealed class ChangeLocaleHandler(IUserRepository userRepository, ITelemet
         user.ChangeLocale(command.Locale);
         userRepository.Update(user);
 
-        events.CollectEvent(new UserLocaleChanged(user.Id, oldLocale, command.Locale));
+        events.CollectEvent(new UserLocaleChanged(oldLocale, command.Locale));
 
         return Result.Success();
     }

--- a/application/account-management/Core/Features/Users/Commands/ChangeUserRole.cs
+++ b/application/account-management/Core/Features/Users/Commands/ChangeUserRole.cs
@@ -28,7 +28,7 @@ public sealed class ChangeUserRoleHandler(IUserRepository userRepository, ITelem
         user.ChangeUserRole(command.UserRole);
         userRepository.Update(user);
 
-        events.CollectEvent(new UserRoleChanged(oldUserRole, command.UserRole));
+        events.CollectEvent(new UserRoleChanged(user.Id, oldUserRole, command.UserRole));
 
         return Result.Success();
     }

--- a/application/account-management/Core/Features/Users/Commands/CreateUser.cs
+++ b/application/account-management/Core/Features/Users/Commands/CreateUser.cs
@@ -51,10 +51,10 @@ public sealed class CreateUserHandler(
         if (gravatar is not null)
         {
             await avatarUpdater.UpdateAvatar(user, true, gravatar.ContentType, gravatar.Stream, cancellationToken);
-            events.CollectEvent(new GravatarUpdated(user.Id, gravatar.Stream.Length));
+            events.CollectEvent(new GravatarUpdated(gravatar.Stream.Length));
         }
 
-        events.CollectEvent(new UserCreated(user.TenantId, user.Avatar.IsGravatar));
+        events.CollectEvent(new UserCreated(user.Id, user.Avatar.IsGravatar));
 
         return user.Id;
     }

--- a/application/account-management/Core/Features/Users/Commands/DeleteUser.cs
+++ b/application/account-management/Core/Features/Users/Commands/DeleteUser.cs
@@ -20,7 +20,7 @@ public sealed class DeleteUserHandler(IUserRepository userRepository, ITelemetry
 
         userRepository.Remove(user);
 
-        events.CollectEvent(new UserDeleted());
+        events.CollectEvent(new UserDeleted(user.Id));
 
         return Result.Success();
     }

--- a/application/account-management/Core/Features/Users/Commands/InviteUser.cs
+++ b/application/account-management/Core/Features/Users/Commands/InviteUser.cs
@@ -42,9 +42,9 @@ public sealed class InviteUserHandler(
             return Result.Forbidden("Only owners are allowed to invite other users.");
         }
 
-        await mediator.Send(new CreateUserCommand(executionContext.TenantId!, command.Email, UserRole.Member, false), cancellationToken);
+        var result = await mediator.Send(new CreateUserCommand(executionContext.TenantId!, command.Email, UserRole.Member, false), cancellationToken);
 
-        events.CollectEvent(new UserInvited());
+        events.CollectEvent(new UserInvited(result.Value!));
 
         var loginPath = $"{Environment.GetEnvironmentVariable(SinglePageAppConfiguration.PublicUrlKey)}/login";
         var inviter = $"{executionContext.UserInfo.FirstName} {executionContext.UserInfo.LastName}".Trim();

--- a/application/account-management/Core/TelemetryEvents/TelemetryEvents.cs
+++ b/application/account-management/Core/TelemetryEvents/TelemetryEvents.cs
@@ -12,76 +12,76 @@ namespace PlatformPlatform.AccountManagement.TelemetryEvents;
 /// are collected with each telemetry event. Since missing or bad data cannot be fixed, it is important to have a good
 /// data quality from the start.
 public sealed class AuthenticationTokensRefreshed(UserId userId)
-    : TelemetryEvent(nameof(AuthenticationTokensRefreshed), ("UserId", userId));
+    : TelemetryEvent(("UserId", userId));
 
 public sealed class LoginBlocked(int retryCount)
-    : TelemetryEvent(nameof(LoginBlocked), ("RetryCount", retryCount));
+    : TelemetryEvent(("RetryCount", retryCount));
 
 public sealed class LoginCompleted(UserId userId, int loginTimeInSeconds)
-    : TelemetryEvent(nameof(LoginCompleted), ("UserId", userId), ("LoginTimeInSeconds", loginTimeInSeconds));
+    : TelemetryEvent(("UserId", userId), ("LoginTimeInSeconds", loginTimeInSeconds));
 
 public sealed class LoginExpired(int secondsFromCreation)
-    : TelemetryEvent(nameof(LoginExpired), ("SecondsFromCreation", secondsFromCreation));
+    : TelemetryEvent(("SecondsFromCreation", secondsFromCreation));
 
 public sealed class LoginFailed(int retryCount)
-    : TelemetryEvent(nameof(LoginFailed), ("RetryCount", retryCount));
+    : TelemetryEvent(("RetryCount", retryCount));
 
 public sealed class LoginStarted(UserId userId)
-    : TelemetryEvent(nameof(LoginStarted), ("UserId", userId));
+    : TelemetryEvent(("UserId", userId));
 
 public sealed class Logout(UserId userId)
-    : TelemetryEvent(nameof(Logout), ("UserId", userId));
+    : TelemetryEvent(("UserId", userId));
 
 public sealed class SignupBlocked(int retryCount)
-    : TelemetryEvent(nameof(SignupBlocked), ("RetryCount", retryCount));
+    : TelemetryEvent(("RetryCount", retryCount));
 
 public sealed class SignupCompleted(TenantId tenantId, int signupTimeInSeconds)
-    : TelemetryEvent(nameof(SignupCompleted), ("TenantId", tenantId), ("SignupTimeInSeconds", signupTimeInSeconds));
+    : TelemetryEvent(("TenantId", tenantId), ("SignupTimeInSeconds", signupTimeInSeconds));
 
 public sealed class SignupExpired(int secondsFromCreation)
-    : TelemetryEvent(nameof(SignupExpired), ("SecondsFromCreation", secondsFromCreation));
+    : TelemetryEvent(("SecondsFromCreation", secondsFromCreation));
 
 public sealed class SignupFailed(int retryCount)
-    : TelemetryEvent(nameof(SignupFailed), ("RetryCount", retryCount));
+    : TelemetryEvent(("RetryCount", retryCount));
 
 public sealed class SignupStarted(TenantId tenantId)
-    : TelemetryEvent(nameof(SignupStarted), ("TenantId", tenantId));
+    : TelemetryEvent(("TenantId", tenantId));
 
 public sealed class TenantCreated(TenantId tenantId, TenantState state)
-    : TelemetryEvent(nameof(TenantCreated), ("TenantId", tenantId), ("TenantState", state));
+    : TelemetryEvent(("TenantId", tenantId), ("TenantState", state));
 
 public sealed class TenantDeleted(TenantId tenantId, TenantState tenantState)
-    : TelemetryEvent(nameof(TenantDeleted), ("TenantId", tenantId), ("TenantState", tenantState));
+    : TelemetryEvent(("TenantId", tenantId), ("TenantState", tenantState));
 
 public sealed class TenantUpdated(TenantId tenantId)
-    : TelemetryEvent(nameof(TenantUpdated), ("TenantId", tenantId));
+    : TelemetryEvent(("TenantId", tenantId));
 
-public sealed class UserAvatarRemoved()
-    : TelemetryEvent(nameof(UserAvatarUpdated));
+public sealed class UserAvatarRemoved
+    : TelemetryEvent;
 
 public sealed class UserAvatarUpdated(string contentType, long size)
-    : TelemetryEvent(nameof(UserAvatarUpdated), ("ContentType", contentType), ("Size", size));
+    : TelemetryEvent(("ContentType", contentType), ("Size", size));
 
 public sealed class GravatarUpdated(UserId userId, long size)
-    : TelemetryEvent(nameof(UserAvatarUpdated), ("UserId", userId), ("Size", size));
+    : TelemetryEvent(("UserId", userId), ("Size", size));
 
 public sealed class UserCreated(TenantId tenantId, bool gravatarProfileFound)
-    : TelemetryEvent(nameof(UserCreated), ("TenantId", tenantId), ("GravatarProfileFound", gravatarProfileFound));
+    : TelemetryEvent(("TenantId", tenantId), ("GravatarProfileFound", gravatarProfileFound));
 
-public sealed class UserDeleted()
-    : TelemetryEvent(nameof(UserDeleted));
+public sealed class UserDeleted
+    : TelemetryEvent;
 
 public sealed class UserInviteAccepted(UserId userId, int inviteAcceptedTimeInMinutes)
-    : TelemetryEvent(nameof(UserInviteAccepted), ("UserId", userId), ("InviteAcceptedTimeInMinutes", inviteAcceptedTimeInMinutes));
+    : TelemetryEvent(("UserId", userId), ("InviteAcceptedTimeInMinutes", inviteAcceptedTimeInMinutes));
 
-public sealed class UserInvited()
-    : TelemetryEvent(nameof(UserInvited));
+public sealed class UserInvited
+    : TelemetryEvent;
 
 public sealed class UserLocaleChanged(UserId userId, string oldLocale, string newLocale)
-    : TelemetryEvent(nameof(UserLocaleChanged), ("UserId", userId), ("OldLocale", oldLocale), ("NewLocale", newLocale));
+    : TelemetryEvent(("UserId", userId), ("OldLocale", oldLocale), ("NewLocale", newLocale));
 
 public sealed class UserRoleChanged(UserRole fromRole, UserRole toRole)
-    : TelemetryEvent(nameof(UserRoleChanged), ("FromRole", fromRole), ("ToRole", toRole));
+    : TelemetryEvent(("FromRole", fromRole), ("ToRole", toRole));
 
-public sealed class UserUpdated()
-    : TelemetryEvent(nameof(UserUpdated));
+public sealed class UserUpdated
+    : TelemetryEvent;

--- a/application/account-management/Core/TelemetryEvents/TelemetryEvents.cs
+++ b/application/account-management/Core/TelemetryEvents/TelemetryEvents.cs
@@ -11,38 +11,38 @@ namespace PlatformPlatform.AccountManagement.TelemetryEvents;
 /// This particular includes the naming of the telemetry events (which should be in past tense) and the properties that
 /// are collected with each telemetry event. Since missing or bad data cannot be fixed, it is important to have a good
 /// data quality from the start.
-public sealed class AuthenticationTokensRefreshed(UserId userId)
-    : TelemetryEvent(("UserId", userId));
+public sealed class AuthenticationTokensRefreshed
+    : TelemetryEvent;
 
-public sealed class LoginBlocked(int retryCount)
-    : TelemetryEvent(("RetryCount", retryCount));
+public sealed class LoginBlocked(UserId userId, int retryCount)
+    : TelemetryEvent(("UserId", userId), ("RetryCount", retryCount));
 
 public sealed class LoginCompleted(UserId userId, int loginTimeInSeconds)
     : TelemetryEvent(("UserId", userId), ("LoginTimeInSeconds", loginTimeInSeconds));
 
-public sealed class LoginExpired(int secondsFromCreation)
-    : TelemetryEvent(("SecondsFromCreation", secondsFromCreation));
+public sealed class LoginExpired(UserId userId, int secondsFromCreation)
+    : TelemetryEvent(("UserId", userId), ("SecondsFromCreation", secondsFromCreation));
 
-public sealed class LoginFailed(int retryCount)
-    : TelemetryEvent(("RetryCount", retryCount));
+public sealed class LoginFailed(UserId userId, int retryCount)
+    : TelemetryEvent(("UserId", userId), ("RetryCount", retryCount));
 
 public sealed class LoginStarted(UserId userId)
     : TelemetryEvent(("UserId", userId));
 
-public sealed class Logout(UserId userId)
-    : TelemetryEvent(("UserId", userId));
+public sealed class Logout
+    : TelemetryEvent;
 
-public sealed class SignupBlocked(int retryCount)
-    : TelemetryEvent(("RetryCount", retryCount));
+public sealed class SignupBlocked(TenantId tenantId, int retryCount)
+    : TelemetryEvent(("TenantId", tenantId), ("RetryCount", retryCount));
 
 public sealed class SignupCompleted(TenantId tenantId, int signupTimeInSeconds)
     : TelemetryEvent(("TenantId", tenantId), ("SignupTimeInSeconds", signupTimeInSeconds));
 
-public sealed class SignupExpired(int secondsFromCreation)
-    : TelemetryEvent(("SecondsFromCreation", secondsFromCreation));
+public sealed class SignupExpired(TenantId tenantId, int secondsFromCreation)
+    : TelemetryEvent(("TenantId", tenantId), ("SecondsFromCreation", secondsFromCreation));
 
-public sealed class SignupFailed(int retryCount)
-    : TelemetryEvent(("RetryCount", retryCount));
+public sealed class SignupFailed(TenantId tenantId, int retryCount)
+    : TelemetryEvent(("TenantId", tenantId), ("RetryCount", retryCount));
 
 public sealed class SignupStarted(TenantId tenantId)
     : TelemetryEvent(("TenantId", tenantId));
@@ -53,8 +53,8 @@ public sealed class TenantCreated(TenantId tenantId, TenantState state)
 public sealed class TenantDeleted(TenantId tenantId, TenantState tenantState)
     : TelemetryEvent(("TenantId", tenantId), ("TenantState", tenantState));
 
-public sealed class TenantUpdated(TenantId tenantId)
-    : TelemetryEvent(("TenantId", tenantId));
+public sealed class TenantUpdated
+    : TelemetryEvent;
 
 public sealed class UserAvatarRemoved
     : TelemetryEvent;
@@ -62,26 +62,26 @@ public sealed class UserAvatarRemoved
 public sealed class UserAvatarUpdated(string contentType, long size)
     : TelemetryEvent(("ContentType", contentType), ("Size", size));
 
-public sealed class GravatarUpdated(UserId userId, long size)
-    : TelemetryEvent(("UserId", userId), ("Size", size));
+public sealed class GravatarUpdated(long size)
+    : TelemetryEvent(("Size", size));
 
-public sealed class UserCreated(TenantId tenantId, bool gravatarProfileFound)
-    : TelemetryEvent(("TenantId", tenantId), ("GravatarProfileFound", gravatarProfileFound));
+public sealed class UserCreated(UserId userId, bool gravatarProfileFound)
+    : TelemetryEvent(("UserId", userId), ("GravatarProfileFound", gravatarProfileFound));
 
-public sealed class UserDeleted
-    : TelemetryEvent;
+public sealed class UserDeleted(UserId userId)
+    : TelemetryEvent(("UserId", userId));
 
 public sealed class UserInviteAccepted(UserId userId, int inviteAcceptedTimeInMinutes)
     : TelemetryEvent(("UserId", userId), ("InviteAcceptedTimeInMinutes", inviteAcceptedTimeInMinutes));
 
-public sealed class UserInvited
-    : TelemetryEvent;
+public sealed class UserInvited(UserId userId)
+    : TelemetryEvent(("UserId", userId));
 
-public sealed class UserLocaleChanged(UserId userId, string oldLocale, string newLocale)
-    : TelemetryEvent(("UserId", userId), ("OldLocale", oldLocale), ("NewLocale", newLocale));
+public sealed class UserLocaleChanged(string oldLocale, string newLocale)
+    : TelemetryEvent(("OldLocale", oldLocale), ("NewLocale", newLocale));
 
-public sealed class UserRoleChanged(UserRole fromRole, UserRole toRole)
-    : TelemetryEvent(("FromRole", fromRole), ("ToRole", toRole));
+public sealed class UserRoleChanged(UserId userId, UserRole fromRole, UserRole toRole)
+    : TelemetryEvent(("UserId", userId), ("FromRole", fromRole), ("ToRole", toRole));
 
 public sealed class UserUpdated
     : TelemetryEvent;

--- a/application/account-management/Tests/Authentication/CompleteLoginTests.cs
+++ b/application/account-management/Tests/Authentication/CompleteLoginTests.cs
@@ -34,8 +34,8 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
         updatedLoginCount.Should().Be(1);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(2);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("LoginStarted");
-        TelemetryEventsCollectorSpy.CollectedEvents[1].Name.Should().Be("LoginCompleted");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("LoginStarted");
+        TelemetryEventsCollectorSpy.CollectedEvents[1].GetType().Name.Should().Be("LoginCompleted");
         TelemetryEventsCollectorSpy.CollectedEvents[1].Properties["event_UserId"].Should().Be(DatabaseSeeder.User1.Id);
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
 
@@ -82,8 +82,8 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
         updatedRetryCount.Should().Be(1);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(2);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("LoginStarted");
-        TelemetryEventsCollectorSpy.CollectedEvents[1].Name.Should().Be("LoginFailed");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("LoginStarted");
+        TelemetryEventsCollectorSpy.CollectedEvents[1].GetType().Name.Should().Be("LoginFailed");
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
     }
 
@@ -129,11 +129,11 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
         updatedRetryCount.Should().Be(4);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(5);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("LoginStarted");
-        TelemetryEventsCollectorSpy.CollectedEvents[1].Name.Should().Be("LoginFailed");
-        TelemetryEventsCollectorSpy.CollectedEvents[2].Name.Should().Be("LoginFailed");
-        TelemetryEventsCollectorSpy.CollectedEvents[3].Name.Should().Be("LoginFailed");
-        TelemetryEventsCollectorSpy.CollectedEvents[4].Name.Should().Be("LoginBlocked");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("LoginStarted");
+        TelemetryEventsCollectorSpy.CollectedEvents[1].GetType().Name.Should().Be("LoginFailed");
+        TelemetryEventsCollectorSpy.CollectedEvents[2].GetType().Name.Should().Be("LoginFailed");
+        TelemetryEventsCollectorSpy.CollectedEvents[3].GetType().Name.Should().Be("LoginFailed");
+        TelemetryEventsCollectorSpy.CollectedEvents[4].GetType().Name.Should().Be("LoginBlocked");
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
     }
 
@@ -167,7 +167,7 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
         await response.ShouldHaveErrorStatusCode(HttpStatusCode.BadRequest, "The code is no longer valid, please request a new code.");
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(1);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("LoginExpired");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("LoginExpired");
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
     }
 
@@ -193,9 +193,9 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
         ).Should().Be(1);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(3);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("LoginStarted");
-        TelemetryEventsCollectorSpy.CollectedEvents[1].Name.Should().Be("UserInviteAccepted");
-        TelemetryEventsCollectorSpy.CollectedEvents[2].Name.Should().Be("LoginCompleted");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("LoginStarted");
+        TelemetryEventsCollectorSpy.CollectedEvents[1].GetType().Name.Should().Be("UserInviteAccepted");
+        TelemetryEventsCollectorSpy.CollectedEvents[2].GetType().Name.Should().Be("LoginCompleted");
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
     }
 

--- a/application/account-management/Tests/Authentication/StartLoginTests.cs
+++ b/application/account-management/Tests/Authentication/StartLoginTests.cs
@@ -29,7 +29,7 @@ public sealed class StartLoginTests : EndpointBaseTest<AccountManagementDbContex
         responseBody!.ValidForSeconds.Should().Be(300);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(1);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("LoginStarted");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("LoginStarted");
         TelemetryEventsCollectorSpy.CollectedEvents[0].Properties["event_UserId"].Should().Be(DatabaseSeeder.User1.Id);
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
 

--- a/application/account-management/Tests/Signups/CompleteSignupTests.cs
+++ b/application/account-management/Tests/Signups/CompleteSignupTests.cs
@@ -45,10 +45,10 @@ public sealed class CompleteSignupTests : EndpointBaseTest<AccountManagementDbCo
         Connection.ExecuteScalar("SELECT COUNT(*) FROM Users WHERE Email = @email", new { email = email.ToLower() }).Should().Be(1);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(4);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("SignupStarted");
-        TelemetryEventsCollectorSpy.CollectedEvents[1].Name.Should().Be("TenantCreated");
-        TelemetryEventsCollectorSpy.CollectedEvents[2].Name.Should().Be("UserCreated");
-        TelemetryEventsCollectorSpy.CollectedEvents[3].Name.Should().Be("SignupCompleted");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("SignupStarted");
+        TelemetryEventsCollectorSpy.CollectedEvents[1].GetType().Name.Should().Be("TenantCreated");
+        TelemetryEventsCollectorSpy.CollectedEvents[2].GetType().Name.Should().Be("UserCreated");
+        TelemetryEventsCollectorSpy.CollectedEvents[3].GetType().Name.Should().Be("SignupCompleted");
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
 
         _tenantCreatedEventHandlerLogger.Received().LogInformation("Raise event to send Welcome mail to tenant.");
@@ -86,8 +86,8 @@ public sealed class CompleteSignupTests : EndpointBaseTest<AccountManagementDbCo
         await response.ShouldHaveErrorStatusCode(HttpStatusCode.BadRequest, "The code is wrong or no longer valid.");
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(2);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("SignupStarted");
-        TelemetryEventsCollectorSpy.CollectedEvents[1].Name.Should().Be("SignupFailed");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("SignupStarted");
+        TelemetryEventsCollectorSpy.CollectedEvents[1].GetType().Name.Should().Be("SignupFailed");
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
     }
 
@@ -128,11 +128,11 @@ public sealed class CompleteSignupTests : EndpointBaseTest<AccountManagementDbCo
         await response.ShouldHaveErrorStatusCode(HttpStatusCode.Forbidden, "To many attempts, please request a new code.");
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(5);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("SignupStarted");
-        TelemetryEventsCollectorSpy.CollectedEvents[1].Name.Should().Be("SignupFailed");
-        TelemetryEventsCollectorSpy.CollectedEvents[2].Name.Should().Be("SignupFailed");
-        TelemetryEventsCollectorSpy.CollectedEvents[3].Name.Should().Be("SignupFailed");
-        TelemetryEventsCollectorSpy.CollectedEvents[4].Name.Should().Be("SignupBlocked");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("SignupStarted");
+        TelemetryEventsCollectorSpy.CollectedEvents[1].GetType().Name.Should().Be("SignupFailed");
+        TelemetryEventsCollectorSpy.CollectedEvents[2].GetType().Name.Should().Be("SignupFailed");
+        TelemetryEventsCollectorSpy.CollectedEvents[3].GetType().Name.Should().Be("SignupFailed");
+        TelemetryEventsCollectorSpy.CollectedEvents[4].GetType().Name.Should().Be("SignupBlocked");
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
     }
 
@@ -167,7 +167,7 @@ public sealed class CompleteSignupTests : EndpointBaseTest<AccountManagementDbCo
         await response.ShouldHaveErrorStatusCode(HttpStatusCode.BadRequest, "The code is no longer valid, please request a new code.");
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(1);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("SignupExpired");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("SignupExpired");
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
     }
 

--- a/application/account-management/Tests/Signups/StartSignupTests.cs
+++ b/application/account-management/Tests/Signups/StartSignupTests.cs
@@ -36,9 +36,9 @@ public sealed class StartSignupTests : EndpointBaseTest<AccountManagementDbConte
         responseBody.ValidForSeconds.Should().Be(300);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(1);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("SignupStarted");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("SignupStarted");
         TelemetryEventsCollectorSpy.CollectedEvents.Count(e =>
-            e.Name == "SignupStarted" &&
+            e.GetType().Name == "SignupStarted" &&
             e.Properties["event_TenantId"] == subdomain
         ).Should().Be(1);
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
@@ -136,7 +136,7 @@ public sealed class StartSignupTests : EndpointBaseTest<AccountManagementDbConte
         await response.ShouldHaveErrorStatusCode(HttpStatusCode.Conflict, "Signup for this subdomain/mail has already been started. Please check your spam folder.");
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(1); // Only the first signup should create an event
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("SignupStarted");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("SignupStarted");
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
         await EmailService.Received(1).SendAsync(
             Arg.Is<string>(s => s.Equals(email.ToLower())),

--- a/application/account-management/Tests/Tenants/DeleteTenantTests.cs
+++ b/application/account-management/Tests/Tenants/DeleteTenantTests.cs
@@ -62,7 +62,7 @@ public sealed class DeleteTenantTests : EndpointBaseTest<AccountManagementDbCont
         Connection.RowExists("Tenants", existingTenantId).Should().BeFalse();
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(1);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("TenantDeleted");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("TenantDeleted");
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
     }
 }

--- a/application/account-management/Tests/Tenants/UpdateTenantTests.cs
+++ b/application/account-management/Tests/Tenants/UpdateTenantTests.cs
@@ -25,7 +25,7 @@ public sealed class UpdateTenantTests : EndpointBaseTest<AccountManagementDbCont
         response.ShouldHaveEmptyHeaderAndLocationOnSuccess();
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(1);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("TenantUpdated");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("TenantUpdated");
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
     }
 

--- a/application/account-management/Tests/Users/InviteUserTests.cs
+++ b/application/account-management/Tests/Users/InviteUserTests.cs
@@ -32,8 +32,8 @@ public sealed class InviteUserTests : EndpointBaseTest<AccountManagementDbContex
         ).Should().Be(1);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(2);
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Name.Should().Be("UserCreated");
-        TelemetryEventsCollectorSpy.CollectedEvents[1].Name.Should().Be("UserInvited");
+        TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("UserCreated");
+        TelemetryEventsCollectorSpy.CollectedEvents[1].GetType().Name.Should().Be("UserInvited");
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
 
         await EmailService.Received(1).SendAsync(

--- a/application/shared-kernel/SharedKernel/Behaviors/PublishTelemetryEventsPipelineBehavior.cs
+++ b/application/shared-kernel/SharedKernel/Behaviors/PublishTelemetryEventsPipelineBehavior.cs
@@ -1,5 +1,6 @@
 using Microsoft.ApplicationInsights;
 using PlatformPlatform.SharedKernel.Cqrs;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.TelemetryEvents;
 
 namespace PlatformPlatform.SharedKernel.Behaviors;
@@ -7,7 +8,8 @@ namespace PlatformPlatform.SharedKernel.Behaviors;
 public sealed class PublishTelemetryEventsPipelineBehavior<TRequest, TResponse>(
     ITelemetryEventsCollector telemetryEventsCollector,
     TelemetryClient telemetryClient,
-    ConcurrentCommandCounter concurrentCommandCounter
+    ConcurrentCommandCounter concurrentCommandCounter,
+    IExecutionContext executionContext
 ) : IPipelineBehavior<TRequest, TResponse> where TRequest : ICommand where TResponse : ResultBase
 {
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
@@ -19,10 +21,24 @@ public sealed class PublishTelemetryEventsPipelineBehavior<TRequest, TResponse>(
             while (telemetryEventsCollector.HasEvents)
             {
                 var telemetryEvent = telemetryEventsCollector.Dequeue();
+
+                AddPropertyIfNotNull(telemetryEvent, "tenant_TenantId", executionContext.TenantId);
+                AddPropertyIfNotNull(telemetryEvent, "user_IsAuthenticated", executionContext.UserInfo.IsAuthenticated.ToString());
+                AddPropertyIfNotNull(telemetryEvent, "user_UserId", executionContext.UserInfo.UserId);
+                AddPropertyIfNotNull(telemetryEvent, "user_Locale", executionContext.UserInfo.Locale);
+                AddPropertyIfNotNull(telemetryEvent, "user_UserRole", executionContext.UserInfo.UserRole);
+
                 telemetryClient.TrackEvent(telemetryEvent.GetType().Name, telemetryEvent.Properties);
             }
         }
 
         return response;
+    }
+
+    private static void AddPropertyIfNotNull(TelemetryEvent telemetryEvent, string name, object? value)
+    {
+        var stringValue = value?.ToString();
+        if (stringValue is null) return;
+        telemetryEvent.Properties.Add(name, stringValue);
     }
 }

--- a/application/shared-kernel/SharedKernel/Behaviors/PublishTelemetryEventsPipelineBehavior.cs
+++ b/application/shared-kernel/SharedKernel/Behaviors/PublishTelemetryEventsPipelineBehavior.cs
@@ -19,7 +19,7 @@ public sealed class PublishTelemetryEventsPipelineBehavior<TRequest, TResponse>(
             while (telemetryEventsCollector.HasEvents)
             {
                 var telemetryEvent = telemetryEventsCollector.Dequeue();
-                telemetryClient.TrackEvent(telemetryEvent.Name, telemetryEvent.Properties);
+                telemetryClient.TrackEvent(telemetryEvent.GetType().Name, telemetryEvent.Properties);
             }
         }
 

--- a/application/shared-kernel/SharedKernel/TelemetryEvents/TelemetryEventsCollector.cs
+++ b/application/shared-kernel/SharedKernel/TelemetryEvents/TelemetryEventsCollector.cs
@@ -26,9 +26,7 @@ public class TelemetryEventsCollector : ITelemetryEventsCollector
     }
 }
 
-public abstract class TelemetryEvent(string name, params (string Key, object Value)[] properties)
+public abstract class TelemetryEvent(params (string Key, object Value)[] properties)
 {
-    public string Name { get; } = name;
-
     public Dictionary<string, string> Properties { get; } = properties.ToDictionary(p => $"event_{p.Key}", p => p.Value.ToString() ?? "");
 }


### PR DESCRIPTION
### Summary & Motivation

Update Application Insights tracking for custom events by adding user-specific properties such as `UserId`, `TenantId`, `Local`, `UserRole`, and `IsAuthenticated`. These properties are prefixed with `user_` (e.g., `user_Local`, `user_IsAuthenticated`) by convention, ensuring consistency and enhancing the clarity of user-related data in telemetry.

The creation of telemetry events has also been simplified to reduce errors. Event names are now derived using `GetType().Name` instead of `nameof(EventName)`, avoiding issues from copy-pasting, such as when `UserUpdated` events were incorrectly named as `UserCreated`.

Additionally, telemetry tracking is now updated to collect `UserId` and `TenantId` specifically in unauthenticated login flows and admin role changes, ensuring precise event data collection for critical user actions.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
