### PR TITLE
Update GitHub Action to allow multi-line commit messages for PlatformPlatform pull requests

### DIFF
--- a/.github/workflows/validate-pull-request-conventions.yml
+++ b/.github/workflows/validate-pull-request-conventions.yml
@@ -82,6 +82,17 @@ jobs:
             EXIT_CODE=1
           fi
 
+          # Check if the required checklist items are checked
+          if ! echo "$DESCRIPTION" | grep -q "\- \[x\] I have added tests, or done manual regression tests"; then
+            echo "❌ Please check the box: 'I have added tests, or done manual regression tests'"
+            EXIT_CODE=1
+          fi
+          
+          if ! echo "$DESCRIPTION" | grep -q "\- \[x\] I have updated the documentation, if necessary"; then
+            echo "❌ Please check the box: 'I have updated the documentation, if necessary'"
+            EXIT_CODE=1
+          fi
+
           if [[ "$EXIT_CODE" -eq 0 ]]; then
             echo "✅ The pull request description looks valid"
           fi


### PR DESCRIPTION
### Summary & Motivation

Modify the GitHub Action for Git convention validation to allow multi-line commit messages if they start with "PlatformPlatform PR". This change accommodates the convention used for cherry-picking merge commits from PlatformPlatform into downstream projects, where these commits have multi-line messages that contain the description from PlatformPlatform.

This update ensures that the validation process remains compatible with downstream project workflows while maintaining consistency for other commit messages.

Also, there is a new check to validate that the checkboxes for `I have added tests or done manual regression tests` and `I have updated the documentation if necessary` have been checked.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
