### PR TITLE
Update PlatformPlatform .NET CLI for improved side-by-side project support

### DIFF
--- a/developer-cli/Commands/CodeCoverageCommand.cs
+++ b/developer-cli/Commands/CodeCoverageCommand.cs
@@ -24,8 +24,6 @@ public class CodeCoverageCommand : Command
     {
         Prerequisite.Ensure(Prerequisite.Dotnet);
 
-        var workingDirectory = new DirectoryInfo(Path.Combine(Configuration.GetSourceCodeFolder(), "..", "application")).FullName;
-
         var solutionFile = SolutionHelper.GetSolution(solutionName);
 
         ProcessHelper.StartProcess("dotnet tool restore", solutionFile.Directory!.FullName);
@@ -36,12 +34,12 @@ public class CodeCoverageCommand : Command
 
         ProcessHelper.StartProcess(
             $"dotnet dotcover test {solutionFile.Name} --no-build --dcOutput=coverage/dotCover.html --dcReportType=HTML --dcFilters=\"+:{solutionFileWithoutExtension}.*;-:*.Tests;-:type=*.AppHost.*\"",
-            workingDirectory
+            Configuration.ApplicationFolder
         );
 
-        var codeCoverageReport = Path.Combine(workingDirectory, "coverage", "dotCover.html");
+        var codeCoverageReport = Path.Combine(Configuration.ApplicationFolder, "coverage", "dotCover.html");
         AnsiConsole.MarkupLine($"[green]Code Coverage Report[/] {codeCoverageReport}");
-        ProcessHelper.StartProcess($"open {codeCoverageReport}", workingDirectory);
+        ProcessHelper.StartProcess($"open {codeCoverageReport}", Configuration.ApplicationFolder);
 
         return 0;
     }

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -460,55 +460,55 @@ public class ConfigureContinuousDeploymentsCommand : Command
              [bold]Please review planned changes before continuing.[/]
 
              1. The following will be created or updated in Azure:
-
+             
                 [bold]Active Directory App Registrations/Service Principals:[/]
                 * [blue]{Config.StagingSubscription.AppRegistration.Name}[/] with access to the [blue]{Config.StagingSubscription.Name}[/] subscription.
                 * [blue]{Config.ProductionSubscription.AppRegistration.Name}[/] with access to the [blue]{Config.ProductionSubscription.Name}[/] subscription.
-
+             
                 [yellow]** The Service Principals will get 'Contributor' and 'User Access Administrator' role on the Azure Subscriptions.[/]
-
+             
                 [bold]Active Directory Security Groups:[/]
                 * [blue]{Config.StagingSubscription.SqlAdminsGroup.Name}[/]
                 * [blue]{Config.ProductionSubscription.SqlAdminsGroup.Name}[/]
-
+             
                 [yellow]** The SQL Admins Security Groups are used to grant Managed Identities and CI/CD permissions to SQL Databases.[/]
 
              2. The following GitHub environments will be created if not exists:
                 * [blue]staging[/]
                 * [blue]production[/]
-
+             
                 [yellow]** Environments are used to require approval when infrastructure is deployed. In private GitHub repositories, this requires a paid plan.[/]
 
              3. The following GitHub repository variables will be created:
-
+             
                 [bold]Shared Variables:[/]
                 * TENANT_ID: [blue]{Config.TenantId}[/]
                 * UNIQUE_PREFIX: [blue]{Config.UniquePrefix}[/]
-
+             
                 [bold]Staging Shared Variables:[/]
                 * STAGING_SUBSCRIPTION_ID: [blue]{Config.StagingSubscription.Id}[/]
                 * STAGING_SHARED_LOCATION: [blue]{Config.StagingLocation.SharedLocation}[/]
                 * STAGING_SERVICE_PRINCIPAL_ID: [blue]{stagingServicePrincipal}[/]
                 * STAGING_SQL_ADMIN_OBJECT_ID: [blue]{stagingSqlAdminObject}[/]
                 * STAGING_DOMAIN_NAME: [blue]-[/] ([yellow]Manually changed this and triggered deployment to set up the domain[/])
