### PR TITLE
Remember to use language choice between browser sessions

### DIFF
--- a/application/account-management/Core/Features/Signups/Commands/CompleteSignup.cs
+++ b/application/account-management/Core/Features/Signups/Commands/CompleteSignup.cs
@@ -15,6 +15,8 @@ public sealed record CompleteSignupCommand(string OneTimePassword) : ICommand, I
 {
     [JsonIgnore] // Removes this property from the API contract
     public SignupId Id { get; init; } = null!;
+
+    public string? PreferredLocale { get; init; }
 }
 
 public sealed class CompleteSignupHandler(
@@ -65,7 +67,10 @@ public sealed class CompleteSignupHandler(
             return Result.BadRequest("The code is no longer valid, please request a new code.", true);
         }
 
-        var result = await mediator.Send(new CreateTenantCommand(signup.TenantId, signup.Email, true), cancellationToken);
+        var result = await mediator.Send(
+            new CreateTenantCommand(signup.TenantId, signup.Email, true, command.PreferredLocale),
+            cancellationToken
+        );
 
         var user = await userRepository.GetByIdAsync(result.Value!, cancellationToken);
         authenticationTokenService.CreateAndSetAuthenticationTokens(user!.Adapt<UserInfo>());

--- a/application/account-management/Core/Features/Tenants/Commands/CreateTenant.cs
+++ b/application/account-management/Core/Features/Tenants/Commands/CreateTenant.cs
@@ -9,7 +9,7 @@ using PlatformPlatform.SharedKernel.Telemetry;
 namespace PlatformPlatform.AccountManagement.Features.Tenants.Commands;
 
 [PublicAPI]
-public sealed record CreateTenantCommand(TenantId Id, string OwnerEmail, bool EmailConfirmed)
+public sealed record CreateTenantCommand(TenantId Id, string OwnerEmail, bool EmailConfirmed, string? Locale)
     : ICommand, IRequest<Result<UserId>>;
 
 public sealed class CreateTenantHandler(ITenantRepository tenantRepository, IMediator mediator, ITelemetryEventsCollector events)
@@ -23,8 +23,8 @@ public sealed class CreateTenantHandler(ITenantRepository tenantRepository, IMed
         events.CollectEvent(new TenantCreated(tenant.Id, tenant.State));
 
         var result = await mediator.Send(
-            new CreateUserCommand(tenant.Id, command.OwnerEmail, UserRole.Owner, command.EmailConfirmed)
-            , cancellationToken
+            new CreateUserCommand(tenant.Id, command.OwnerEmail, UserRole.Owner, command.EmailConfirmed, command.Locale),
+            cancellationToken
         );
 
         return result.Value!;

--- a/application/account-management/Core/Features/Users/Commands/InviteUser.cs
+++ b/application/account-management/Core/Features/Users/Commands/InviteUser.cs
@@ -41,7 +41,10 @@ public sealed class InviteUserHandler(
             return Result.Forbidden("Only owners are allowed to invite other users.");
         }
 
-        var result = await mediator.Send(new CreateUserCommand(executionContext.TenantId!, command.Email, UserRole.Member, false), cancellationToken);
+        var result = await mediator.Send(
+            new CreateUserCommand(executionContext.TenantId!, command.Email, UserRole.Member, false, null),
+            cancellationToken
+        );
 
         events.CollectEvent(new UserInvited(result.Value!));
 

--- a/application/account-management/Core/Features/Users/Domain/User.cs
+++ b/application/account-management/Core/Features/Users/Domain/User.cs
@@ -6,13 +6,14 @@ public sealed class User : AggregateRoot<UserId>, ITenantScopedEntity
 {
     private string _email = string.Empty;
 
-    private User(TenantId tenantId, string email, UserRole role, bool emailConfirmed)
+    private User(TenantId tenantId, string email, UserRole role, bool emailConfirmed, string? locale)
         : base(UserId.NewId())
     {
         Email = email;
         TenantId = tenantId;
         Role = role;
         EmailConfirmed = emailConfirmed;
+        Locale = locale ?? string.Empty;
         Avatar = new Avatar();
     }
 
@@ -34,13 +35,13 @@ public sealed class User : AggregateRoot<UserId>, ITenantScopedEntity
 
     public Avatar Avatar { get; private set; }
 
-    public string Locale { get; private set; } = string.Empty;
+    public string Locale { get; private set; }
 
     public TenantId TenantId { get; }
 
-    public static User Create(TenantId tenantId, string email, UserRole role, bool emailConfirmed)
+    public static User Create(TenantId tenantId, string email, UserRole role, bool emailConfirmed, string? locale)
     {
-        return new User(tenantId, email, role, emailConfirmed);
+        return new User(tenantId, email, role, emailConfirmed, locale);
     }
 
     public void Update(string firstName, string lastName, string title)

--- a/application/account-management/Tests/DatabaseSeeder.cs
+++ b/application/account-management/Tests/DatabaseSeeder.cs
@@ -14,7 +14,7 @@ public sealed class DatabaseSeeder
     {
         Tenant1 = Tenant.Create(new TenantId("tenant-1"), "owner@tenant-1.com");
         accountManagementDbContext.Tenants.AddRange(Tenant1);
-        User1 = User.Create(Tenant1.Id, "owner@tenant-1.com", UserRole.Owner, true);
+        User1 = User.Create(Tenant1.Id, "owner@tenant-1.com", UserRole.Owner, true, null);
         accountManagementDbContext.Users.AddRange(User1);
 
         accountManagementDbContext.SaveChanges();

--- a/application/account-management/Tests/Users/CreateUserTests.cs
+++ b/application/account-management/Tests/Users/CreateUserTests.cs
@@ -18,7 +18,7 @@ public sealed class CreateUserTests : EndpointBaseTest<AccountManagementDbContex
     {
         // Arrange
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
-        var command = new CreateUserCommand(existingTenantId, Faker.Internet.Email(), UserRole.Member, false);
+        var command = new CreateUserCommand(existingTenantId, Faker.Internet.Email(), UserRole.Member, false, null);
 
         // Act
         var response = await AuthenticatedHttpClient.PostAsJsonAsync("/api/account-management/users", command);
@@ -34,7 +34,7 @@ public sealed class CreateUserTests : EndpointBaseTest<AccountManagementDbContex
         // Arrange
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
         var invalidEmail = Faker.InvalidEmail();
-        var command = new CreateUserCommand(existingTenantId, invalidEmail, UserRole.Member, false);
+        var command = new CreateUserCommand(existingTenantId, invalidEmail, UserRole.Member, false, null);
 
         // Act
         var response = await AuthenticatedHttpClient.PostAsJsonAsync("/api/account-management/users", command);
@@ -53,7 +53,7 @@ public sealed class CreateUserTests : EndpointBaseTest<AccountManagementDbContex
         // Arrange
         var existingTenantId = DatabaseSeeder.Tenant1.Id;
         var existingUserEmail = DatabaseSeeder.User1.Email;
-        var command = new CreateUserCommand(existingTenantId, existingUserEmail, UserRole.Member, false);
+        var command = new CreateUserCommand(existingTenantId, existingUserEmail, UserRole.Member, false, null);
 
         // Act
         var response = await AuthenticatedHttpClient.PostAsJsonAsync("/api/account-management/users", command);
@@ -71,7 +71,7 @@ public sealed class CreateUserTests : EndpointBaseTest<AccountManagementDbContex
     {
         // Arrange
         var unknownTenantId = new TenantId(Faker.Subdomain());
-        var command = new CreateUserCommand(unknownTenantId, Faker.Internet.Email(), UserRole.Member, false);
+        var command = new CreateUserCommand(unknownTenantId, Faker.Internet.Email(), UserRole.Member, false, null);
 
         // Act
         var response = await AuthenticatedHttpClient.PostAsJsonAsync("/api/account-management/users", command);

--- a/application/account-management/WebApp/routes/__root.tsx
+++ b/application/account-management/WebApp/routes/__root.tsx
@@ -4,6 +4,7 @@ import { NotFound } from "@repo/infrastructure/errorComponents/NotFoundPage";
 import { AuthenticationProvider } from "@repo/infrastructure/auth/AuthenticationProvider";
 import { ReactAriaRouterProvider } from "@repo/infrastructure/router/ReactAriaRouterProvider";
 import { ThemeModeProvider } from "@repo/ui/theme/mode/ThemeMode";
+import { useInitializeLocale } from "@repo/infrastructure/translations/useInitializeLocale";
 
 export const Route = createRootRoute({
   component: Root,
@@ -13,6 +14,7 @@ export const Route = createRootRoute({
 
 function Root() {
   const navigate = useNavigate();
+  useInitializeLocale();
 
   return (
     <ThemeModeProvider>

--- a/application/account-management/WebApp/routes/signup/verify.tsx
+++ b/application/account-management/WebApp/routes/signup/verify.tsx
@@ -15,6 +15,7 @@ import { getSignupState, setSignupState } from "./-shared/signupState";
 import { api } from "@/shared/lib/api/client";
 import { FormErrorMessage } from "@repo/ui/components/FormErrorMessage";
 import { loggedInPath, signedUpPath } from "@repo/infrastructure/auth/constants";
+import { preferredLocaleKey } from "@repo/infrastructure/translations/constants";
 import { useActionState, useEffect } from "react";
 import { useIsAuthenticated } from "@repo/infrastructure/auth/hooks";
 
@@ -80,6 +81,7 @@ export function CompleteSignupForm() {
     <div className="w-full max-w-sm space-y-3">
       <Form action={action} validationErrors={errors} validationBehavior="aria">
         <input type="hidden" name="id" value={signupId} />
+        <input type="hidden" name="preferredLocale" value={localStorage.getItem(preferredLocaleKey) ?? ""} />
         <div className="flex w-full flex-col gap-4 rounded-lg px-6 pt-8 pb-4">
           <div className="flex justify-center">
             <Link href="/">

--- a/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
+++ b/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
@@ -834,6 +834,10 @@
         "properties": {
           "oneTimePassword": {
             "type": "string"
+          },
+          "preferredLocale": {
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -1129,6 +1133,10 @@
           },
           "emailConfirmed": {
             "type": "boolean"
+          },
+          "preferredLocale": {
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/application/back-office/WebApp/routes/__root.tsx
+++ b/application/back-office/WebApp/routes/__root.tsx
@@ -4,6 +4,7 @@ import { NotFound } from "@repo/infrastructure/errorComponents/NotFoundPage";
 import { AuthenticationProvider } from "@repo/infrastructure/auth/AuthenticationProvider";
 import { ReactAriaRouterProvider } from "@repo/infrastructure/router/ReactAriaRouterProvider";
 import { ThemeModeProvider } from "@repo/ui/theme/mode/ThemeMode";
+import { useInitializeLocale } from "@repo/infrastructure/translations/useInitializeLocale";
 
 export const Route = createRootRoute({
   component: Root,
@@ -13,6 +14,8 @@ export const Route = createRootRoute({
 
 function Root() {
   const navigate = useNavigate();
+  useInitializeLocale();
+
   return (
     <ThemeModeProvider>
       <ReactAriaRouterProvider>

--- a/application/shared-webapp/infrastructure/translations/LocaleSwitcher.tsx
+++ b/application/shared-webapp/infrastructure/translations/LocaleSwitcher.tsx
@@ -8,6 +8,7 @@ import { Popover } from "@repo/ui/components/Popover";
 import { DialogTrigger } from "@repo/ui/components/Dialog";
 import type { Selection } from "react-aria-components";
 import { AuthenticationContext } from "@repo/infrastructure/auth/AuthenticationProvider";
+import { preferredLocaleKey } from "./constants";
 
 export function LocaleSwitcher() {
   const [isOpen, setIsOpen] = useState(false);
@@ -35,10 +36,12 @@ export function LocaleSwitcher() {
         })
           .then(async (_) => {
             await setLocale(newLocale);
+            localStorage.setItem(preferredLocaleKey, newLocale);
           })
           .catch((error) => console.error("Failed to update locale:", error));
       } else {
         await setLocale(newLocale);
+        localStorage.setItem(preferredLocaleKey, newLocale);
       }
 
       setIsOpen(false);

--- a/application/shared-webapp/infrastructure/translations/constants.ts
+++ b/application/shared-webapp/infrastructure/translations/constants.ts
@@ -1,0 +1,1 @@
+export const preferredLocaleKey = "preferred-locale";

--- a/application/shared-webapp/infrastructure/translations/useInitializeLocale.ts
+++ b/application/shared-webapp/infrastructure/translations/useInitializeLocale.ts
@@ -1,0 +1,22 @@
+import { useEffect, useContext } from "react";
+import { preferredLocaleKey } from "./constants";
+import { AuthenticationContext } from "../auth/AuthenticationProvider";
+import { translationContext } from "./TranslationContext";
+import type { Locale } from "./Translation";
+
+export function useInitializeLocale() {
+  const { userInfo } = useContext(AuthenticationContext);
+  const { setLocale } = useContext(translationContext);
+
+  useEffect(() => {
+    if (userInfo?.isAuthenticated) {
+      localStorage.setItem(preferredLocaleKey, document.documentElement.lang);
+    } else {
+      const storedLocale = localStorage.getItem(preferredLocaleKey) as Locale;
+      if (storedLocale) {
+        document.documentElement.lang = storedLocale;
+        setLocale(storedLocale);
+      }
+    }
+  }, [userInfo?.isAuthenticated, setLocale]);
+}


### PR DESCRIPTION
### Summary & Motivation

Ensure that a user's language selection is saved in the browser, so the same language is used when they sign out or later return. If an anonymous user changes the language while signing up, the created user will have the selected language set. Maintain the logic that sets the language to match the user's profile language upon signing in.

This is achieved by saving the preferred language in the browser storage. Additionally, the `CreateUser` and `CompleteSignup` endpoints have been extended to include language preferences, ensuring that language settings are properly stored during user creation and signup completion.

### Downstream projects

Please update the `/WebApp/routes/__root.tsx` file to initialize the correct locale.

```typescript
import { useInitializeLocale } from "@repo/infrastructure/translations/useInitializeLocale";


function Root() {
  const navigate = useNavigate();
  useInitializeLocale(); // Add this line

  return ( ... )
}
```

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
