### PR TITLE
Fix pull-platformplatform-changes CLI command on Windows

### DIFF
--- a/developer-cli/Utilities/ProcessHelper.cs
+++ b/developer-cli/Utilities/ProcessHelper.cs
@@ -55,8 +55,9 @@ public static class ProcessHelper
         bool createNoWindow = false
     )
     {
-        var fileName = command.Split(' ')[0];
-        var arguments = command.Length > fileName.Length ? command.Substring(fileName.Length + 1) : string.Empty;
+        var originalFileName = command.Split(' ')[0];
+        var fileName = FindFullPathFromPath(originalFileName) ?? throw new FileNotFoundException($"Command '{command}' not found");
+        var arguments = command.Contains(' ') ? command[(originalFileName.Length + 1)..] : string.Empty;
         var processStartInfo = new ProcessStartInfo
         {
             FileName = fileName,
@@ -122,6 +123,30 @@ public static class ProcessHelper
     public static bool IsProcessRunning(string process)
     {
         return Process.GetProcessesByName(process).Length > 0;
+    }
+
+    private static string? FindFullPathFromPath(string command)
+    {
+       string[] commandFormats = OperatingSystem.IsWindows() ? ["{0}.exe", "{0}.cmd"] : ["{0}"];
+
+        var pathVariable = Environment.GetEnvironmentVariable("PATH");
+        if (pathVariable is null) return null;
+
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        foreach (var directory in pathVariable.Split(separator))
+        {
+            foreach (var format in commandFormats)
+            {
+                var fullPath = Path.Combine(directory, string.Format(format, command));
+
+                if (File.Exists(fullPath))
+                {
+                    return fullPath;
+                }
+            }
+        }
+
+        return null;
     }
 }
 


### PR DESCRIPTION
### Summary & Motivation

While running on Windows, the `pp pull-platform platform-changes` fails because it couldn't find the `npm` command, which is not an executable file.

This fix searches for the precise command location while running on Windows OS using the `.exe` and `.cmd` extensions.

### Checklist

- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
