### PR TITLE
Enhance telemetry tracking with geo data and align property naming with OpenTelemetry standards

### DIFF
--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -47,6 +47,9 @@ builder.Services
     .AddSingleton<BlockInternalApiTransform>()
     .AddSingleton<AuthenticationCookieMiddleware>();
 
+// Ensure correct client IP addresses are set for requests
+builder.Services.AddHttpForwardHeaders();
+
 reverseProxyBuilder.AddTransforms(context =>
     context.RequestTransforms.Add(context.Services.GetRequiredService<BlockInternalApiTransform>())
 );
@@ -60,6 +63,9 @@ builder.Services.AddScoped<ApiAggregationService>();
 builder.Services.AddOutputCache();
 
 var app = builder.Build();
+
+// Enable support for proxy headers such as X-Forwarded-For and X-Forwarded-Proto. Should run before other middleware.
+app.UseForwardedHeaders();
 
 app.UseOutputCache();
 

--- a/application/account-management/Core/TelemetryEvents/TelemetryEvents.cs
+++ b/application/account-management/Core/TelemetryEvents/TelemetryEvents.cs
@@ -15,43 +15,43 @@ public sealed class AuthenticationTokensRefreshed
     : TelemetryEvent;
 
 public sealed class LoginBlocked(UserId userId, int retryCount)
-    : TelemetryEvent(("UserId", userId), ("RetryCount", retryCount));
+    : TelemetryEvent(("user_id", userId), ("retry_count", retryCount));
 
 public sealed class LoginCompleted(UserId userId, int loginTimeInSeconds)
-    : TelemetryEvent(("UserId", userId), ("LoginTimeInSeconds", loginTimeInSeconds));
+    : TelemetryEvent(("user_id", userId), ("login_time_in_seconds", loginTimeInSeconds));
 
 public sealed class LoginExpired(UserId userId, int secondsFromCreation)
-    : TelemetryEvent(("UserId", userId), ("SecondsFromCreation", secondsFromCreation));
+    : TelemetryEvent(("user_id", userId), ("seconds_from_creation", secondsFromCreation));
 
 public sealed class LoginFailed(UserId userId, int retryCount)
-    : TelemetryEvent(("UserId", userId), ("RetryCount", retryCount));
+    : TelemetryEvent(("user_id", userId), ("retry_count", retryCount));
 
 public sealed class LoginStarted(UserId userId)
-    : TelemetryEvent(("UserId", userId));
+    : TelemetryEvent(("user_id", userId));
 
 public sealed class Logout
     : TelemetryEvent;
 
 public sealed class SignupBlocked(TenantId tenantId, int retryCount)
-    : TelemetryEvent(("TenantId", tenantId), ("RetryCount", retryCount));
+    : TelemetryEvent(("tenant_id", tenantId), ("retry_count", retryCount));
 
 public sealed class SignupCompleted(TenantId tenantId, int signupTimeInSeconds)
-    : TelemetryEvent(("TenantId", tenantId), ("SignupTimeInSeconds", signupTimeInSeconds));
+    : TelemetryEvent(("tenant_id", tenantId), ("signup_time_in_seconds", signupTimeInSeconds));
 
 public sealed class SignupExpired(TenantId tenantId, int secondsFromCreation)
-    : TelemetryEvent(("TenantId", tenantId), ("SecondsFromCreation", secondsFromCreation));
+    : TelemetryEvent(("tenant_id", tenantId), ("seconds_from_creation", secondsFromCreation));
 
 public sealed class SignupFailed(TenantId tenantId, int retryCount)
-    : TelemetryEvent(("TenantId", tenantId), ("RetryCount", retryCount));
+    : TelemetryEvent(("tenant_id", tenantId), ("retry_count", retryCount));
 
 public sealed class SignupStarted(TenantId tenantId)
-    : TelemetryEvent(("TenantId", tenantId));
+    : TelemetryEvent(("tenant_id", tenantId));
 
 public sealed class TenantCreated(TenantId tenantId, TenantState state)