-
+             
                 [bold]Staging Cluster Variables:[/]
                 * STAGING_CLUSTER_ENABLED: [blue]true[/]
                 * STAGING_CLUSTER_LOCATION: [blue]{Config.StagingLocation.ClusterLocation}[/]
                 * STAGING_CLUSTER_LOCATION_ACRONYM: [blue]{Config.StagingLocation.ClusterLocationAcronym}[/]
-
+             
                 [bold]Production Shared Variables:[/]
                 * PRODUCTION_SUBSCRIPTION_ID: [blue]{Config.ProductionSubscription.Id}[/]
                 * PRODUCTION_SHARED_LOCATION: [blue]{Config.ProductionLocation.SharedLocation}[/]
                 * PRODUCTION_SERVICE_PRINCIPAL_ID: [blue]{productionServicePrincipal}[/]
                 * PRODUCTION_SQL_ADMIN_OBJECT_ID: [blue]{productionSqlAdminObject}[/]
                 * PRODUCTION_DOMAIN_NAME: [blue]-[/] ([yellow]Manually changed this and triggered deployment to set up the domain[/])
-
+             
                 [bold]Production Cluster 1 Variables:[/]
                 * PRODUCTION_CLUSTER1_ENABLED: [blue]false[/] ([yellow]Change this to 'true' when ready to deploy to production[/])
                 * PRODUCTION_CLUSTER1_LOCATION: [blue]{Config.ProductionLocation.ClusterLocation}[/]
                 * PRODUCTION_CLUSTER1_LOCATION_ACRONYM: [blue]{Config.ProductionLocation.ClusterLocationAcronym}[/]
-
+             
                 [yellow]** All variables can be changed on the GitHub Settings page. For example, if you want to deploy production or staging to different locations.[/]
 
              4. Disable the reusable GitHub workflows [blue]Deploy Container[/] and [blue]Plan and Deploy Infrastructure[/].
@@ -610,23 +610,23 @@ public class ConfigureContinuousDeploymentsCommand : Command
         void CreateFederatedCredential(string appRegistrationId, string displayName, string refRefsHeadsMain)
         {
             var parameters = JsonSerializer.Serialize(new
-            {
-                name = displayName,
-                issuer = "https://token.actions.githubusercontent.com",
-                subject = $"""repo:{Config.GithubInfo!.Path}:{refRefsHeadsMain}""",
-                audiences = new[] { "api://AzureADTokenExchange" }
-            }
+                {
+                    name = displayName,
+                    issuer = "https://token.actions.githubusercontent.com",
+                    subject = $"""repo:{Config.GithubInfo!.Path}:{refRefsHeadsMain}""",
+                    audiences = new[] { "api://AzureADTokenExchange" }
+                }
             );
 
             ProcessHelper.StartProcess(new ProcessStartInfo
-            {
-                FileName = Configuration.IsWindows ? "cmd.exe" : "az",
-                Arguments =
+                {
+                    FileName = Configuration.IsWindows ? "cmd.exe" : "az",
+                    Arguments =
                         $"{(Configuration.IsWindows ? "/C az" : string.Empty)} ad app federated-credential create --id {appRegistrationId} --parameters  @-",
-                RedirectStandardInput = true,
-                RedirectStandardOutput = !Configuration.VerboseLogging,
-                RedirectStandardError = !Configuration.VerboseLogging
-            }, parameters
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = !Configuration.VerboseLogging,
+                    RedirectStandardError = !Configuration.VerboseLogging
+                }, parameters
             );
         }
     }
@@ -864,9 +864,9 @@ public class ConfigureContinuousDeploymentsCommand : Command
              - To add a step for manual approval during infrastructure deployment to the staging and production environments, set up required reviewers on GitHub environments. Visit [blue]{Config.GithubInfo!.Url}/settings/environments[/] and enable [blue]Required reviewers[/] for the [bold]staging[/] and [bold]production[/] environments. Requires a paid GitHub plan for private repositories.
 
              - Configure the Domain Name for the staging and production environments. This involves two steps:
-
+             
                  a. Go to [blue]{Config.GithubInfo!.Url}/settings/variables/actions[/] to set the [blue]DOMAIN_NAME_STAGING[/] and [blue]DOMAIN_NAME_PRODUCTION[/] variables. E.g. [blue]staging.your-saas-company.com[/] and [blue]your-saas-company.com[/].
