### PR TITLE
Follow-up improvements to Aspire 9 debugging and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Using .NET Aspire, docker images with SQL Server, Blob Storage, and mail server 
 
 ```bash
 cd application/AppHost
-dotnet dotnet run # First run will be slow as Docker images are downloaded
+dotnet run # First run will be slow as Docker images are downloaded
 ```
 
 Alternatively, open the [PlatformPlatform](/application/PlatformPlatform.sln) solution in Rider or Visual Studio and run the [Aspire AppHost](/application/AppHost/AppHost.csproj) project.

--- a/application/AppGateway/Properties/launchSettings.json
+++ b/application/AppGateway/Properties/launchSettings.json
@@ -3,7 +3,6 @@
   "profiles": {
     "Api": {
       "commandName": "Project",
-      "launchBrowser": true,
       "applicationUrl": "https://localhost:9000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development"

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -1,7 +1,11 @@
+using System.Diagnostics;
 using AppHost;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Projects;
+
+// Detect if Aspire ports from the previous run are released. See https://github.com/dotnet/aspire/issues/6704
+EnsureDeveloperControlPaneIsNotRunning();
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -77,11 +81,36 @@ builder
     .WithReference(frontendBuild)
     .WithReference(accountManagementApi)
     .WithReference(backOfficeApi)
-    .WaitFor(accountManagementApi);
+    .WaitFor(accountManagementApi)
+    .WaitFor(frontendBuild);
 
 await builder.Build().RunAsync();
 
 return;
+
+void EnsureDeveloperControlPaneIsNotRunning()
+{
+    const string processName = "dcpctrl"; // The Aspire Developer Control Pane process name
+
+    var process = Process.GetProcesses()
+        .SingleOrDefault(p => p.ProcessName.Contains(processName, StringComparison.OrdinalIgnoreCase));
+
+    if (process == null) return;
+
+    Console.WriteLine($"Shutting down developer control pane from previous run. Process: {process.ProcessName} (ID: {process.Id})");
+
+    Thread.Sleep(TimeSpan.FromSeconds(5)); // Allow Docker containers to shut down to avoid orphaned containers
+
+    try
+    {
+        process.Kill();
+        Console.WriteLine($"Process {process.Id} killed successfully.");
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"Failed to kill process {process.Id}: {ex.Message}");
+    }
+}
 
 void CreateBlobContainer(string containerName)
 {

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -11,7 +11,8 @@ SecretManagerHelper.GenerateAuthenticationTokenSigningKey("authentication-token-
 
 var sqlPassword = builder.CreateStablePassword("sql-server-password");
 var sqlServer = builder.AddSqlServer("sql-server", sqlPassword, 9002)
-    .WithDataVolume("platform-platform-sql-server-data");
+    .WithDataVolume("platform-platform-sql-server-data")
+    .WithLifetime(ContainerLifetime.Persistent);
 
 var azureStorage = builder
     .AddAzureStorage("azure-storage")

--- a/application/shared-webapp/build/plugin/DevelopmentServerPlugin.ts
+++ b/application/shared-webapp/build/plugin/DevelopmentServerPlugin.ts
@@ -40,7 +40,7 @@ export function DevelopmentServerPlugin(options: DevelopmentServerPluginOptions)
         }
 
         // Path to the platformplatform.pfx certificate generated as part of the Aspire setup
-        const pfxPath = path.join(os.homedir(), ".aspnet", "dev-certs", "https", "platformplatform.pfx");
+        const pfxPath = path.join(os.homedir(), ".aspnet", "dev-certs", "https", "localhost.pfx");
         const passphrase = process.env.CERTIFICATE_PASSWORD ?? "";
 
         if (!fs.existsSync(pfxPath)) {


### PR DESCRIPTION
### Summary & Motivation

Aspire is now configured to keep SQL Server alive between debug sessions using the new Aspire 9 `.WithLifetime(ContainerLifetime.Persistent)`, significantly improving secondary startup.

Unfortunately, Aspire does not seem to release ports immediately upon shutdown, requiring 10 seconds to a minute before the AppHost can restart. To mitigate this issue temporarily, logic has been added to kill any Developer Control Pane processes (`dcpctrl`) from previous sessions when starting the AppHost, preventing conflicts and strange errors. For more details, see this issue: https://github.com/dotnet/aspire/issues/6704.

The SPA generation and `index.html` caching strategy have been updated to align with the new Aspire startup behavior during debugging.

The AppGateway no longer launches automatically when starting Aspire AppHost, as it needs a moment to be ready.

Additionally, a bug has been resolved where the frontend incorrectly used the old `platformplatform.pfx` certificate instead of `localhost.pfx`.

Lastly, a fix for a duplicated `dotnet dotnet` issue in the README has been applied.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