-    : TelemetryEvent(("TenantId", tenantId), ("TenantState", state));
+    : TelemetryEvent(("tenant_id", tenantId), ("tenant_state", state));
 
 public sealed class TenantDeleted(TenantId tenantId, TenantState tenantState)
-    : TelemetryEvent(("TenantId", tenantId), ("TenantState", tenantState));
+    : TelemetryEvent(("tenant_id", tenantId), ("tenant_state", tenantState));
 
 public sealed class TenantUpdated
     : TelemetryEvent;
@@ -60,28 +60,28 @@ public sealed class UserAvatarRemoved
     : TelemetryEvent;
 
 public sealed class UserAvatarUpdated(string contentType, long size)
-    : TelemetryEvent(("ContentType", contentType), ("Size", size));
+    : TelemetryEvent(("content_type", contentType), ("size", size));
 
 public sealed class GravatarUpdated(long size)
-    : TelemetryEvent(("Size", size));
+    : TelemetryEvent(("size", size));
 
 public sealed class UserCreated(UserId userId, bool gravatarProfileFound)
-    : TelemetryEvent(("UserId", userId), ("GravatarProfileFound", gravatarProfileFound));
+    : TelemetryEvent(("user_id", userId), ("gravatar_profile_found", gravatarProfileFound));
 
 public sealed class UserDeleted(UserId userId)
-    : TelemetryEvent(("UserId", userId));
+    : TelemetryEvent(("user_id", userId));
 
 public sealed class UserInviteAccepted(UserId userId, int inviteAcceptedTimeInMinutes)
-    : TelemetryEvent(("UserId", userId), ("InviteAcceptedTimeInMinutes", inviteAcceptedTimeInMinutes));
+    : TelemetryEvent(("user_id", userId), ("invite_accepted_time_in_minutes", inviteAcceptedTimeInMinutes));
 
 public sealed class UserInvited(UserId userId)
-    : TelemetryEvent(("UserId", userId));
+    : TelemetryEvent(("user_id", userId));
 
 public sealed class UserLocaleChanged(string oldLocale, string newLocale)
-    : TelemetryEvent(("OldLocale", oldLocale), ("NewLocale", newLocale));
+    : TelemetryEvent(("old_locale", oldLocale), ("new_locale", newLocale));
 
 public sealed class UserRoleChanged(UserId userId, UserRole fromRole, UserRole toRole)
-    : TelemetryEvent(("UserId", userId), ("FromRole", fromRole), ("ToRole", toRole));
+    : TelemetryEvent(("user_id", userId), ("from_role", fromRole), ("to_role", toRole));
 
 public sealed class UserUpdated
     : TelemetryEvent;

--- a/application/account-management/Tests/Authentication/CompleteLoginTests.cs
+++ b/application/account-management/Tests/Authentication/CompleteLoginTests.cs
@@ -36,7 +36,7 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(2);
         TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("LoginStarted");
         TelemetryEventsCollectorSpy.CollectedEvents[1].GetType().Name.Should().Be("LoginCompleted");
-        TelemetryEventsCollectorSpy.CollectedEvents[1].Properties["event_UserId"].Should().Be(DatabaseSeeder.User1.Id);
+        TelemetryEventsCollectorSpy.CollectedEvents[1].Properties["event.user_id"].Should().Be(DatabaseSeeder.User1.Id);
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
 
         response.Headers.Count(h => h.Key == "X-Refresh-Token").Should().Be(1);

--- a/application/account-management/Tests/Authentication/StartLoginTests.cs
+++ b/application/account-management/Tests/Authentication/StartLoginTests.cs
@@ -30,7 +30,7 @@ public sealed class StartLoginTests : EndpointBaseTest<AccountManagementDbContex
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(1);
         TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("LoginStarted");