-
+             
                  b. Run the [blue]Cloud Infrastructure - Deployment[/] workflow again. Note that it might fail with an error message to set up a DNS TXT and CNAME record. Once done, re-run the failed jobs.
 
              - Set up SonarCloud for code quality and security analysis. This service is free for public repositories. Visit [blue]https://sonarcloud.io[/] to connect your GitHub account. Add the [blue]SONAR_TOKEN[/] secret, and the [blue]SONAR_ORGANIZATION[/] and [blue]SONAR_PROJECT_KEY[/] variables to the GitHub repository. The workflows are already configured for SonarCloud analysis.

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -164,7 +164,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
         while (true)
         {
             var listWorkflowsCommand = $"gh workflow list --json name,state,id --repo={Config.GithubInfo!.Path}";
-            var result = ProcessHelper.StartProcess(listWorkflowsCommand, Configuration.GetSourceCodeFolder(), true).Trim();
+            var result = ProcessHelper.StartProcess(listWorkflowsCommand, Configuration.CliFolder, true).Trim();
 
             if (result.StartsWith('[') && result.EndsWith(']'))
             {
@@ -742,7 +742,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
         {
             // Command to list workflows
             var listWorkflowsCommand = $"gh workflow list --json name,state,id --repo={Config.GithubInfo!.Path}";
-            var workflowsJson = ProcessHelper.StartProcess(listWorkflowsCommand, Configuration.GetSourceCodeFolder(), true);
+            var workflowsJson = ProcessHelper.StartProcess(listWorkflowsCommand, Configuration.CliFolder, true);
 
             // Parse JSON to find the specific workflow and check if it's active
             using var jsonDocument = JsonDocument.Parse(workflowsJson);
@@ -756,7 +756,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
                 // Disable the workflow if it is active
                 var workflowId = element.GetProperty("id").GetInt64();
                 var disableCommand = $"gh workflow disable {workflowId} --repo={Config.GithubInfo!.Path}";
-                ProcessHelper.StartProcess(disableCommand, Configuration.GetSourceCodeFolder(), true);
+                ProcessHelper.StartProcess(disableCommand, Configuration.CliFolder, true);
 
                 AnsiConsole.MarkupLine($"[green]Reusable Git Workflow '{workflowName}' has been disabled.[/]");
 
@@ -794,7 +794,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
                 AnsiConsole.MarkupLine($"[green]Starting {workflowName} GitHub workflow...[/]");
 
                 var runWorkflowCommand = $"gh workflow run {workflowFileName} --ref main --repo={Config.GithubInfo!.Path}";
-                ProcessHelper.StartProcess(runWorkflowCommand, Configuration.GetSourceCodeFolder(), true);
+                ProcessHelper.StartProcess(runWorkflowCommand, Configuration.CliFolder, true);
 
                 // Wait briefly to ensure the run has started
                 Thread.Sleep(TimeSpan.FromSeconds(15));
@@ -802,7 +802,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
                 // Fetch and filter the workflows to find a "running" one
                 var listWorkflowRunsCommand =
                     $"gh run list --workflow={workflowFileName} --json databaseId,status --repo={Config.GithubInfo!.Path}";
-                var workflowsJson = ProcessHelper.StartProcess(listWorkflowRunsCommand, Configuration.GetSourceCodeFolder(), true);
+                var workflowsJson = ProcessHelper.StartProcess(listWorkflowRunsCommand, Configuration.CliFolder, true);
 
                 long? workflowId = null;
                 using (var jsonDocument = JsonDocument.Parse(workflowsJson))
@@ -826,10 +826,10 @@ public class ConfigureContinuousDeploymentsCommand : Command
                 }
 
                 var watchWorkflowRunCommand = $"gh run watch {workflowId.Value} --repo={Config.GithubInfo!.Path}";
-                ProcessHelper.StartProcessWithSystemShell(watchWorkflowRunCommand, Configuration.GetSourceCodeFolder());
+                ProcessHelper.StartProcessWithSystemShell(watchWorkflowRunCommand, Configuration.CliFolder);
 
                 // Run the command one more time to get the result
-                var runResult = ProcessHelper.StartProcess(watchWorkflowRunCommand, Configuration.GetSourceCodeFolder(), true);
+                var runResult = ProcessHelper.StartProcess(watchWorkflowRunCommand, Configuration.CliFolder, true);
                 if (runResult.Contains("completed") && runResult.Contains("success")) return;
 
                 AnsiConsole.MarkupLine($"[red]Error: Failed to run the {workflowName} GitHub workflow.[/]");

--- a/developer-cli/Commands/InstallCommand.cs
+++ b/developer-cli/Commands/InstallCommand.cs
@@ -50,7 +50,11 @@ public class InstallCommand : Command
 
         if (IsAliasRegistered())
         {
-            AnsiConsole.MarkupLine($"[yellow]The CLI is already installed please run {Configuration.AliasName} to use it.[/]");
+            var installedAliasPath = Configuration.GetConfigurationSetting().CliSourceCodeFolder!;
+            AnsiConsole.MarkupLine(Environment.ProcessPath!.StartsWith(installedAliasPath)
+                ? $"[yellow]The CLI is already installed please run {Configuration.AliasName} to use it.[/]"
+                : $"[yellow]There is already a CLI with the alias '{Configuration.AliasName}' installed in {installedAliasPath}.[/]");
+
             return;
         }
 

--- a/developer-cli/Commands/TranslateCommand.cs
+++ b/developer-cli/Commands/TranslateCommand.cs
@@ -47,21 +47,19 @@ public class TranslateCommand : Command
 
     private static string GetTranslationFile(string? language)
     {
-        var workingDirectory = new DirectoryInfo(Path.Combine(Configuration.GetSourceCodeFolder(), "..", "application"));
-        var translationFiles = workingDirectory
-            .GetFiles("*.po", SearchOption.AllDirectories)
-            .Where(f => !f.FullName.Contains("node_modules") &&
-                        !f.FullName.EndsWith("en-US.po") &&
-                        !f.FullName.EndsWith("pseudo.po")
+        var translationFiles = Directory.GetFiles(Configuration.ApplicationFolder, "*.po", SearchOption.AllDirectories)
+            .Where(f => !f.Contains("node_modules") &&
+                        !f.EndsWith("en-US.po") &&
+                        !f.EndsWith("pseudo.po")
             )
-            .ToDictionary(s => s.FullName.Replace(workingDirectory.FullName, ""), f => f);
+            .ToDictionary(s => s.Replace(Configuration.ApplicationFolder, ""), f => f);
 
         if (language is not null)
         {
             var translationFile = translationFiles.Values
-                .FirstOrDefault(f => f.Name.Equals($"{language}.po", StringComparison.OrdinalIgnoreCase));
+                .FirstOrDefault(f => f.Equals($"{language}.po", StringComparison.OrdinalIgnoreCase));
 
-            return translationFile?.FullName
+            return translationFile
                    ?? throw new InvalidOperationException($"Translation file for language '{language}' not found.");
         }
 
@@ -70,7 +68,7 @@ public class TranslateCommand : Command
             .AddChoices(translationFiles.Keys);
 
         var selection = AnsiConsole.Prompt(prompt);
-        return translationFiles[selection].FullName;
+        return translationFiles[selection];
     }
 
     private static async Task RunTranslation(string translationFile)

--- a/developer-cli/Commands/UninstallCommand.cs
+++ b/developer-cli/Commands/UninstallCommand.cs
@@ -19,7 +19,7 @@ public class UninstallCommand : Command
     {
         if (Configuration.IsWindows && !Configuration.IsDebugMode)
         {
-            AnsiConsole.MarkupLine($"[yellow]Please run 'dotnet run uninstall' from {Configuration.GetSourceCodeFolder()}.[/]");
+            AnsiConsole.MarkupLine($"[yellow]Please run 'dotnet run uninstall' from {Configuration.CliFolder}.[/]");
             Environment.Exit(0);
         }
 

--- a/developer-cli/Installation/ChangeDetection.cs
+++ b/developer-cli/Installation/ChangeDetection.cs
@@ -33,7 +33,7 @@ public static class ChangeDetection
     {
         // Get all files C# and C# project files in the Developer CLI solution
         var solutionFiles = Directory
-            .EnumerateFiles(Configuration.GetSourceCodeFolder(), "*.cs*", SearchOption.AllDirectories)
+            .EnumerateFiles(Configuration.CliFolder, "*.cs*", SearchOption.AllDirectories)
             .Where(f => !f.Contains("artifacts"))
             .ToList();
 
@@ -61,7 +61,7 @@ public static class ChangeDetection
         try
         {
             // Build the project before renaming exe on Windows
-            ProcessHelper.StartProcess("dotnet build", Configuration.GetSourceCodeFolder());
+            ProcessHelper.StartProcess("dotnet build", Configuration.CliFolder);
 
             if (Configuration.IsWindows)
             {
@@ -74,11 +74,11 @@ public static class ChangeDetection
             // Call "dotnet publish" to create a new executable
             ProcessHelper.StartProcess(
                 $"dotnet publish DeveloperCli.csproj -o \"{Configuration.PublishFolder}\"",
-                Configuration.GetSourceCodeFolder()
+                Configuration.CliFolder
             );
 
             var configurationSetting = Configuration.GetConfigurationSetting();
-            configurationSetting.SourceCodeFolder = Configuration.GetSourceCodeFolder();
+            configurationSetting.SourceCodeFolder = Configuration.CliFolder;
             configurationSetting.Hash = currentHash;
             Configuration.SaveConfigurationSetting(configurationSetting);
         }

--- a/developer-cli/Installation/ChangeDetection.cs
+++ b/developer-cli/Installation/ChangeDetection.cs
@@ -78,7 +78,6 @@ public static class ChangeDetection
             );
 
             var configurationSetting = Configuration.GetConfigurationSetting();
-            configurationSetting.SourceCodeFolder = Configuration.CliFolder;
             configurationSetting.Hash = currentHash;
             Configuration.SaveConfigurationSetting(configurationSetting);
         }

--- a/developer-cli/Installation/Configuration.cs
+++ b/developer-cli/Installation/Configuration.cs
@@ -14,30 +14,28 @@ public static class Configuration
 
     private static readonly string UserFolder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
+    public static readonly string AliasName = Assembly.GetExecutingAssembly().GetName().Name!;
+
     public static readonly string PublishFolder = IsWindows
         ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "PlatformPlatform")
         : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".PlatformPlatform");
 
-    public static readonly string AliasName = Assembly.GetExecutingAssembly().GetName().Name!;
+    public static readonly string SourceCodeFolder = IsDebugMode
+        // In debug mode, the ProcessPath is in /developer-cli/artifacts/bin/DeveloperCli/debug/pp.exe
+        ? new DirectoryInfo(Environment.ProcessPath!).Parent!.Parent!.Parent!.Parent!.Parent!.Parent!.FullName
+        : new DirectoryInfo(GetConfigurationSetting().SourceCodeFolder!).Parent!.FullName;
+
+    public static readonly string ApplicationFolder = new(Path.Combine(SourceCodeFolder, "application"));
+
+    public static readonly string CliFolder = new(Path.Combine(SourceCodeFolder, "developer-cli"));
+
+    public static bool IsDebugMode => Environment.ProcessPath!.Contains("debug");
 
     private static string ConfigFile => Path.Combine(PublishFolder, $"{AliasName}.json");
 
     public static bool VerboseLogging { get; set; }
 
     public static bool AutoConfirm { get; set; }
-
-    public static bool IsDebugMode => Environment.ProcessPath!.Contains("debug");
-
-    public static string GetSourceCodeFolder()
-    {
-        if (IsDebugMode)
-        {
-            // In debug mode the ProcessPath is in developer-cli/artifacts/bin/DeveloperCli/debug/pp.exe
-            return new DirectoryInfo(Environment.ProcessPath!).Parent!.Parent!.Parent!.Parent!.Parent!.FullName;
-        }
-
-        return GetConfigurationSetting().SourceCodeFolder!;
-    }
 
     public static ConfigurationSetting GetConfigurationSetting()
     {

--- a/developer-cli/Program.cs
+++ b/developer-cli/Program.cs
@@ -17,15 +17,18 @@ if (args.Length == 0)
     args = ["--help"];
 }
 
+var solutionName = new DirectoryInfo(Configuration.SourceCodeFolder).Name;
 if (args.Length == 1 && (args[0] == "--help" || args[0] == "-h" || args[0] == "-?"))
 {
-    var figletText = new FigletText("PlatformPlatform");
+    var figletText = new FigletText(solutionName);
     AnsiConsole.Write(figletText);
 }
 
+AnsiConsole.WriteLine($"Source code folder: {Configuration.SourceCodeFolder} \n");
+
 var rootCommand = new RootCommand
 {
-    Description = "Welcome to the PlatformPlatform Developer CLI!"
+    Description = $"Welcome to the {solutionName} Developer CLI!"
 };
 
 var allCommands = Assembly.GetExecutingAssembly().GetTypes()

--- a/developer-cli/Utilities/GitHelper.cs
+++ b/developer-cli/Utilities/GitHelper.cs
@@ -19,7 +19,7 @@ public record Commit1(string Date, string Hash, string Message)
 {
     public string GetCommitMessage()
     {
-        return ProcessHelper.StartProcess($"git log -1 --pretty=%B {Hash}", Configuration.GetSourceCodeFolder(), true);
+        return ProcessHelper.StartProcess($"git log -1 --pretty=%B {Hash}", Configuration.SourceCodeFolder, true);
     }
 }
 
@@ -49,6 +49,6 @@ public record Commit
 
     public string GetFullCommitMessage()
     {
-        return ProcessHelper.StartProcess($"git log -1 --pretty=%B {Hash}", Configuration.GetSourceCodeFolder(), true);
+        return ProcessHelper.StartProcess($"git log -1 --pretty=%B {Hash}", Configuration.SourceCodeFolder, true);
     }
 }

--- a/developer-cli/Utilities/GithubHelper.cs
+++ b/developer-cli/Utilities/GithubHelper.cs
@@ -9,7 +9,7 @@ public static class GithubHelper
     public static string GetGithubUri(string? remote = null)
     {
         // Get all Git remotes
-        var output = ProcessHelper.StartProcess("git remote -v", Configuration.GetSourceCodeFolder(), true);
+        var output = ProcessHelper.StartProcess("git remote -v", Configuration.SourceCodeFolder, true);
 
         // Sort the output lines so that the "origin" is at the top
         output = string.Join('\n', output.Split('\n')

--- a/developer-cli/Utilities/SolutionHelper.cs
+++ b/developer-cli/Utilities/SolutionHelper.cs
@@ -7,10 +7,8 @@ public static class SolutionHelper
 {
     public static FileInfo GetSolution(string? solutionName)
     {
-        var workingDirectory = Path.Combine(Configuration.GetSourceCodeFolder(), "..", "application");
-
         var solutionsFiles = Directory
-            .GetFiles(workingDirectory, "*.sln", SearchOption.AllDirectories)
+            .GetFiles(Configuration.ApplicationFolder, "*.sln", SearchOption.AllDirectories)
             .ToDictionary(s => new FileInfo(s).Name.Replace(".sln", ""), s => s);
 
         if (solutionName is not null && !solutionsFiles.ContainsKey(solutionName))


### PR DESCRIPTION
### Summary & Motivation

Update the PlatformPlatform .NET CLI to address issues encountered when running multiple CLIs side by side. These changes improve configuration management, naming conventions, and code quality for better usability and maintainability.

Key updates include:
- Use the Git source code folder root name as the CLI name, enhancing support for running multiple CLIs side by side.
- Add detection for existing CLI installations when setting up aliases to avoid conflicts.
- Refactor `GetSourceCodeFolder` to a static `SourceCodeFolder` property and introduce `ApplicationFolder` and `CliFolder` properties in `Configuration.GitFolder` for more structured folder management.
- Rename `SourceCodeFolder` in CLI .json to `CliSourceCodeFolder`.
- Ensure it's not possible to change the path in CliSourceCodeFolder to prevent accidental changes when having multiple git repositories of PlatformPlatform side by side.
- Perform a full JetBrains code cleanup of the CLI solution for consistency and improved code quality.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
