### PR TITLE
Fix JetBrains warnings and update ReSharper version to 2024.3.4

### DIFF
--- a/application/dotnet-tools.json
+++ b/application/dotnet-tools.json
@@ -11,7 +11,7 @@
       "commands": ["dotnet-dotcover"]
     },
     "jetbrains.resharper.globaltools": {
-      "version": "2024.3.0",
+      "version": "2024.3.4",
       "commands": ["jb"]
     }
   }

--- a/application/shared-kernel/Tests/Behaviors/PublishDomainEventsPipelineBehaviorTests.cs
+++ b/application/shared-kernel/Tests/Behaviors/PublishDomainEventsPipelineBehaviorTests.cs
@@ -21,7 +21,6 @@ public sealed class PublishDomainEventsPipelineBehaviorTests
             publisher
         );
         var request = new TestCommand();
-        var cancellationToken = new CancellationToken();
         var next = Substitute.For<RequestHandlerDelegate<Result<TestAggregate>>>();
         next.Invoke().Returns(TestAggregate.Create("Test"));
 
@@ -32,10 +31,10 @@ public sealed class PublishDomainEventsPipelineBehaviorTests
         );
 
         // Act
-        await behavior.Handle(request, next, cancellationToken);
+        await behavior.Handle(request, next, CancellationToken.None);
 
         // Assert
-        await publisher.Received(1).Publish(domainEvent, cancellationToken);
+        await publisher.Received(1).Publish(domainEvent, CancellationToken.None);
         testAggregate.DomainEvents.Should().BeEmpty();
     }
 }

--- a/application/shared-kernel/Tests/Behaviors/UnitOfWorkPipelineBehaviorTests.cs
+++ b/application/shared-kernel/Tests/Behaviors/UnitOfWorkPipelineBehaviorTests.cs
@@ -29,20 +29,19 @@ public sealed class UnitOfWorkPipelineBehaviorTests
     {
         // Arrange
         var command = new TestCommand();
-        var cancellationToken = new CancellationToken();
         var next = Substitute.For<RequestHandlerDelegate<Result<TestAggregate>>>();
         var successfulCommandResult = Result<TestAggregate>.Success(TestAggregate.Create("Foo"));
         next.Invoke().Returns(Task.FromResult(successfulCommandResult));
 
         // Act
-        _ = await _behavior.Handle(command, next, cancellationToken);
+        _ = await _behavior.Handle(command, next, CancellationToken.None);
 
         // Assert
-        await _unitOfWork.Received().CommitAsync(cancellationToken);
+        await _unitOfWork.Received().CommitAsync(CancellationToken.None);
         Received.InOrder(() =>
             {
                 next.Invoke();
-                _unitOfWork.CommitAsync(cancellationToken);
+                _unitOfWork.CommitAsync(CancellationToken.None);
             }
         );
     }
@@ -52,16 +51,15 @@ public sealed class UnitOfWorkPipelineBehaviorTests
     {
         // Arrange
         var command = new TestCommand();
-        var cancellationToken = new CancellationToken();
         var next = Substitute.For<RequestHandlerDelegate<Result<TestAggregate>>>();
         var successfulCommandResult = Result<TestAggregate>.BadRequest("Fail");
         next.Invoke().Returns(Task.FromResult(successfulCommandResult));
 
         // Act
-        _ = await _behavior.Handle(command, next, cancellationToken);
+        _ = await _behavior.Handle(command, next, CancellationToken.None);
 
         // Assert
-        await _unitOfWork.DidNotReceive().CommitAsync(cancellationToken);
+        await _unitOfWork.DidNotReceive().CommitAsync(CancellationToken.None);
         await next.Received().Invoke();
     }
 }

--- a/application/shared-kernel/Tests/Persistence/RepositoryTests.cs
+++ b/application/shared-kernel/Tests/Persistence/RepositoryTests.cs
@@ -31,14 +31,13 @@ public sealed class RepositoryTests : IDisposable
     {
         // Arrange
         var testAggregate = TestAggregate.Create("TestAggregate");
-        var cancellationToken = new CancellationToken();
 
         // Act
-        await _testAggregateRepository.AddAsync(testAggregate, cancellationToken);
-        await _testDbContext.SaveChangesAsync(cancellationToken);
+        await _testAggregateRepository.AddAsync(testAggregate, CancellationToken.None);
+        await _testDbContext.SaveChangesAsync(CancellationToken.None);
 
         // Assert
-        var retrievedAggregate = await _testAggregateRepository.GetByIdAsync(testAggregate.Id, cancellationToken);
+        var retrievedAggregate = await _testAggregateRepository.GetByIdAsync(testAggregate.Id, CancellationToken.None);
         retrievedAggregate.Should().NotBeNull();
         retrievedAggregate!.Id.Should().Be(testAggregate.Id);
     }
@@ -136,9 +135,8 @@ public sealed class RepositoryTests : IDisposable
         // Arrange
         var primaryRepository = new TestAggregateRepository(_testDbContext);
         var originalTestAggregate = TestAggregate.Create("TestAggregate");
-        var cancellationToken = new CancellationToken();
-        await primaryRepository.AddAsync(originalTestAggregate, cancellationToken);
-        await _testDbContext.SaveChangesAsync(cancellationToken);
+        await primaryRepository.AddAsync(originalTestAggregate, CancellationToken.None);
+        await _testDbContext.SaveChangesAsync(CancellationToken.None);
 
         // Simulate another user by creating a new DbContext and repository instance
         var secondaryDbContext = _sqliteInMemoryDbContextFactory.CreateContext();
@@ -146,16 +144,16 @@ public sealed class RepositoryTests : IDisposable
 
         // Act
         var concurrentTestAggregate =
-            (await secondaryRepository.GetByIdAsync(originalTestAggregate.Id, cancellationToken))!;
+            (await secondaryRepository.GetByIdAsync(originalTestAggregate.Id, CancellationToken.None))!;
         concurrentTestAggregate.Name = "UpdatedTestAggregateByAnotherUser";
         secondaryRepository.Update(concurrentTestAggregate);
-        await secondaryDbContext.SaveChangesAsync(cancellationToken);
+        await secondaryDbContext.SaveChangesAsync(CancellationToken.None);
 
         originalTestAggregate.Name = "UpdatedTestAggregate";
         primaryRepository.Update(originalTestAggregate);
 
         // Assert
-        await Assert.ThrowsAsync<DbUpdateConcurrencyException>(() => _testDbContext.SaveChangesAsync(cancellationToken));
+        await Assert.ThrowsAsync<DbUpdateConcurrencyException>(() => _testDbContext.SaveChangesAsync(CancellationToken.None));
     }
 
     [Fact]


### PR DESCRIPTION
### Summary & Motivation

After upgrading Rider and ReSharper to JetBrains 2024.3.4, new warnings started appearing in the editor, specifically recommending the use of `CancellationToken.None` instead of `new CancellationToken()`. 

Warnings have been fixed, and the `jetbrains.resharper.globaltools` version in the `global.json` .NET tooling file has been updated to 2024.3.4, ensuring consistency between the build server and local development environments.

### Downstream Projects

Please run the `code-inspections` CLI command to detect any warnings and fix these before continuing.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
