### PR TITLE
Allow serving local environment from any address

### DIFF
--- a/application/AppHost/ConfigurationExtensions.cs
+++ b/application/AppHost/ConfigurationExtensions.cs
@@ -1,0 +1,16 @@
+namespace AppHost;
+
+public static class ConfigurationExtensions
+{
+    public static IResourceBuilder<TDestination> WithUrlConfiguration<TDestination>(
+        this IResourceBuilder<TDestination> builder,
+        string applicationBasePath) where TDestination : IResourceWithEnvironment
+    {
+        var baseUrl = Environment.GetEnvironmentVariable("PUBLIC_URL") ?? "https://localhost:9000";
+        applicationBasePath = applicationBasePath.TrimEnd('/');
+
+        return builder
+            .WithEnvironment("PUBLIC_URL", baseUrl)
+            .WithEnvironment("CDN_URL", baseUrl + applicationBasePath);
+    }
+}

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -59,6 +59,7 @@ var accountManagementWorkers = builder
 
 var accountManagementApi = builder
     .AddProject<AccountManagement_Api>("account-management-api")
+    .WithUrlConfiguration("/account-management")
     .WithReference(accountManagementDatabase)
     .WithReference(azureStorage)
     .WaitFor(accountManagementWorkers);
@@ -74,6 +75,7 @@ var backOfficeWorkers = builder
 
 var backOfficeApi = builder
     .AddProject<BackOffice_Api>("back-office-api")
+    .WithUrlConfiguration("/back-office")
     .WithReference(backOfficeDatabase)
     .WithReference(azureStorage)
     .WaitFor(backOfficeWorkers);

--- a/application/account-management/Api/Properties/launchSettings.json
+++ b/application/account-management/Api/Properties/launchSettings.json
@@ -4,9 +4,7 @@
     "Api": {
       "commandName": "Project",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "development",
-        "PUBLIC_URL": "https://localhost:9000",
-        "CDN_URL": "https://localhost:9000/account-management"
+        "ASPNETCORE_ENVIRONMENT": "development"
       }
     }
   }

--- a/application/back-office/Api/Properties/launchSettings.json
+++ b/application/back-office/Api/Properties/launchSettings.json
@@ -4,9 +4,7 @@
     "Api": {
       "commandName": "Project",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "development",
-        "PUBLIC_URL": "https://localhost:9000",
-        "CDN_URL": "https://localhost:9000/back-office"
+        "ASPNETCORE_ENVIRONMENT": "development"
       }
     }
   }

--- a/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppConfiguration.cs
@@ -146,7 +146,8 @@ public class SinglePageAppConfiguration
 
         if (_isDevelopment)
         {
-            trustedHosts += " wss://localhost:* https://localhost:*";
+            var hostname = new Uri(PublicUrl).Host;
+            trustedHosts += $" wss://{hostname}:* https://{hostname}:*";
         }
 
         var contentSecurityPolicies = new[]


### PR DESCRIPTION
### Summary & Motivation

Up to now, it has been hard to test the web app on other devices, as the code was hard coded to the web app being at `localhost:9000`, thus allowing only tests from the computer where development takes place. With this change, `PUBLIC_URL` can be configured for the AppGateway to allow serving the app on any address, allowing testing on multiple devices.

This allows using a reverse proxy tool, such as ngrok or Tailscale, to serve the local web app on address of your choice. With Tailscale you can use `tailscale serve` to serve on your Tailscale network, or `tailscale funnel` to serve on the internet:

```
➜  ~ tailscale serve https://localhost:9000
Available within your tailnet:

https://your-computer-name.tail492ec.ts.net/
|-- proxy https://localhost:9000
```

Tailscale assigns a unique hostname to the app, in this example `your-computer-name.tail492ec.ts.net`. This you put into the `PUBLIC_URL` environment variable for the AppHost project.

Alternatively, this can be used without a reverse proxy tool, to serve directly on your local network: Set `PUBLIC_URL` e.g. to `https://<your IP>:9000 `. This is not ideal however, as the local development TLS certificate will not match the address, and as this currently requires `applicationUrl` in `launchSettings.json` in the AppGateway to be set to listen on any `0.0.0.0`. 

### Downstream Projects

Projects that are using PlatformPlatform need to make the following changes:

1. For each self-contained system, remove `PUBLIC_URL` and `CDN_URL` from `launchSettings.json` in the API and Worker projects
2. Then, for each project, call `WithUrlConfiguration` in `AppHost/Program.cs` like this:

```
var yourSelfContainedSystemApi = builder
    .AddProject<YourSelfContainedSystem_Api>("your-self-contained-system-api")
    .WithUrlConfiguration("/your-self-contained-system")
    ....
```

### Checklist

- [x] I have added tests, and done manual regression tests
- [x] I have updated the documentation, if necessary
