### PR TITLE
Allow multiple sentences in commit messages for PlatformPlatform cherry-picked commits

### DIFF
--- a/.github/workflows/validate-pull-request-conventions.yml
+++ b/.github/workflows/validate-pull-request-conventions.yml
@@ -207,8 +207,8 @@ jobs:
               fi
             fi
 
-            # Check for period-space-capital (new sentence)
-            if echo "$COMMIT_MESSAGE" | grep -P '\. [A-Z]' | grep -vP '(incl\.|e\.g\.|etc\.|i\.e\.) [A-Z]' > /dev/null; then
+            # Check for period-space-capital (new sentence) unless it's a downstream commit of a pull request cherry-picked from PlatformPlatform
+            if [[ ! "$COMMIT_MESSAGE" =~ ^"PlatformPlatform PR" ]] && echo "$COMMIT_MESSAGE" | grep -P '\. [A-Z]' | grep -vP '(incl\.|e\.g\.|etc\.|i\.e\.) [A-Z]' > /dev/null; then
               echo "❌ Commit $COMMIT_SHORT contains multiple sentences"
               echo "   Message: $COMMIT_MESSAGE"
               EXIT_CODE=1


### PR DESCRIPTION
### Summary & Motivation

As a follow-up to the previous change, extend the GitHub Action for Git convention validation to allow commit messages with multiple sentences if they are cherry-picked from PlatformPlatform and start with "PlatformPlatform PR".

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
