### PR TITLE
Fix OpenAPI generation issue after .NET 9 upgrade

### DIFF
--- a/application/account-management/Api/AccountManagement.Api.csproj
+++ b/application/account-management/Api/AccountManagement.Api.csproj
@@ -6,7 +6,7 @@
         <RootNamespace>PlatformPlatform.AccountManagement.Api</RootNamespace>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/../WebApp/shared/lib/api/</OpenApiDocumentsDirectory>
+        <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)\..\WebApp\shared\lib\api\</OpenApiDocumentsDirectory>
         <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>
         <OpenApiGenerateDocumentsOnBuild>true</OpenApiGenerateDocumentsOnBuild>
         <DefaultItemExcludes>$(DefaultItemExcludes);publish\**;Dockerfile</DefaultItemExcludes>

--- a/application/back-office/Api/BackOffice.Api.csproj
+++ b/application/back-office/Api/BackOffice.Api.csproj
@@ -6,7 +6,7 @@
         <RootNamespace>PlatformPlatform.BackOffice.Api</RootNamespace>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/../WebApp/shared/lib/api/</OpenApiDocumentsDirectory>
+        <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)\..\WebApp\shared\lib\api\</OpenApiDocumentsDirectory>
         <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>
         <OpenApiGenerateDocumentsOnBuild>true</OpenApiGenerateDocumentsOnBuild>
         <DefaultItemExcludes>$(DefaultItemExcludes);publish\**;Dockerfile</DefaultItemExcludes>


### PR DESCRIPTION
### Summary & Motivation

Resolve the issue with OpenAPI generation failing in .NET 9 due to the `<OpenApiDocumentsDirectory>` using forward slashes instead of backslashes. The configuration now uses backslashes to ensure compatibility with the new .NET 9 requirements.

Fix the issue with OpenAPI generation failing in .NET 9 with the error `Missing required option '--project'`. This was caused by `<OpenApiDocumentsDirectory>` using forward slashes instead of backslashes.


### Downstream Projects

Update all paths in `.csproj` files to use backslash for compatibility with Windows.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
