### PR TITLE
Switch ID columns to varchar(32) to prevent padding issues

### DIFF
--- a/application/account-management/Core/Database/DatabaseMigrations.cs
+++ b/application/account-management/Core/Database/DatabaseMigrations.cs
@@ -13,7 +13,7 @@ public sealed class DatabaseMigrations : Migration
             "Signups",
             table => new
             {
-                Id = table.Column<string>("char(33)", nullable: false),
+                Id = table.Column<string>("varchar(33)", nullable: false),
                 CreatedAt = table.Column<DateTimeOffset>("datetimeoffset", nullable: false),
                 ModifiedAt = table.Column<DateTimeOffset>("datetimeoffset", nullable: true),
                 TenantId = table.Column<string>("varchar(30)", nullable: false),
@@ -44,7 +44,7 @@ public sealed class DatabaseMigrations : Migration
             table => new
             {
                 TenantId = table.Column<string>("varchar(30)", nullable: false),
-                Id = table.Column<string>("char(30)", nullable: false),
+                Id = table.Column<string>("varchar(32)", nullable: false),
                 CreatedAt = table.Column<DateTimeOffset>("datetimeoffset", nullable: false),
                 ModifiedAt = table.Column<DateTimeOffset>("datetimeoffset", nullable: true),
                 Email = table.Column<string>("nvarchar(100)", nullable: false),
@@ -70,8 +70,8 @@ public sealed class DatabaseMigrations : Migration
             table => new
             {
                 TenantId = table.Column<string>("varchar(30)", nullable: false),
-                UserId = table.Column<string>("char(30)", nullable: false),
-                Id = table.Column<string>("char(32)", nullable: false),
+                UserId = table.Column<string>("varchar(32)", nullable: false),
+                Id = table.Column<string>("varchar(32)", nullable: false),
                 CreatedAt = table.Column<DateTimeOffset>("datetimeoffset", nullable: false),
                 ModifiedAt = table.Column<DateTimeOffset>("datetimeoffset", nullable: true),
                 OneTimePasswordHash = table.Column<string>("char(84)", nullable: false),


### PR DESCRIPTION
### Summary & Motivation

Switch ID columns from `char(xx)` to `varchar(32)` to eliminate issues with blank spaces when saving strongly typed IDs like `usr_01JA5QZTCP69B5T916WF1TSQG8` (30 characters). Developers often forget to adjust column sizes when copying migration code, causing unnecessary padding in `char` columns. Defaulting to `varchar(32)` provides flexibility for IDs up to 32 characters without blank space issues and supports strongly typed IDs with up to 5-character prefixes. The `signup` ID column remains `varchar(33)` due to the lack of a suitable 5-character prefix for "signup."

### Downstream Projects

Update all Entity Framework database migrations to replace `char(xx)` with `varchar(32)` for ID columns. Note that this is a non-breaking change, as the original EF Core migration is updated instead of creating a new one, ensuring the existing schema remains compatible.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
