### PR TITLE
Upgrade to .NET 9

### DIFF
--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -64,8 +64,7 @@ jobs:
       - name: Restore .NET tools
         working-directory: application
         run: |
-          dotnet tool restore &&
-          dotnet workload install aspire
+          dotnet tool restore
 
       - name: Restore .NET dependencies
         working-directory: application
@@ -165,8 +164,7 @@ jobs:
       - name: Restore .NET tools
         working-directory: application
         run: |
-          dotnet tool restore &&
-          dotnet workload install aspire
+          dotnet tool restore
 
       - name: Restore .NET dependencies
         working-directory: application

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Restore .NET tools
         working-directory: application
@@ -159,7 +159,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Restore .NET tools
         working-directory: application

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Restore .NET tools
         working-directory: application
@@ -107,7 +107,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Restore .NET tools
         working-directory: application

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -62,8 +62,7 @@ jobs:
       - name: Restore .NET tools
         working-directory: application
         run: |
-          dotnet tool restore &&
-          dotnet workload install aspire
+          dotnet tool restore
 
       - name: Restore .NET dependencies
         working-directory: application
@@ -113,8 +112,7 @@ jobs:
       - name: Restore .NET tools
         working-directory: application
         run: |
-          dotnet tool restore &&
-          dotnet workload install aspire
+          dotnet tool restore
 
       - name: Restore .NET dependencies
         working-directory: application

--- a/.github/workflows/back-office.yml
+++ b/.github/workflows/back-office.yml
@@ -64,8 +64,7 @@ jobs:
       - name: Restore .NET tools
         working-directory: application
         run: |
-          dotnet tool restore &&
-          dotnet workload install aspire
+          dotnet tool restore
 
       - name: Restore .NET dependencies
         working-directory: application
@@ -165,8 +164,7 @@ jobs:
       - name: Restore .NET tools
         working-directory: application
         run: |
-          dotnet tool restore &&
-          dotnet workload install aspire
+          dotnet tool restore
 
       - name: Restore .NET dependencies
         working-directory: application

--- a/.github/workflows/back-office.yml
+++ b/.github/workflows/back-office.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Restore .NET tools
         working-directory: application
@@ -159,7 +159,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Restore .NET tools
         working-directory: application

--- a/application/AppGateway/AppGateway.csproj
+++ b/application/AppGateway/AppGateway.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AssemblyName>PlatformPlatform.AppGateway</AssemblyName>
         <RootNamespace>PlatformPlatform.AppGateway</RootNamespace>
         <Nullable>enable</Nullable>

--- a/application/AppGateway/Dockerfile
+++ b/application/AppGateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
 
 WORKDIR /app
 COPY ./AppGateway/publish .

--- a/application/AppHost/AppHost.csproj
+++ b/application/AppHost/AppHost.csproj
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsAspireHost>true</IsAspireHost>

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -29,13 +29,13 @@
     <PackageVersion Include="Meziantou.Xunit.ParallelTestFramework" Version="2.3.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="8.0.10">
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
     </PackageVersion>

--- a/application/account-management/Api/AccountManagement.Api.csproj
+++ b/application/account-management/Api/AccountManagement.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AssemblyName>PlatformPlatform.AccountManagement.Api</AssemblyName>
         <RootNamespace>PlatformPlatform.AccountManagement.Api</RootNamespace>
         <Nullable>enable</Nullable>

--- a/application/account-management/Api/Dockerfile
+++ b/application/account-management/Api/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
 
 RUN apk add --no-cache icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false

--- a/application/account-management/Core/AccountManagement.csproj
+++ b/application/account-management/Core/AccountManagement.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AssemblyName>PlatformPlatform.AccountManagement</AssemblyName>
         <RootNamespace>PlatformPlatform.AccountManagement</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/application/account-management/Tests/AccountManagement.Tests.csproj
+++ b/application/account-management/Tests/AccountManagement.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AssemblyName>PlatformPlatform.AccountManagement.Tests</AssemblyName>
         <RootNamespace>PlatformPlatform.AccountManagement.Tests</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/application/account-management/WebApp/AccountManagement.WebApp.esproj
+++ b/application/account-management/WebApp/AccountManagement.WebApp.esproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
         <ShouldRunBuildScript>false</ShouldRunBuildScript>
-        <TargetFrameworkMoniker>net8.0</TargetFrameworkMoniker>
+        <TargetFrameworkMoniker>net9.0</TargetFrameworkMoniker>
         <DefaultItemExcludes>$(DefaultItemExcludes);dist\**;*.config.*;*.d.ts</DefaultItemExcludes>
         <NpmInstallCheck>$(MSBuildProjectDirectory)\..\..\package-lock.json</NpmInstallCheck>
     </PropertyGroup>

--- a/application/account-management/Workers/AccountManagement.Workers.csproj
+++ b/application/account-management/Workers/AccountManagement.Workers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AssemblyName>PlatformPlatform.AccountManagement.Workers</AssemblyName>
         <RootNamespace>PlatformPlatform.AccountManagement.Workers</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/application/account-management/Workers/Dockerfile
+++ b/application/account-management/Workers/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
 
 RUN apk add --no-cache icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false

--- a/application/back-office/Api/BackOffice.Api.csproj
+++ b/application/back-office/Api/BackOffice.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AssemblyName>PlatformPlatform.BackOffice.Api</AssemblyName>
         <RootNamespace>PlatformPlatform.BackOffice.Api</RootNamespace>
         <Nullable>enable</Nullable>

--- a/application/back-office/Api/Dockerfile
+++ b/application/back-office/Api/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
 
 RUN apk add --no-cache icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false

--- a/application/back-office/Core/BackOffice.csproj
+++ b/application/back-office/Core/BackOffice.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AssemblyName>PlatformPlatform.BackOffice</AssemblyName>
         <RootNamespace>PlatformPlatform.BackOffice</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/application/back-office/Tests/BackOffice.Tests.csproj
+++ b/application/back-office/Tests/BackOffice.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AssemblyName>PlatformPlatform.BackOffice.Tests</AssemblyName>
         <RootNamespace>PlatformPlatform.BackOffice.Tests</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/application/back-office/WebApp/BackOffice.WebApp.esproj
+++ b/application/back-office/WebApp/BackOffice.WebApp.esproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
         <ShouldRunBuildScript>false</ShouldRunBuildScript>
-        <TargetFrameworkMoniker>net8.0</TargetFrameworkMoniker>
+        <TargetFrameworkMoniker>net9.0</TargetFrameworkMoniker>
         <DefaultItemExcludes>$(DefaultItemExcludes);dist\**;*.config.*;*.d.ts</DefaultItemExcludes>
         <NpmInstallCheck>$(MSBuildProjectDirectory)\..\..\package-lock.json</NpmInstallCheck>
     </PropertyGroup>

--- a/application/back-office/Workers/BackOffice.Workers.csproj
+++ b/application/back-office/Workers/BackOffice.Workers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AssemblyName>PlatformPlatform.BackOffice.Workers</AssemblyName>
         <RootNamespace>PlatformPlatform.BackOffice.Workers</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/application/back-office/Workers/Dockerfile
+++ b/application/back-office/Workers/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
 
 RUN apk add --no-cache icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false

--- a/application/global.json
+++ b/application/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "9.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
@@ -3,6 +3,7 @@ using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Azure.Storage.Blobs;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -120,7 +121,8 @@ public static class SharedInfrastructureConfiguration
     {
         builder.Services.Configure<AspNetCoreTraceInstrumentationOptions>(options =>
             {
-                options.Filter = httpContext =>
+                // ReSharper disable once RedundantLambdaParameterType
+                options.Filter = (HttpContext httpContext) =>
                 {
                     var requestPath = httpContext.Request.Path.ToString();
 

--- a/application/shared-kernel/SharedKernel/SharedKernel.csproj
+++ b/application/shared-kernel/SharedKernel/SharedKernel.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsAspireSharedProject>true</IsAspireSharedProject>

--- a/application/shared-kernel/Tests/SharedKernel.Tests.csproj
+++ b/application/shared-kernel/Tests/SharedKernel.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AssemblyName>PlatformPlatform.SharedKernel.Tests</AssemblyName>
         <RootNamespace>PlatformPlatform.SharedKernel.Tests</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/application/shared-webapp/SharedKernel.WebApp.esproj
+++ b/application/shared-webapp/SharedKernel.WebApp.esproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
         <ShouldRunBuildScript>false</ShouldRunBuildScript>
-        <TargetFrameworkMoniker>net8.0</TargetFrameworkMoniker>
+        <TargetFrameworkMoniker>net9.0</TargetFrameworkMoniker>
         <DefaultItemExcludes>$(DefaultItemExcludes);**\dist\**;*.config.*;*.d.ts</DefaultItemExcludes>
         <NpmInstallCheck>$(MSBuildProjectDirectory)\..\..\package-lock.json</NpmInstallCheck>
     </PropertyGroup>


### PR DESCRIPTION
### Summary & Motivation

Upgrade the project from .NET 8 to .NET 9, bringing improved features and simplifying workflows. All .NET projects and the global `global.json` have been updated to target .NET 9. NuGet packages have also been upgraded to their .NET 9-compatible versions, except for Entity Framework, which remains on the older version due to test failures caused by multiple service registrations.

The Docker image has been updated to use `mcr.microsoft.com/dotnet/aspnet:9.0-alpine`, and GitHub Actions have been upgraded to use .NET 9. Additionally, the Aspire workload installation step has been removed from GitHub Actions, as it is no longer needed.

The `SslCertificateManager` has been refactored and simplified with .NET 9’s new cross-platform `X509CertificateLoader.LoadPkcs12FromFile` method, replacing the now-deprecated `new X509Certificate2(certificateLocation, password)`. This change makes creating self-signed developer certificates for localhost significantly simpler and ensures compatibility across Mac and Windows platforms.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