-        TelemetryEventsCollectorSpy.CollectedEvents[0].Properties["event_UserId"].Should().Be(DatabaseSeeder.User1.Id);
+        TelemetryEventsCollectorSpy.CollectedEvents[0].Properties["event.user_id"].Should().Be(DatabaseSeeder.User1.Id);
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
 
         await EmailService.Received(1).SendAsync(

--- a/application/account-management/Tests/Signups/StartSignupTests.cs
+++ b/application/account-management/Tests/Signups/StartSignupTests.cs
@@ -39,7 +39,7 @@ public sealed class StartSignupTests : EndpointBaseTest<AccountManagementDbConte
         TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("SignupStarted");
         TelemetryEventsCollectorSpy.CollectedEvents.Count(e =>
             e.GetType().Name == "SignupStarted" &&
-            e.Properties["event_TenantId"] == subdomain
+            e.Properties["event.tenant_id"] == subdomain
         ).Should().Be(1);
         TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
 

--- a/application/shared-kernel/SharedKernel/ApiDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/ApiDependencyConfiguration.cs
@@ -10,6 +10,7 @@ using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.Middleware;
 using PlatformPlatform.SharedKernel.SchemaProcessor;
 using PlatformPlatform.SharedKernel.SinglePageApp;
+using PlatformPlatform.SharedKernel.Telemetry;
 
 namespace PlatformPlatform.SharedKernel;
 
@@ -57,6 +58,7 @@ public static class ApiDependencyConfiguration
             .AddExceptionHandler<TimeoutExceptionHandler>()
             .AddExceptionHandler<GlobalExceptionHandler>()
             .AddTransient<ModelBindingExceptionHandlerMiddleware>()
+            .AddTransient<TelemetryContextMiddleware>()
             .AddProblemDetails()
             .AddEndpointsApiExplorer()
             .AddApiEndpoints(assemblies)
@@ -100,6 +102,8 @@ public static class ApiDependencyConfiguration
         app.UseOpenApi(options => options.Path = "/openapi/v1.json");
 
         app.UseMiddleware<ModelBindingExceptionHandlerMiddleware>();
+
+        app.UseMiddleware<TelemetryContextMiddleware>();
 
         app.UseApiEndpoints();
 

--- a/application/shared-kernel/SharedKernel/ApiDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/ApiDependencyConfiguration.cs
@@ -175,7 +175,7 @@ public static class ApiDependencyConfiguration
         return services;
     }
 
-    private static IServiceCollection AddHttpForwardHeaders(this IServiceCollection services)
+    public static IServiceCollection AddHttpForwardHeaders(this IServiceCollection services)
     {
         // Ensure correct client IP addresses are set for requests
         // This is required when running behind a reverse proxy like YARP or Azure Container Apps

--- a/application/shared-kernel/SharedKernel/Behaviors/PublishTelemetryEventsPipelineBehavior.cs
+++ b/application/shared-kernel/SharedKernel/Behaviors/PublishTelemetryEventsPipelineBehavior.cs
@@ -1,6 +1,5 @@
 using Microsoft.ApplicationInsights;
 using PlatformPlatform.SharedKernel.Cqrs;
-using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.TelemetryEvents;
 
 namespace PlatformPlatform.SharedKernel.Behaviors;
@@ -8,8 +7,7 @@ namespace PlatformPlatform.SharedKernel.Behaviors;
 public sealed class PublishTelemetryEventsPipelineBehavior<TRequest, TResponse>(
     ITelemetryEventsCollector telemetryEventsCollector,
     TelemetryClient telemetryClient,
-    ConcurrentCommandCounter concurrentCommandCounter,
-    IExecutionContext executionContext
+    ConcurrentCommandCounter concurrentCommandCounter
 ) : IPipelineBehavior<TRequest, TResponse> where TRequest : ICommand where TResponse : ResultBase
 {
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
@@ -22,23 +20,10 @@ public sealed class PublishTelemetryEventsPipelineBehavior<TRequest, TResponse>(
             {
                 var telemetryEvent = telemetryEventsCollector.Dequeue();
 
-                AddPropertyIfNotNull(telemetryEvent, "tenant_Id", executionContext.TenantId);
-                AddPropertyIfNotNull(telemetryEvent, "user_IsAuthenticated", executionContext.UserInfo.IsAuthenticated.ToString());
-                AddPropertyIfNotNull(telemetryEvent, "user_Id", executionContext.UserInfo.UserId);
-                AddPropertyIfNotNull(telemetryEvent, "user_Locale", executionContext.UserInfo.Locale);
-                AddPropertyIfNotNull(telemetryEvent, "user_Role", executionContext.UserInfo.UserRole);
-
                 telemetryClient.TrackEvent(telemetryEvent.GetType().Name, telemetryEvent.Properties);
             }
         }
 
         return response;
-    }
-
-    private static void AddPropertyIfNotNull(TelemetryEvent telemetryEvent, string name, object? value)
-    {
-        var stringValue = value?.ToString();
-        if (stringValue is null) return;
-        telemetryEvent.Properties.Add(name, stringValue);
     }
 }

