### PR TITLE
Persist Blob Storage emulator and Mail Server across Aspire sessions

### DIFF
--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -24,6 +24,7 @@ var azureStorage = builder
         {
             resourceBuilder.WithDataVolume("platform-platform-azure-storage-data");
             resourceBuilder.WithBlobPort(10000);
+            resourceBuilder.WithLifetime(ContainerLifetime.Persistent);
         }
     )
     .WithAnnotation(new ContainerImageAnnotation
@@ -38,7 +39,8 @@ var azureStorage = builder
 builder
     .AddContainer("mail-server", "axllent/mailpit")
     .WithHttpEndpoint(9003, 8025)
-    .WithEndpoint(9004, 1025);
+    .WithEndpoint(9004, 1025)
+    .WithLifetime(ContainerLifetime.Persistent);
 
 CreateBlobContainer("avatars");
 


### PR DESCRIPTION
### Summary & Motivation

Configure the Azure Blob Storage emulator and the Mailpit mail server to remain running between Aspire sessions using the new `.WithLifetime(ContainerLifetime.Persistent)` feature in Aspire 9. This reduces startup time during debugging by keeping these services alive across sessions.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
