### PR TITLE
Improve Developer CLI error handling for prerequisites and Azure subscription validation

### DIFF
--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -242,6 +242,14 @@ public class ConfigureContinuousDeploymentsCommand : Command
         Config.StagingSubscription = SelectSubscription("Staging");
         Config.ProductionSubscription = SelectSubscription("Production");
 
+        if(Config.StagingSubscription.TenantId != Config.ProductionSubscription.TenantId)
+        {
+            AnsiConsole.MarkupLine($"[red]ERROR:[/] Please select two subscriptions from the same tenant, and try again.");
+            Environment.Exit(1);
+        }
+
+        RunAzureCliCommand($"""account set --subscription "{Config.StagingSubscription.Id}" """);
+
         return;
 
         Subscription SelectSubscription(string environmentName)

--- a/developer-cli/Installation/Prerequisite.cs
+++ b/developer-cli/Installation/Prerequisite.cs
@@ -36,7 +36,8 @@ file sealed record CommandLineToolPrerequisite(string Command, string DisplayNam
                 Arguments = Command,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
-            }
+            },
+            exitOnError: false
         );
 
         var possibleFileLocations = checkOutput.Split(Environment.NewLine);


### PR DESCRIPTION
### Summary & Motivation

Fix an issue in the Developer CLI where missing prerequisites (e.g., NodeJS) resulted in the CLI exiting without any error message. The CLI now correctly identifies missing prerequisites and displays an error such as: `NodeJS of minimum version 25.3.0 should be installed.`

Additionally, a validation has been added to the `configure-continuous-deployments` CLI command to ensure that the selected Azure subscriptions for staging and production belong to the same tenant, preventing configuration errors.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