--- a/application/shared-kernel/SharedKernel/Behaviors/PublishTelemetryEventsPipelineBehavior.cs
+++ b/application/shared-kernel/SharedKernel/Behaviors/PublishTelemetryEventsPipelineBehavior.cs
@@ -22,11 +22,11 @@ public sealed class PublishTelemetryEventsPipelineBehavior<TRequest, TResponse>(
             {
                 var telemetryEvent = telemetryEventsCollector.Dequeue();
 
-                AddPropertyIfNotNull(telemetryEvent, "tenant_TenantId", executionContext.TenantId);
+                AddPropertyIfNotNull(telemetryEvent, "tenant_Id", executionContext.TenantId);
                 AddPropertyIfNotNull(telemetryEvent, "user_IsAuthenticated", executionContext.UserInfo.IsAuthenticated.ToString());
-                AddPropertyIfNotNull(telemetryEvent, "user_UserId", executionContext.UserInfo.UserId);
+                AddPropertyIfNotNull(telemetryEvent, "user_Id", executionContext.UserInfo.UserId);
                 AddPropertyIfNotNull(telemetryEvent, "user_Locale", executionContext.UserInfo.Locale);
-                AddPropertyIfNotNull(telemetryEvent, "user_UserRole", executionContext.UserInfo.UserRole);
+                AddPropertyIfNotNull(telemetryEvent, "user_Role", executionContext.UserInfo.UserRole);
 
                 telemetryClient.TrackEvent(telemetryEvent.GetType().Name, telemetryEvent.Properties);
             }

--- a/application/shared-kernel/SharedKernel/ExecutionContext/BackgroundWorkerExecutionContext.cs
+++ b/application/shared-kernel/SharedKernel/ExecutionContext/BackgroundWorkerExecutionContext.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using PlatformPlatform.SharedKernel.Authentication;
 using PlatformPlatform.SharedKernel.Domain;
 
@@ -9,4 +10,6 @@ public class BackgroundWorkerExecutionContext(TenantId? tenantId = null, UserInf
     public TenantId? TenantId { get; } = tenantId;
 
     public UserInfo UserInfo { get; } = userInfo ?? UserInfo.System;
+
+    public IPAddress ClientIpAddress { get; } = IPAddress.None;
 }

--- a/application/shared-kernel/SharedKernel/ExecutionContext/HttpExecutionContext.cs
+++ b/application/shared-kernel/SharedKernel/ExecutionContext/HttpExecutionContext.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 using PlatformPlatform.SharedKernel.Authentication;
@@ -7,6 +8,7 @@ namespace PlatformPlatform.SharedKernel.ExecutionContext;
 
 public class HttpExecutionContext(IHttpContextAccessor httpContextAccessor) : IExecutionContext
 {
+    private IPAddress? _clientIpAddress;
     private bool _isTenantIdCalculated;
     private TenantId? _tenantId;
     private UserInfo? _userInfo;
@@ -38,6 +40,30 @@ public class HttpExecutionContext(IHttpContextAccessor httpContextAccessor) : IE
             var browserLocale = httpContextAccessor.HttpContext?.Features.Get<IRequestCultureFeature>()?.RequestCulture.Culture.Name;
 
             return _userInfo = UserInfo.Create(httpContextAccessor.HttpContext?.User, browserLocale);
+        }
+    }
+
+    public IPAddress ClientIpAddress
+    {
+        get
+        {
+            if (_clientIpAddress is not null)
+            {
+                return _clientIpAddress;
+            }
+
+            if (httpContextAccessor.HttpContext == null)
+            {
+                return _clientIpAddress = IPAddress.None;
+            }
+
+            var forwardedIps = httpContextAccessor.HttpContext.Request.Headers["X-Forwarded-For"].ToString().Split(',');
+            if (IPAddress.TryParse(forwardedIps.LastOrDefault(), out var clientIpAddress))
+            {
+                return _clientIpAddress = clientIpAddress;
+            }
+
+            return _clientIpAddress = IPAddress.None;
         }
     }
 }

