### PR TITLE
Add option to delete a user with confirmation and enhanced permissions

### DIFF
--- a/application/account-management/Core/Features/Tenants/Commands/DeleteTenant.cs
+++ b/application/account-management/Core/Features/Tenants/Commands/DeleteTenant.cs
@@ -17,7 +17,7 @@ public sealed class DeleteTenantValidator : AbstractValidator<DeleteTenantComman
     {
         RuleFor(x => x.Id)
             .MustAsync(async (tenantId, cancellationToken) =>
-                await userRepository.CountTenantUsersAsync(tenantId, cancellationToken) == 0
+                await userRepository.CountTenantUsersAsync(tenantId, cancellationToken) <= 1
             )
             .WithMessage("All users must be deleted before the tenant can be deleted.");
     }

--- a/application/account-management/Core/Features/Users/Commands/ChangeUserRole.cs
+++ b/application/account-management/Core/Features/Users/Commands/ChangeUserRole.cs
@@ -2,6 +2,7 @@ using JetBrains.Annotations;
 using PlatformPlatform.AccountManagement.Features.Users.Domain;
 using PlatformPlatform.SharedKernel.Cqrs;
 using PlatformPlatform.SharedKernel.Domain;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.Telemetry;
 
 namespace PlatformPlatform.AccountManagement.Features.Users.Commands;
@@ -15,11 +16,21 @@ public sealed record ChangeUserRoleCommand : ICommand, IRequest<Result>
     public required UserRole UserRole { get; init; }
 }
 
