### PR TITLE
Ensure certificate directory exists before creating it

### DIFF
--- a/application/AppHost/SslCertificateManager.cs
+++ b/application/AppHost/SslCertificateManager.cs
@@ -46,6 +46,16 @@ public static class SslCertificateManager
 
             File.Delete(certificateLocation);
         }
+        else
+        {
+            var certificateDirectory = Path.GetDirectoryName(certificateLocation)!;
+            if (!Directory.Exists(certificateDirectory))
+            {
+                Console.WriteLine($"Certificate directory {certificateDirectory} does not exist. Creating it.");
+
+                Directory.CreateDirectory(certificateDirectory);
+            }
+        }
 
         Process.Start(new ProcessStartInfo
             {


### PR DESCRIPTION
### Summary & Motivation

When running on Windows, the `dotnet dev-certs` command fails to create the SSL certificate when the `.aspnet/dev-certs/https/` folder doesn't exist.

This change ensures the full path is created before executing the `dotnet dev-certs`.

### Checklist

- [x] I have added a Label to the pull-request
- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
