### PR TITLE
Redirect users to the intended page after successful login

### DIFF
--- a/application/account-management/WebApp/routes/login/index.tsx
+++ b/application/account-management/WebApp/routes/login/index.tsx
@@ -18,6 +18,13 @@ import { loggedInPath, signUpPath } from "@repo/infrastructure/auth/constants";
 import { useIsAuthenticated } from "@repo/infrastructure/auth/hooks";
 
 export const Route = createFileRoute("/login/")({
+  validateSearch: (search) => {
+    const returnPath = search.returnPath as string | undefined;
+    // Only allow paths starting with / to prevent open redirect attacks to external domains
+    return {
+      returnPath: returnPath?.startsWith("/") ? returnPath : undefined
+    };
+  },
   component: function LoginRoute() {
     const isAuthenticated = useIsAuthenticated();
 
@@ -40,6 +47,7 @@ export const Route = createFileRoute("/login/")({
 
 export function LoginForm() {
   const [email, setEmail] = useState("");
+  const { returnPath } = Route.useSearch();
 
   const [{ success, errors, data, title, message }, action, isPending] = useActionState(
     api.actionPost("/api/account-management/authentication/login/start"),
@@ -55,7 +63,7 @@ export function LoginForm() {
       expireAt: new Date(Date.now() + validForSeconds * 1000)
     });
 
-    return <Navigate to="/login/verify" />;
+    return <Navigate to="/login/verify" search={{ returnPath }} />;
   }
 
   return (

--- a/application/account-management/WebApp/routes/login/verify.tsx
+++ b/application/account-management/WebApp/routes/login/verify.tsx
@@ -19,6 +19,13 @@ import { useActionState, useEffect } from "react";
 import { useIsAuthenticated } from "@repo/infrastructure/auth/hooks";
 
 export const Route = createFileRoute("/login/verify")({
+  validateSearch: (search) => {
+    const returnPath = search.returnPath as string | undefined;
+    // Only allow paths starting with / to prevent open redirect attacks to external domains
+    return {
+      returnPath: returnPath?.startsWith("/") ? returnPath : undefined
+    };
+  },
   component: function LoginVerifyRoute() {
     const isAuthenticated = useIsAuthenticated();
 
@@ -42,6 +49,7 @@ export const Route = createFileRoute("/login/verify")({
 export function CompleteLoginForm() {
   const { email, loginId, expireAt } = getLoginState();
   const { expiresInString, isExpired } = useExpirationTimeout(expireAt);
+  const { returnPath } = Route.useSearch();
 
   const [{ success, title, message, errors }, action] = useActionState(
     api.actionPost("/api/account-management/authentication/login/{id}/complete"),
@@ -66,9 +74,9 @@ export function CompleteLoginForm() {
 
   useEffect(() => {
     if (success) {
-      window.location.href = loggedInPath;
+      window.location.href = returnPath || loggedInPath;
     }
-  }, [success]);
+  }, [success, returnPath]);
 
   useEffect(() => {
     if (isExpired) {


### PR DESCRIPTION
### Summary & Motivation

Improve the login flow by redirecting users to the page they were attempting to access before being prompted to log in. For example, if a user tries to visit `/admin/users` without being logged in, they are redirected to the login page with `?returnPath=%2Fadmin%2Fusers` in the URL. After logging in, the user is redirected back to `/admin/users`.

To ensure security, redirects to different domains are explicitly blocked. Only `returnPath` values starting with `/` are allowed, preventing open redirect vulnerabilities.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
