### PR TITLE
Persist side menu state in the admin center

### DIFF
--- a/application/shared-webapp/ui/components/SideMenu.tsx
+++ b/application/shared-webapp/ui/components/SideMenu.tsx
@@ -1,14 +1,15 @@
-import { createContext, useContext, useState } from "react";
-import { ChevronsLeftIcon, type LucideIcon } from "lucide-react";
-import { Button } from "./Button";
-import { tv } from "tailwind-variants";
 import logoMarkUrl from "../images/logo-mark.svg";
 import logoWrapUrl from "../images/logo-wrap.svg";
-import { Tooltip, TooltipTrigger } from "./Tooltip";
+import { ChevronsLeftIcon, type LucideIcon } from "lucide-react";
+import { createContext, useContext } from "react";
+import { tv } from "tailwind-variants";
+import { Button } from "./Button";
 import { useRouter } from "@tanstack/react-router";
 import { Dialog, DialogTrigger } from "./Dialog";
 import { Modal } from "./Modal";
+import { Tooltip, TooltipTrigger } from "./Tooltip";
 import type { Href } from "@react-types/shared";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 
 const collapsedContext = createContext(false);
 
@@ -121,10 +122,13 @@ type SideMenuProps = {
 };
 
 export function SideMenu({ children }: Readonly<SideMenuProps>) {
-  const [isCollapsed, setIsCollapsed] = useState(() => !window.matchMedia("(min-width: 1024px)").matches);
+  const [isCollapsed, setIsCollapsed] = useLocalStorage<boolean>(
+    !window.matchMedia("(min-width: 1024px)").matches,
+    "side-menu-collapsed"
+  );
 
   const toggleCollapse = () => {
-    setIsCollapsed((v) => !v);
+    setIsCollapsed((v: boolean) => !v);
   };
 
   return (

--- a/application/shared-webapp/ui/hooks/useLocalStorage.ts
+++ b/application/shared-webapp/ui/hooks/useLocalStorage.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+export function useLocalStorage<T>(defaultState: T, key: string) {
+  const [state, setState] = useState<T>(() => {
+    const storedValue = localStorage.getItem(key);
+    return storedValue ? JSON.parse(storedValue) : defaultState;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(state));
+  }, [key, state]);
+
+  return [state, setState] as const;
+}


### PR DESCRIPTION
### Summary & Motivation

Add logic to save the collapsed state of the side menu in the admin center to ensure it retains the same state when reloading the browser.

The `useLocalStorage` hook has been introduced to enable seamless saving of state to the browser's local storage.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
