### PR TITLE
Enable custom naming for table names

### DIFF
--- a/application/shared-kernel/SharedKernel/EntityFramework/SharedKernelDbContext.cs
+++ b/application/shared-kernel/SharedKernel/EntityFramework/SharedKernelDbContext.cs
@@ -30,8 +30,16 @@ public abstract class SharedKernelDbContext<TContext>(DbContextOptions<TContext>
         // Set pluralized table names for all aggregates
         foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {
-            var tableName = entityType.GetTableName()!.Pluralize();
-            entityType.SetTableName(tableName);
+            var tableNameAnnotation = entityType.GetAnnotations().FirstOrDefault(a => a.Name == "Relational:TableName");
+            if (tableNameAnnotation?.Value is not null)
+            {
+                entityType.SetTableName(tableNameAnnotation.Value.ToString());
+            }
+            else
+            {
+                var tableName = entityType.GetTableName()!.Pluralize();
+                entityType.SetTableName(tableName);
+            }
         }
 
         // Ensures that all enum properties are stored as strings in the database.


### PR DESCRIPTION
### Summary & Motivation

Enable custom naming for table names as a follow-up to the **"Simplify DbContext by extracting aggregate configuration into dedicated classes"** change from a few pull requests ago. This allows more flexibility in defining table names instead of relying solely on convention-based pluralization.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