--- a/application/shared-kernel/SharedKernel/ExecutionContext/IExecutionContext.cs
+++ b/application/shared-kernel/SharedKernel/ExecutionContext/IExecutionContext.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using PlatformPlatform.SharedKernel.Authentication;
 using PlatformPlatform.SharedKernel.Domain;
 
@@ -20,4 +21,6 @@ public interface IExecutionContext
     ///     If the user is not authenticated, it will be set to <see cref="Authentication.UserInfo.System" />.
     /// </summary>
     UserInfo UserInfo { get; }
+
+    IPAddress ClientIpAddress { get; }
 }

--- a/application/shared-kernel/SharedKernel/SharedInfrastructureConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/SharedInfrastructureConfiguration.cs
@@ -2,6 +2,7 @@ using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Azure.Storage.Blobs;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +13,7 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using PlatformPlatform.SharedKernel.Filters;
 using PlatformPlatform.SharedKernel.Services;
+using PlatformPlatform.SharedKernel.Telemetry;
 
 namespace PlatformPlatform.SharedKernel;
 
@@ -202,6 +204,7 @@ public static class SharedInfrastructureConfiguration
 
         services.AddApplicationInsightsTelemetry(applicationInsightsServiceOptions);
         services.AddApplicationInsightsTelemetryProcessor<EndpointTelemetryFilter>();
+        services.AddSingleton<ITelemetryInitializer, ApplicationInsightsTelemetryInitializer>();
 
         return services;
     }

--- a/application/shared-kernel/SharedKernel/SharedInfrastructureConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/SharedInfrastructureConfiguration.cs
@@ -204,6 +204,7 @@ public static class SharedInfrastructureConfiguration
 
         services.AddApplicationInsightsTelemetry(applicationInsightsServiceOptions);
         services.AddApplicationInsightsTelemetryProcessor<EndpointTelemetryFilter>();
+        services.AddScoped<OpenTelemetryEnricher>();
         services.AddSingleton<ITelemetryInitializer, ApplicationInsightsTelemetryInitializer>();
 
         return services;

