### PR TITLE
Upgrade GitHub runners to Ubuntu 24.04 and improve Bicep output parsing

### DIFF
--- a/.github/workflows/_deploy-container.yml
+++ b/.github/workflows/_deploy-container.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   stage:
     name: Staging
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # environment: "staging"  # Manual approval disabled
     if: ${{ vars.STAGING_CLUSTER_ENABLED == 'true' && github.ref == 'refs/heads/main' }}
     env:
@@ -101,7 +101,7 @@ jobs:
     name: Production
     needs: stage
     environment: "production" # Force a manual approval
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ vars.PRODUCTION_CLUSTER1_ENABLED == 'true' && github.ref == 'refs/heads/main' }}
     env:
       UNIQUE_PREFIX: ${{ vars.UNIQUE_PREFIX }}

--- a/.github/workflows/_deploy-infrastructure.yml
+++ b/.github/workflows/_deploy-infrastructure.yml
@@ -112,9 +112,8 @@ jobs:
           tenant-id: ${{ inputs.tenant_id }}
           subscription-id: ${{ inputs.subscription_id }}
 
-      - name: Replace Classic sqlcmd (ODBC) with sqlcmd (GO)
+      - name: Install Microsoft sqlcmd tool
         run: |
-          sudo apt-get remove -y mssql-tools &&
           curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc &&
           sudo add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/22.04/prod.list)" &&
           sudo apt-get update &&

--- a/.github/workflows/_deploy-infrastructure.yml
+++ b/.github/workflows/_deploy-infrastructure.yml
@@ -46,7 +46,7 @@ on:
 jobs:
   plan:
     name: "Planning"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
     if: ${{ inputs.deployment_enabled == 'true' && github.ref == 'refs/heads/main' }}
     needs: plan
     environment: "${{ inputs.github_environment }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   build-and-test:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.generate_version.outputs.version }}
 
@@ -141,7 +141,7 @@ jobs:
   code-style-and-linting:
     name: Code Style and Linting
     if: github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   build-and-test:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.generate_version.outputs.version }}
 
@@ -89,7 +89,7 @@ jobs:
   code-style-and-linting:
     name: Code Style and Linting
     if: github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/back-office.yml
+++ b/.github/workflows/back-office.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   build-and-test:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.generate_version.outputs.version }}
 
@@ -141,7 +141,7 @@ jobs:
   code-style-and-linting:
     name: Code Style and Linting
     if: github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/validate-pull-request-conventions.yml
+++ b/.github/workflows/validate-pull-request-conventions.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check-conventions:
     name: Validate Pull Request and Git Conventions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/cloud-infrastructure/cluster/deploy-cluster.sh
+++ b/cloud-infrastructure/cluster/deploy-cluster.sh
@@ -63,7 +63,7 @@ then
   RED='\033[0;31m'
   RESET='\033[0m' # Reset formatting
 
-  cleaned_output=$(echo "$output" | sed '/^WARNING/d')
+  cleaned_output=$(echo "$output" | sed '/^WARNING/d' | sed '/^\/home\/runner\/work\//d')
   # Check for the specific error message indicating that DNS Records are missing
   if [[ $cleaned_output == *"InvalidCustomHostNameValidation"* ]] || [[ $cleaned_output == *"FailedCnameValidation"* ]] || [[ $cleaned_output == *"-certificate' under resource group '$RESOURCE_GROUP_NAME' was not found"* ]]; then
     # Get details about the container apps environment. Although the creation of the container app fails, the verification ID on the container apps environment is consistent across all container apps.
@@ -78,7 +78,7 @@ then
     echo -e "${RED}- A TXT record with the name 'asuid.$DOMAIN_NAME' and the value '$custom_domain_verification_id'.${RESET}"
     echo -e "${RED}- A CNAME record with the Host name '$DOMAIN_NAME' that points to address 'app-gateway.$default_domain'.${RESET}"
     exit 1
-  elif [[ $cleaned_output == *"ERROR:"* ]]; then
+  elif [[ $output == *"ERROR:"* ]]; then
     echo -e "${RED}$output${RESET}"
     exit 1
   fi
