### PR TITLE
Fix logout issue on pages without user context

### DIFF
--- a/application/account-management/WebApp/shared/components/AvatarButton.tsx
+++ b/application/account-management/WebApp/shared/components/AvatarButton.tsx
@@ -10,6 +10,8 @@ import { useUserInfo } from "@repo/infrastructure/auth/hooks";
 import { api } from "@/shared/lib/api/client";
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
+import { createLoginUrlWithReturnPath } from "@repo/infrastructure/auth/util";
+import { loginPath } from "@repo/infrastructure/auth/constants";
 
 export default function AvatarButton() {
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
@@ -27,7 +29,7 @@ export default function AvatarButton() {
 
   async function logout() {
     await api.post("/api/account-management/authentication/logout");
-    window.location.reload();
+    window.location.href = createLoginUrlWithReturnPath(loginPath);
   }
 
   return (


### PR DESCRIPTION
### Summary & Motivation

Fix an issue where logging out from a page without user context did not immediately redirect the user. While the authentication cookies were removed, the logout was only detected after an authenticated API request failed with a `401 Unauthorized` response.

Now, the logout logic immediately redirects the browser to the `loginPath`, ensuring an instant logout experience rather than waiting for a failed request. This makes the logout process more seamless and responsive.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