--- a/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppConfiguration.cs
@@ -150,9 +150,8 @@ public class SinglePageAppConfiguration
 
     private string GetContentSecurityPolicies()
     {
-        var trustedCdnHost = "https://platformplatformgithub.blob.core.windows.net";
-        var gravatarHost = "https://gravatar.com";
-        var trustedHosts = $"{PublicUrl} {CdnUrl} {trustedCdnHost} {gravatarHost}";
+        const string trustedCdnHost = "https://platformplatformgithub.blob.core.windows.net";
+        var trustedHosts = $"{PublicUrl} {CdnUrl} {trustedCdnHost}";
 
         if (_isDevelopment)
         {

--- a/application/shared-kernel/SharedKernel/Telemetry/ApplicationInsightsTelemetryInitializer.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/ApplicationInsightsTelemetryInitializer.cs
@@ -1,0 +1,53 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using PlatformPlatform.SharedKernel.ExecutionContext;
+
+namespace PlatformPlatform.SharedKernel.Telemetry;
+
+public class ApplicationInsightsTelemetryInitializer : ITelemetryInitializer
+{
+    private static readonly AsyncLocal<IExecutionContext> CurrentContext = new();
+
+    public void Initialize(ITelemetry telemetry)
+    {
+        var executionContext = CurrentContext.Value;
+        if (executionContext == null)
+        {
+            return;
+        }
+
+        if (executionContext.TenantId is not null)
+        {
+            telemetry.Context.User.AccountId = executionContext.TenantId.Value;
+        }
+
+        if (executionContext.UserInfo.UserId is not null)
+        {
+            telemetry.Context.User.Id = executionContext.UserInfo.UserId;
+        }
+
+        if (executionContext.UserInfo.IsAuthenticated)
+        {
+            telemetry.Context.User.AuthenticatedUserId = executionContext.UserInfo.UserId;
+        }
+
+        AddCustomProperty(telemetry, "user_Locale", executionContext.UserInfo.Locale);
+        AddCustomProperty(telemetry, "user_Role", executionContext.UserInfo.UserRole);
+
+        // If you have the user creation date in your execution context, you can set it like this:
+        // The format should be ISO 8601: "2024-03-19T10:30:00.000Z"
+        // telemetry.Context.User.AcquisitionDate = executionContext.UserInfo.CreatedDate.ToString("o");
+    }
+
+    public static void SetContext(IExecutionContext executionContext)
+    {
+        CurrentContext.Value = executionContext;
+    }
+
+    private static void AddCustomProperty(ITelemetry telemetry, string name, object? value)
+    {
+        var stringValue = value?.ToString();
+        if (stringValue is null) return;
+        telemetry.Context.GlobalProperties[name] = stringValue;
+    }
+}

--- a/application/shared-kernel/SharedKernel/Telemetry/ApplicationInsightsTelemetryInitializer.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/ApplicationInsightsTelemetryInitializer.cs
@@ -16,6 +16,8 @@ public class ApplicationInsightsTelemetryInitializer : ITelemetryInitializer
             return;
         }
 
+        telemetry.Context.Location.Ip = executionContext.ClientIpAddress.ToString();
+
         if (executionContext.TenantId is not null)
         {
             telemetry.Context.User.AccountId = executionContext.TenantId.Value;

--- a/application/shared-kernel/SharedKernel/Telemetry/ApplicationInsightsTelemetryInitializer.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/ApplicationInsightsTelemetryInitializer.cs
@@ -36,11 +36,11 @@ public class ApplicationInsightsTelemetryInitializer : ITelemetryInitializer
 
         // Also track TenantId and UserId as custom properties, to be consistent with OpenTelemetry where build-in properties cannot be tracked
         // Set custom properties, ensure any changes here are also added to OpenTelemetryEnricher
-        AddCustomProperty(telemetry, "tenant_id", executionContext.TenantId?.Value);
-        AddCustomProperty(telemetry, "user_id", executionContext.UserInfo.UserId);
-        AddCustomProperty(telemetry, "user_IsAuthenticated", executionContext.UserInfo.IsAuthenticated);
-        AddCustomProperty(telemetry, "user_Locale", executionContext.UserInfo.Locale);
-        AddCustomProperty(telemetry, "user_Role", executionContext.UserInfo.UserRole);
+        AddCustomProperty(telemetry, "tenant.id", executionContext.TenantId?.Value);
+        AddCustomProperty(telemetry, "user.id", executionContext.UserInfo.UserId);
+        AddCustomProperty(telemetry, "user.is_authenticated", executionContext.UserInfo.IsAuthenticated);
+        AddCustomProperty(telemetry, "user.locale", executionContext.UserInfo.Locale);
+        AddCustomProperty(telemetry, "user.role", executionContext.UserInfo.UserRole);
     }
 
     public static void SetContext(IExecutionContext executionContext)

--- a/application/shared-kernel/SharedKernel/Telemetry/OpenTelemetryEnricher.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/OpenTelemetryEnricher.cs
@@ -17,10 +17,10 @@ public class OpenTelemetryEnricher(IExecutionContext executionContext)
         }
 
         // Set custom properties, ensure any changes here are also added to ApplicationInsightsTelemetryInitializer
-        Activity.Current.SetTag("tenant_id", executionContext.TenantId?.Value);
-        Activity.Current.SetTag("user_id", executionContext.UserInfo.UserId);
-        Activity.Current.SetTag("user_IsAuthenticated", executionContext.UserInfo.IsAuthenticated);
-        Activity.Current.SetTag("user_Locale", executionContext.UserInfo.Locale);
-        Activity.Current.SetTag("user_Role", executionContext.UserInfo.UserRole);
+        Activity.Current.SetTag("tenant.id", executionContext.TenantId?.Value);
+        Activity.Current.SetTag("user.id", executionContext.UserInfo.UserId);
+        Activity.Current.SetTag("user.is_authenticated", executionContext.UserInfo.IsAuthenticated);
+        Activity.Current.SetTag("user.locale", executionContext.UserInfo.Locale);
+        Activity.Current.SetTag("user.role", executionContext.UserInfo.UserRole);
     }
 }

--- a/application/shared-kernel/SharedKernel/Telemetry/OpenTelemetryEnricher.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/OpenTelemetryEnricher.cs
@@ -1,0 +1,26 @@
+using PlatformPlatform.SharedKernel.ExecutionContext;
+
+namespace PlatformPlatform.SharedKernel.Telemetry;
+
+public class OpenTelemetryEnricher(IExecutionContext executionContext)
+{
+    public void Apply()
+    {
+        if (Activity.Current is null) return;
+
+        // Set standard OpenTelemetry semantic convention for getting the geo data from the Client IP Address
+        Activity.Current.SetTag("client.address", executionContext.ClientIpAddress.ToString());
+
+        if (executionContext.UserInfo.IsAuthenticated)
+        {
+            Activity.Current.SetTag("enduser.id", executionContext.UserInfo.UserId);
+        }
+
+        // Set custom properties, ensure any changes here are also added to ApplicationInsightsTelemetryInitializer
+        Activity.Current.SetTag("tenant_id", executionContext.TenantId?.Value);
+        Activity.Current.SetTag("user_id", executionContext.UserInfo.UserId);
+        Activity.Current.SetTag("user_IsAuthenticated", executionContext.UserInfo.IsAuthenticated);
+        Activity.Current.SetTag("user_Locale", executionContext.UserInfo.Locale);
+        Activity.Current.SetTag("user_Role", executionContext.UserInfo.UserRole);
+    }
+}

--- a/application/shared-kernel/SharedKernel/Telemetry/TelemetryContextMiddleware.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/TelemetryContextMiddleware.cs
@@ -9,6 +9,9 @@ public sealed class TelemetryContextMiddleware(IExecutionContext executionContex
     {
         ApplicationInsightsTelemetryInitializer.SetContext(executionContext);
 
+        // Set standard OpenTelemetry semantic convention for getting the geo data form the Client IP Address
+        Activity.Current?.SetTag("client.address", executionContext.ClientIpAddress.ToString());
+
         await next(context);
     }
 }

--- a/application/shared-kernel/SharedKernel/Telemetry/TelemetryContextMiddleware.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/TelemetryContextMiddleware.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Http;
+using PlatformPlatform.SharedKernel.ExecutionContext;
+
+namespace PlatformPlatform.SharedKernel.Telemetry;
+
+public sealed class TelemetryContextMiddleware(IExecutionContext executionContext) : IMiddleware
+{
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        ApplicationInsightsTelemetryInitializer.SetContext(executionContext);
+
+        await next(context);
+    }
+}

--- a/application/shared-kernel/SharedKernel/Telemetry/TelemetryContextMiddleware.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/TelemetryContextMiddleware.cs
@@ -3,14 +3,14 @@ using PlatformPlatform.SharedKernel.ExecutionContext;
 
 namespace PlatformPlatform.SharedKernel.Telemetry;
 