@@ -90,7 +90,7 @@ then
     DEPLOYMENT_PARAMETERS="-l $CLUSTER_LOCATION -n $CURRENT_DATE-$RESOURCE_GROUP_NAME --output json -f ./main-cluster.bicep -p resourceGroupName=$RESOURCE_GROUP_NAME environmentResourceGroupName=$ENVIRONMENT_RESOURCE_GROUP_NAME environment=$ENVIRONMENT containerRegistryName=$CONTAINER_REGISTRY_NAME domainName=$DOMAIN_NAME isDomainConfigured=$IS_DOMAIN_CONFIGURED sqlAdminObjectId=$SQL_ADMIN_OBJECT_ID appGatewayVersion=$APP_GATEWAY_VERSION accountManagementVersion=$ACTIVE_ACCOUNT_MANAGEMENT_VERSION backOfficeVersion=$ACTIVE_BACK_OFFICE_VERSION applicationInsightsConnectionString=$APPLICATIONINSIGHTS_CONNECTION_STRING"
     . ../deploy.sh
 
-    cleaned_output=$(echo "$output" | sed '/^WARNING/d')
+    cleaned_output=$(echo "$output" | sed '/^WARNING/d' | sed '/^\/home\/runner\/work\//d')
     if [[ $cleaned_output == "ERROR:"* ]]; then
       echo -e "${RED}$output"
       exit 1

--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -238,7 +238,6 @@ module accountManagementWorkers '../modules/container-app.bicep' = {
     hasProbesEndpoint: false
     environmentVariables: accountManagementEnvironmentVariables
   }
-  dependsOn: [accountManagementDatabase, accountManagementIdentity, communicationService]
 }
 
 module accountManagementApi '../modules/container-app.bicep' = {
@@ -263,7 +262,7 @@ module accountManagementApi '../modules/container-app.bicep' = {
     hasProbesEndpoint: true
     environmentVariables: accountManagementEnvironmentVariables
   }
-  dependsOn: [accountManagementDatabase, accountManagementIdentity, communicationService, accountManagementWorkers]
+  dependsOn: [accountManagementWorkers]
 }
 
 // Back Office
@@ -365,7 +364,6 @@ module backOfficeWorkers '../modules/container-app.bicep' = {
     hasProbesEndpoint: false
     environmentVariables: backOfficeEnvironmentVariables
   }
-  dependsOn: [backOfficeDatabase, backOfficeIdentity, communicationService]
 }
 
 module backOfficeApi '../modules/container-app.bicep' = {
@@ -390,7 +388,7 @@ module backOfficeApi '../modules/container-app.bicep' = {
     hasProbesEndpoint: true
     environmentVariables: backOfficeEnvironmentVariables
   }
-  dependsOn: [backOfficeDatabase, backOfficeIdentity, communicationService, backOfficeWorkers]
+  dependsOn: [backOfficeWorkers]
 }
 
 // App Gateway
@@ -460,7 +458,6 @@ module appGateway '../modules/container-app.bicep' = {
       }
     ]
   }
-  dependsOn: [appGatewayIdentity]
 }
 
 module appGatwayAccountManagementStorageBlobDataReaderRoleAssignment '../modules/role-assignments-storage-blob-data-reader.bicep' = {

--- a/cloud-infrastructure/environment/deploy-environment.sh
+++ b/cloud-infrastructure/environment/deploy-environment.sh
@@ -13,8 +13,7 @@ DEPLOYMENT_PARAMETERS="-l $LOCATION_SHARED -n $CURRENT_DATE-$UNIQUE_PREFIX-$ENVI
 cd "$(dirname "${BASH_SOURCE[0]}")"
 . ../deploy.sh
 
-cleaned_output=$(echo "$output" | sed '/^WARNING/d')
-if [[ $cleaned_output == *"ERROR:"* ]]; then
+if [[ $output == *"ERROR:"* ]]; then
   echo -e "${RED}$output"
   exit 1
 fi


### PR DESCRIPTION
### Summary & Motivation

Upgrade all GitHub runners to the latest stable version, Ubuntu 24.04, for improved stability and predictability. Previously, runners used `ubuntu:latest`, which posed risks due to breaking changes between updates.

In Ubuntu 24.04, the classic Microsoft `sqlcmd` (ODBC) is no longer installed by default, so the logic to uninstall it has been removed. The new `sqlcmd` (Go) is still installed, but it relies on the older package source from Ubuntu 22.04 (`https://packages.microsoft.com/config/ubuntu/22.04/prod.list`) due to the lack of an updated package for 24.04. For more details, see: https://github.com/microsoft/go-sqlcmd/issues/532.

Additionally, Bicep output parsing has been improved. JSON extraction now removes warnings about unneeded dependencies, preventing failures in detecting valid JSON or errors. The unneeded Bicep dependencies that were causing these warnings have also been removed.

### Downstream projects

Please update the GitHub runner for all GitHub actions to use Ubuntu 24.04. Do this by replacing `runs-on: ubuntu-latest` with `runs-on: ubuntu-24.04` in all .yaml pipelines.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary