### PR TITLE
Move authentication token registration to Shared Kernel

### DIFF
--- a/application/account-management/Core/Configuration.cs
+++ b/application/account-management/Core/Configuration.cs
@@ -1,11 +1,8 @@
-using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using PlatformPlatform.AccountManagement.Database;
 using PlatformPlatform.AccountManagement.Features.Users.Shared;
 using PlatformPlatform.AccountManagement.Integrations.Gravatar;
-using PlatformPlatform.SharedKernel.Authentication;
-using PlatformPlatform.SharedKernel.Authentication.TokenGeneration;
 using PlatformPlatform.SharedKernel.Configuration;
 
 namespace PlatformPlatform.AccountManagement;
@@ -28,11 +25,6 @@ public static class Configuration
 
         return services
             .AddSharedServices<AccountManagementDbContext>(Assembly)
-            .AddScoped<IPasswordHasher<object>, PasswordHasher<object>>()
-            .AddScoped<OneTimePasswordHelper>()
-            .AddScoped<RefreshTokenGenerator>()
-            .AddScoped<AccessTokenGenerator>()
-            .AddScoped<AuthenticationTokenService>()
             .AddScoped<AvatarUpdater>()
             .AddScoped<GravatarClient>();
     }

--- a/application/shared-kernel/SharedKernel/Configuration/SharedDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/SharedDependencyConfiguration.cs
@@ -4,9 +4,12 @@ using Azure.Security.KeyVault.Keys.Cryptography;
 using Azure.Security.KeyVault.Secrets;
 using FluentValidation;
 using Microsoft.AspNetCore.Http.Json;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using PlatformPlatform.SharedKernel.Authentication;
+using PlatformPlatform.SharedKernel.Authentication.TokenGeneration;
 using PlatformPlatform.SharedKernel.Authentication.TokenSigning;
 using PlatformPlatform.SharedKernel.DomainEvents;
 using PlatformPlatform.SharedKernel.Integrations.Email;
@@ -36,6 +39,7 @@ public static class SharedDependencyConfiguration
         return services
             .AddServiceDiscovery()
             .AddSingleton(GetTokenSigningService())
+            .AddAuthentication()
             .AddDefaultJsonSerializerOptions()
             .AddPersistenceHelpers<T>()
             .AddDefaultHealthChecks()
@@ -64,6 +68,16 @@ public static class SharedDependencyConfiguration
         }
 
         return new DevelopmentTokenSigningClient();
+    }
+
+    private static IServiceCollection AddAuthentication(this IServiceCollection services)
+    {
+        return services
+            .AddScoped<IPasswordHasher<object>, PasswordHasher<object>>()
+            .AddScoped<OneTimePasswordHelper>()
+            .AddScoped<RefreshTokenGenerator>()
+            .AddScoped<AccessTokenGenerator>()
+            .AddScoped<AuthenticationTokenService>();
     }
 
     private static IServiceCollection AddDefaultJsonSerializerOptions(this IServiceCollection services)

--- a/application/shared-kernel/SharedKernel/Configuration/SharedDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/SharedDependencyConfiguration.cs
@@ -43,7 +43,7 @@ public static class SharedDependencyConfiguration
             .AddDefaultJsonSerializerOptions()
             .AddPersistenceHelpers<T>()
             .AddDefaultHealthChecks()
-            .AddEmailSignatureClient()
+            .AddEmailClient()
             .AddMediatRPipelineBehaviours()
             .RegisterMediatRRequest(assemblies)
             .RegisterRepositories(assemblies);
@@ -111,7 +111,7 @@ public static class SharedDependencyConfiguration
         return services;
     }
 
-    private static IServiceCollection AddEmailSignatureClient(this IServiceCollection services)
+    private static IServiceCollection AddEmailClient(this IServiceCollection services)
     {
         if (SharedInfrastructureConfiguration.IsRunningInAzure)
         {


### PR DESCRIPTION
### Summary & Motivation

Move the registration of authentication-related services to the Shared Kernel to allow self-contained systems to create authenticated HTTP clients in base tests. The following services are now registered in the Shared Kernel:

- `IPasswordHasher<object>`
- `OneTimePasswordHelper`
- `RefreshTokenGenerator`
- `AccessTokenGenerator`
- `AuthenticationTokenService`

Additionally, `AddEmailSignatureClient` has been renamed to `AddEmailClient` for improved clarity and consistency.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
