### PR TITLE
Fix YARP Gateway routes for Account Management and BackOffice APIs

### DIFF
--- a/application/AppGateway/appsettings.json
+++ b/application/AppGateway/appsettings.json
@@ -14,11 +14,11 @@
       "account-management-api": {
         "ClusterId": "account-management-api",
         "Match": {
-          "Path": "/api/account-management-api/{**catch-all}"
+          "Path": "/api/account-management/{**catch-all}"
         },
         "Transforms": [
           {
-            "PathPattern": "/api/{**catch-all}"
+            "PathPattern": "/api/account-management/{**catch-all}"
           }
         ]
       },
@@ -46,7 +46,7 @@
         },
         "Transforms": [
           {
-            "PathPattern": "api/{**catch-all}"
+            "PathPattern": "/api/back-office/{**catch-all}"
           }
         ]
       },


### PR DESCRIPTION
### Summary & Motivation

Fix issues with YARP Gateway routes for `/api/account-management` and `/api/back-office`. The route for the BackOffice API was not correctly redirecting API traffic, causing requests to fail. Additionally, the Account Management API route was misconfigured but appeared to work because it was inadvertently using the SPA YARP route.

Both routes have been updated to ensure proper redirection and alignment with their respective APIs.

### Downstream Projects

Update YARP configuration for self-contained system to map API endpoints correctly.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