-public sealed class ChangeUserRoleHandler(IUserRepository userRepository, ITelemetryEventsCollector events)
+public sealed class ChangeUserRoleHandler(IUserRepository userRepository, IExecutionContext executionContext, ITelemetryEventsCollector events)
     : IRequestHandler<ChangeUserRoleCommand, Result>
 {
     public async Task<Result> Handle(ChangeUserRoleCommand command, CancellationToken cancellationToken)
     {
+        if (executionContext.UserInfo.Id == command.Id)
+        {
+            return Result.Forbidden("You cannot change your own user role.");
+        }
+
+        if (executionContext.UserInfo.Role != UserRole.Owner.ToString())
+        {
+            return Result.Forbidden("Only owners are allowed to change the user roles of users.");
+        }
+
         var user = await userRepository.GetByIdAsync(command.Id, cancellationToken);
         if (user is null) return Result.NotFound($"User with id '{command.Id}' not found.");
 

--- a/application/account-management/Core/Features/Users/Commands/DeleteUser.cs
+++ b/application/account-management/Core/Features/Users/Commands/DeleteUser.cs
@@ -2,6 +2,7 @@ using JetBrains.Annotations;
 using PlatformPlatform.AccountManagement.Features.Users.Domain;
 using PlatformPlatform.SharedKernel.Cqrs;
 using PlatformPlatform.SharedKernel.Domain;
+using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.Telemetry;
 
 namespace PlatformPlatform.AccountManagement.Features.Users.Commands;
@@ -9,11 +10,21 @@ namespace PlatformPlatform.AccountManagement.Features.Users.Commands;
 [PublicAPI]
 public sealed record DeleteUserCommand(UserId Id) : ICommand, IRequest<Result>;
 
-public sealed class DeleteUserHandler(IUserRepository userRepository, ITelemetryEventsCollector events)
+public sealed class DeleteUserHandler(IUserRepository userRepository, IExecutionContext executionContext, ITelemetryEventsCollector events)
     : IRequestHandler<DeleteUserCommand, Result>
 {
     public async Task<Result> Handle(DeleteUserCommand command, CancellationToken cancellationToken)
     {
+        if (executionContext.UserInfo.Id == command.Id)
+        {
+            return Result.Forbidden("You cannot delete yourself.");
+        }
+
+        if (executionContext.UserInfo.Role != UserRole.Owner.ToString())
+        {
+            return Result.Forbidden("Only owners are allowed to delete other users.");
+        }
+
         var user = await userRepository.GetByIdAsync(command.Id, cancellationToken);
         if (user is null) return Result.NotFound($"User with id '{command.Id}' not found.");
 

--- a/application/account-management/Tests/Tenants/DeleteTenantTests.cs
+++ b/application/account-management/Tests/Tenants/DeleteTenantTests.cs
@@ -1,6 +1,9 @@
 using System.Net;
+using System.Text.Json;
 using FluentAssertions;
 using PlatformPlatform.AccountManagement.Database;
+using PlatformPlatform.AccountManagement.Features.Users.Domain;
+using PlatformPlatform.SharedKernel.Domain;
 using PlatformPlatform.SharedKernel.Tests;
 using PlatformPlatform.SharedKernel.Tests.Persistence;
 using PlatformPlatform.SharedKernel.Validation;
@@ -30,6 +33,21 @@ public sealed class DeleteTenantTests : EndpointBaseTest<AccountManagementDbCont
     {
         // Arrange
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
+        Connection.Insert("Users", [
+                ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
+                ("Id", UserId.NewId().ToString()),
+                ("CreatedAt", DateTime.UtcNow.AddMinutes(-10)),
+                ("ModifiedAt", null),
+                ("Email", Faker.Internet.Email()),
+                ("FirstName", Faker.Person.FirstName),
+                ("LastName", Faker.Person.LastName),
+                ("Title", "Philanthropist & Innovator"),
+                ("Role", UserRole.Member.ToString()),
+                ("EmailConfirmed", true),
+                ("Avatar", JsonSerializer.Serialize(new Avatar())),
+                ("Locale", "en-US")
+            ]
+        );
 
         // Act
         var response = await AuthenticatedHttpClient.DeleteAsync($"/api/account-management/tenants/{existingTenantId}");
@@ -50,9 +68,6 @@ public sealed class DeleteTenantTests : EndpointBaseTest<AccountManagementDbCont
     {
         // Arrange
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
-        var existingUserId = DatabaseSeeder.User1.Id;
-        await AuthenticatedHttpClient.DeleteAsync($"/api/account-management/users/{existingUserId}");
-        TelemetryEventsCollectorSpy.Reset();
 
         // Act
         var response = await AuthenticatedHttpClient.DeleteAsync($"/api/account-management/tenants/{existingTenantId}");

--- a/application/account-management/WebApp/routes/admin/users/-components/UserTable.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/UserTable.tsx
@@ -84,7 +84,7 @@ export function UserTable() {
 
   return (
     <>
-      <Modal isOpen={userToDelete !== null} onOpenChange={() => setUserToDelete(null)} variant="alert">
+      <Modal isOpen={userToDelete !== null} onOpenChange={() => setUserToDelete(null)} blur={false}>
         <AlertDialog
           title={t`Delete User`}
           variant="destructive"

--- a/application/account-management/WebApp/routes/admin/users/-components/UserTable.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/UserTable.tsx
@@ -5,22 +5,29 @@ import { useCallback, useState } from "react";
 import { Cell, Column, Row, Table, TableHeader } from "@repo/ui/components/Table";
 import { Badge } from "@repo/ui/components/Badge";
 import { Pagination } from "@repo/ui/components/Pagination";
-import { Popover } from "@repo/ui/components/Popover";
 import { Menu, MenuItem, MenuSeparator } from "@repo/ui/components/Menu";
 import { Button } from "@repo/ui/components/Button";
 import { Avatar } from "@repo/ui/components/Avatar";
-import { SortableUserProperties, SortOrder, useApi } from "@/shared/lib/api/client";
+import { api, type components, SortableUserProperties, SortOrder, useApi } from "@/shared/lib/api/client";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { t, Trans } from "@lingui/macro";
+import { AlertDialog } from "@repo/ui/components/AlertDialog";
+import { Modal } from "@repo/ui/components/Modal";
+import { useUserInfo } from "@repo/infrastructure/auth/hooks";
+
+type UserDetails = components["schemas"]["UserDetails"];
 
 export function UserTable() {
   const navigate = useNavigate();
   const { orderBy, pageOffset, sortOrder } = useSearch({ strict: false });
+  const userInfo = useUserInfo();
 
   const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>(() => ({
     column: orderBy,
     direction: sortOrder === "Ascending" ? "ascending" : "descending"
   }));
+
+  const [refreshKey, setRefreshKey] = useState(0);
 
   const { data } = useApi("/api/account-management/users", {
     params: {
@@ -29,8 +36,11 @@ export function UserTable() {
         OrderBy: orderBy,
         SortOrder: sortOrder
       }
-    }
+    },
+    key: refreshKey
   });
+
+  const [userToDelete, setUserToDelete] = useState<UserDetails | null>(null);
 
   const handlePageChange = useCallback(
     (page: number) => {
@@ -52,7 +62,7 @@ export function UserTable() {
         to: "/admin/users",
         search: (prev) => ({
           ...prev,
-          pageOffset: undefined, // I Just added this to set the PageOffset to 0 when sorting
+          pageOffset: undefined,
           orderBy: (newSortDescriptor.column?.toString() ?? "Name") as SortableUserProperties,
           sortOrder: newSortDescriptor.direction === "ascending" ? SortOrder.Ascending : SortOrder.Descending
         })
@@ -61,125 +71,163 @@ export function UserTable() {
     [navigate]
   );
 
+  const handleDelete = useCallback(async () => {
+    if (!userToDelete) return;
+
+    await api.delete("/api/account-management/users/{id}", { params: { path: { id: userToDelete.id } } });
+
+    setRefreshKey((prev) => prev + 1);
+    setUserToDelete(null);
+  }, [userToDelete]);
+
   const currentPage = (data?.currentPageOffset ?? 0) + 1;
 
   return (
-    <div className="flex flex-col gap-2 h-full w-full">
-      <Table
-        key={`${orderBy}-${sortOrder}`}
-        selectionMode="multiple"
-        selectionBehavior="toggle"
-        sortDescriptor={sortDescriptor}
-        onSortChange={handleSortChange}
-        aria-label={t`Users`}
-      >
-        <TableHeader>
-          <Column minWidth={180} allowsSorting id={SortableUserProperties.Name} isRowHeader>
-            <Trans>Name</Trans>
-          </Column>
-          <Column minWidth={120} allowsSorting id={SortableUserProperties.Email}>
-            <Trans>Email</Trans>
-          </Column>
-          <Column minWidth={65} defaultWidth={110} allowsSorting id={SortableUserProperties.CreatedAt}>
-            <Trans>Added</Trans>
-          </Column>
-          <Column minWidth={65} defaultWidth={120} allowsSorting id={SortableUserProperties.ModifiedAt}>
-            <Trans>Last Seen</Trans>
-          </Column>
-          <Column minWidth={65} defaultWidth={75} allowsSorting id={SortableUserProperties.Role}>
-            <Trans>Role</Trans>
-          </Column>
-          <Column width={114}>
-            <Trans>Actions</Trans>
-          </Column>
-        </TableHeader>
-        <TableBody>
-          {data?.users.map((user) => (
-            <Row key={user.id}>
-              <Cell>
-                <div className="flex h-14 items-center gap-2">
-                  <Avatar
-                    initials={getInitials(user.firstName, user.lastName, user.email)}
-                    avatarUrl={user.avatarUrl}
-                    size="sm"
-                    isRound
-                  />
-                  <div className="flex flex-col truncate">
-                    <div className="truncate text-foreground">
-                      {user.firstName} {user.lastName}
-                      {user.emailConfirmed ? (
-                        ""
-                      ) : (
-                        <Badge variant="outline">
-                          <Trans>Pending</Trans>
-                        </Badge>
-                      )}
+    <>
+      <Modal isOpen={userToDelete !== null} onOpenChange={() => setUserToDelete(null)} variant="alert">
+        <AlertDialog
+          title={t`Delete User`}
+          variant="destructive"
+          actionLabel={t`Delete`}
+          cancelLabel={t`Cancel`}
+          onAction={handleDelete}
+        >
+          <Trans>
+            Are you sure you want to delete{" "}
+            {`${userToDelete?.firstName ?? ""} ${userToDelete?.lastName ?? ""}`.trim() || userToDelete?.email}?
+          </Trans>
+        </AlertDialog>
+      </Modal>
+
+      <div className="flex flex-col gap-2 h-full w-full">
+        <Table
+          key={`${orderBy}-${sortOrder}`}
+          selectionMode="multiple"
+          selectionBehavior="toggle"
+          sortDescriptor={sortDescriptor}
+          onSortChange={handleSortChange}
+          aria-label={t`Users`}
+        >
+          <TableHeader>
+            <Column minWidth={180} allowsSorting id={SortableUserProperties.Name} isRowHeader>
+              <Trans>Name</Trans>
+            </Column>
+            <Column minWidth={120} allowsSorting id={SortableUserProperties.Email}>
+              <Trans>Email</Trans>
+            </Column>
+            <Column minWidth={65} defaultWidth={110} allowsSorting id={SortableUserProperties.CreatedAt}>
+              <Trans>Added</Trans>
+            </Column>
+            <Column minWidth={65} defaultWidth={120} allowsSorting id={SortableUserProperties.ModifiedAt}>
+              <Trans>Last Seen</Trans>
+            </Column>
+            <Column minWidth={65} defaultWidth={75} allowsSorting id={SortableUserProperties.Role}>
+              <Trans>Role</Trans>
+            </Column>
+            <Column width={114}>
+              <Trans>Actions</Trans>
+            </Column>
+          </TableHeader>
+          <TableBody>
+            {data?.users.map((user) => (
+              <Row key={user.id}>
+                <Cell>
+                  <div className="flex h-14 items-center gap-2">
+                    <Avatar
+                      initials={getInitials(user.firstName, user.lastName, user.email)}
+                      avatarUrl={user.avatarUrl}
+                      size="sm"
+                      isRound
+                    />
+                    <div className="flex flex-col truncate">
+                      <div className="truncate text-foreground">
+                        {user.firstName} {user.lastName}
+                        {user.emailConfirmed ? (
+                          ""
+                        ) : (
+                          <Badge variant="outline">
+                            <Trans>Pending</Trans>
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="truncate">{user.title ?? ""}</div>
                     </div>
-                    <div className="truncate">{user.title ?? ""}</div>
                   </div>
-                </div>
-              </Cell>
-              <Cell>{user.email}</Cell>
-              <Cell>{toFormattedDate(user.createdAt)}</Cell>
-              <Cell>{toFormattedDate(user.modifiedAt)}</Cell>
-              <Cell>
-                <Badge variant="outline">{user.role}</Badge>
-              </Cell>
-              <Cell>
-                <div className="group flex gap-2 w-full">
-                  <Button
-                    variant="icon"
-                    className="group-hover:opacity-100 opacity-0 duration-300 transition-opacity ease-in-out"
-                  >
-                    <Trash2Icon className="w-5 h-5 text-muted-foreground" />
-                  </Button>
-                  <MenuTrigger>
-                    <Button variant="icon" aria-label={t`Menu`}>
-                      <EllipsisVerticalIcon className="w-5 h-5 text-muted-foreground" />
+                </Cell>
+                <Cell>{user.email}</Cell>
+                <Cell>{toFormattedDate(user.createdAt)}</Cell>
+                <Cell>{toFormattedDate(user.modifiedAt)}</Cell>
+                <Cell>
+                  <Badge variant="outline">{user.role}</Badge>
+                </Cell>
+                <Cell>
+                  <div className="group flex gap-2 w-full">
+                    <Button
+                      variant="icon"
+                      className="group-hover:opacity-100 opacity-0 duration-300 transition-opacity ease-in-out"
+                      onPress={() => setUserToDelete(user)}
+                      isDisabled={user.id === userInfo?.id}
+                    >
+                      <Trash2Icon className="w-5 h-5 text-muted-foreground" />
                     </Button>
-                    <Popover>
-                      <Menu>
-                        <MenuItem onAction={() => alert("open")}>
+                    <MenuTrigger>
+                      <Button variant="icon" aria-label={t`Menu`}>
+                        <EllipsisVerticalIcon className="w-5 h-5 text-muted-foreground" />
+                      </Button>
+                      <Menu
+                        onAction={(key) => {
+                          if (key === "viewProfile") {
+                            alert("open");
+                          } else if (key === "deleteUser") {
+                            setUserToDelete(user);
+                          }
+                        }}
+                      >
+                        <MenuItem id="viewProfile">
                           <UserIcon className="w-4 h-4" />
                           <Trans>View Profile</Trans>
                         </MenuItem>
                         <MenuSeparator />
-                        <MenuItem onAction={() => alert("rename")}>
+                        <MenuItem
+                          id="deleteUser"
+                          isDisabled={user.id === userInfo?.id}
+                          onAction={() => setUserToDelete(user)}
+                        >
                           <Trash2Icon className="w-4 h-4 text-destructive" />
                           <span className="text-destructive">
                             <Trans>Delete</Trans>
                           </span>
                         </MenuItem>
                       </Menu>
-                    </Popover>
-                  </MenuTrigger>
-                </div>
-              </Cell>
-            </Row>
-          ))}
-        </TableBody>
-      </Table>
-      {data && (
-        <>
-          <Pagination
-            paginationSize={5}
-            currentPage={currentPage}
-            totalPages={data?.totalPages ?? 1}
-            onPageChange={handlePageChange}
-            className="w-full pr-12 sm:hidden"
-          />
-          <Pagination
-            paginationSize={9}
-            currentPage={currentPage}
-            totalPages={data?.totalPages ?? 1}
-            onPageChange={handlePageChange}
-            previousLabel={t`Previous`}
-            nextLabel={t`Next`}
-            className="hidden sm:flex w-full"
-          />
-        </>
-      )}
-    </div>
+                    </MenuTrigger>
+                  </div>
+                </Cell>
+              </Row>
+            ))}
+          </TableBody>
+        </Table>
+        {data && (
+          <>
+            <Pagination
+              paginationSize={5}
+              currentPage={currentPage}
+              totalPages={data?.totalPages ?? 1}
+              onPageChange={handlePageChange}
+              className="w-full pr-12 sm:hidden"
+            />
+            <Pagination
+              paginationSize={9}
+              currentPage={currentPage}
+              totalPages={data?.totalPages ?? 1}
+              onPageChange={handlePageChange}
+              previousLabel={t`Previous`}
+              nextLabel={t`Next`}
+              className="hidden sm:flex w-full"
+            />
+          </>
+        )}
+      </div>
+    </>
   );
 }
 

--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -46,6 +46,9 @@ msgstr "Alle brugere"
 msgid "An error occurred while processing your request. {0}"
 msgstr "Der opstod en fejl under behandlingen af din anmodning. {0}"
 
+msgid "Are you sure you want to delete {0}?"
+msgstr "Er du sikker på, at du vil slette {0}?"
+
 msgid "By continuing, you accept our policies"
 msgstr "Ved at fortsætte accepterer du vores vilkår"
 
@@ -72,6 +75,9 @@ msgstr "Slet"
 
 msgid "Delete Account"
 msgstr "Slet konto"
+
+msgid "Delete User"
+msgstr "Slet bruger"
 
 msgid "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."
 msgstr "Sletning af kontoen og alle tilknyttede data. Denne handling kan ikke fortrydes, så fortsæt med forsigtighed."

--- a/application/account-management/WebApp/shared/translations/locale/en-US.po
+++ b/application/account-management/WebApp/shared/translations/locale/en-US.po
@@ -46,6 +46,9 @@ msgstr "All Users"
 msgid "An error occurred while processing your request. {0}"
 msgstr "An error occurred while processing your request. {0}"
 
+msgid "Are you sure you want to delete {0}?"
+msgstr "Are you sure you want to delete {0}?"
+
 msgid "By continuing, you accept our policies"
 msgstr "By continuing, you accept our policies"
 
@@ -72,6 +75,9 @@ msgstr "Delete"
 
 msgid "Delete Account"
 msgstr "Delete Account"
+
+msgid "Delete User"
+msgstr "Delete User"
 
 msgid "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."
 msgstr "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."

--- a/application/account-management/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/account-management/WebApp/shared/translations/locale/nl-NL.po
@@ -46,6 +46,9 @@ msgstr "Alle gebruikers"
 msgid "An error occurred while processing your request. {0}"
 msgstr "Er is een fout opgetreden bij het verwerken van uw verzoek. {0}"
 
+msgid "Are you sure you want to delete {0}?"
+msgstr "Weet je zeker dat je {0} wilt verwijderen?"
+
 msgid "By continuing, you accept our policies"
 msgstr "Door verder te gaan, accepteer je onze voorwaarden"
 
@@ -72,6 +75,9 @@ msgstr "Verwijderen"
 
 msgid "Delete Account"
 msgstr "Account verwijderen"
+
+msgid "Delete User"
+msgstr "Gebruiker verwijderen"
 
 msgid "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."
 msgstr "Het account en alle bijbehorende gegevens worden verwijderd. Deze actie kan niet ongedaan worden gemaakt, dus ga voorzichtig te werk."

--- a/application/shared-webapp/ui/components/Modal.tsx
+++ b/application/shared-webapp/ui/components/Modal.tsx
@@ -6,7 +6,7 @@ import { Modal as AriaModal, ModalOverlay, type ModalOverlayProps } from "react-
 import { tv } from "tailwind-variants";
 
 const overlayStyles = tv({
-  base: "fixed top-0 left-0 w-full h-[--visual-viewport-height] isolate z-20 bg-black/[15%] text-center flex backdrop-blur-lg",
+  base: "fixed top-0 left-0 w-full h-[--visual-viewport-height] isolate z-20 bg-black/[15%] text-center flex",
   variants: {
     isEntering: {
       true: "animate-in fade-in duration-200 ease-out"
@@ -24,11 +24,16 @@ const overlayStyles = tv({
     fullSize: {
       true: "",
       false: "p-4"
+    },
+    blur: {
+      true: "backdrop-blur-lg",
+      false: ""
     }
   },
   defaultVariants: {
     position: "center",
-    fullSize: false
+    fullSize: false,
+    blur: true
   }
 });
 
@@ -47,11 +52,12 @@ const modalStyles = tv({
 type ModalProps = {
   position?: "center" | "top" | "left" | "right" | "bottom";
   fullSize?: boolean;
+  blur?: boolean;
 } & ModalOverlayProps;
 
-export function Modal({ position, fullSize, ...props }: Readonly<ModalProps>) {
+export function Modal({ position, fullSize, blur, ...props }: Readonly<ModalProps>) {
   return (
-    <ModalOverlay {...props} className={(renderProps) => overlayStyles({ position, fullSize, ...renderProps })}>
+    <ModalOverlay {...props} className={(renderProps) => overlayStyles({ position, fullSize, blur, ...renderProps })}>
       <AriaModal {...props} className={modalStyles} />
     </ModalOverlay>
   );


### PR DESCRIPTION
### Summary & Motivation

Introduce the ability to delete a user, with a confirmation dialog in the UI. The dialog displays the user's name or email (if the name is not provided) when confirming the deletion.

The `Modal` component has been updated to support disabling background blur, which is not useful when showing confirmation box.

On the server side, logic has been added to allow only owners to delete users or change roles. Owners cannot delete or modify their own roles.

The delete option has been disabled in the UI by default.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
