### PR TITLE
Restore .NET global.json in application folder and upgrade to .NET 9.0.102

### DIFF
--- a/application/global.json
+++ b/application/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.102",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
### Summary & Motivation

Correct a mistake from the previous change where the `.NET global.json` file was wrongly moved from `/application` to `/developer-cli`. This restores `global.json` to `/application` while also upgrading the .NET SDK version from `9.0.100` to `9.0.102`.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