-public sealed class TelemetryContextMiddleware(IExecutionContext executionContext) : IMiddleware
+public sealed class TelemetryContextMiddleware(IExecutionContext executionContext, OpenTelemetryEnricher openTelemetryEnricher)
+    : IMiddleware
 {
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
         ApplicationInsightsTelemetryInitializer.SetContext(executionContext);
 
-        // Set standard OpenTelemetry semantic convention for getting the geo data form the Client IP Address
-        Activity.Current?.SetTag("client.address", executionContext.ClientIpAddress.ToString());
+        openTelemetryEnricher.Apply();
 
         await next(context);
     }

--- a/application/shared-kernel/SharedKernel/TelemetryEvents/TelemetryEventsCollector.cs
+++ b/application/shared-kernel/SharedKernel/TelemetryEvents/TelemetryEventsCollector.cs
@@ -28,5 +28,5 @@ public class TelemetryEventsCollector : ITelemetryEventsCollector
 
 public abstract class TelemetryEvent(params (string Key, object Value)[] properties)
 {
-    public Dictionary<string, string> Properties { get; } = properties.ToDictionary(p => $"event_{p.Key}", p => p.Value.ToString() ?? "");
+    public Dictionary<string, string> Properties { get; } = properties.ToDictionary(p => $"event.{p.Key}", p => p.Value.ToString() ?? "");
 }

--- a/application/shared-webapp/infrastructure/applicationInsights/ApplicationInsightsProvider.tsx
+++ b/application/shared-webapp/infrastructure/applicationInsights/ApplicationInsightsProvider.tsx
@@ -1,5 +1,6 @@
 import { AppInsightsContext, AppInsightsErrorBoundary, ReactPlugin } from "@microsoft/applicationinsights-react-js";
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
+import { useUserInfo } from "@repo/infrastructure/auth/hooks";
 import type { ReactNode } from "react";
 
 const reactPlugin = new ReactPlugin();
@@ -10,6 +11,13 @@ export interface AppInsightsProviderProps {
 }
 
 export function ApplicationInsightsProvider({ children }: Readonly<AppInsightsProviderProps>) {
+  const userInfo = useUserInfo();
+  if (userInfo?.isAuthenticated) {
+    applicationInsights.setAuthenticatedUserContext(userInfo.userId as string, userInfo.tenantId as string, true);
+  } else {
+    applicationInsights.clearAuthenticatedUserContext();
+  }
+
   return (
     <AppInsightsErrorBoundary onError={ErrorFallback} appInsights={reactPlugin}>
       <AppInsightsContext.Provider value={reactPlugin}>{children}</AppInsightsContext.Provider>


### PR DESCRIPTION
### Summary & Motivation

Enhance telemetry tracking for better accuracy and consistency across the YARP AppGateway, Application Insights, and OpenTelemetry.

The YARP AppGateway has been updated to correctly forward the client’s IP address, allowing Application Insights telemetry (events and page views) and OpenTelemetry requests to track the correct geo-location data, including city and country.

When saving OpenTelemetry request data to Application Insights, the built-in authenticated user ID is now set. Since OpenTelemetry cannot set the built-in Application Insights properties for `UserID` and `TenantId`, these are added as custom properties across PageViews and CustomEvents, ensuring that all telemetry data consistently includes these values.

Custom property naming has been standardized to align with OpenTelemetry conventions. Properties such as `user_UserId`, `user_UserRole`, `user_Local`, `event_RetryCount`, etc., have been renamed to follow the OpenTelemetry format, e.g., `user.id`, `tenant.id`, `user.local`, `user.role`, and `event.retry_count`.

Finally, the Application Insights Provider in the Single Page Application (SPA) has been configured to correctly set the Authenticated User Id and Tenant Id, ensuring accurate tracking for PageViews and other telemetry data.

### Downstream projects
Change naming on custom properties on track to use the OpenTelemetry format

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
