### PR TITLE
Fix commit parsing and improve error handling in pull-platformplatform-changes CLI command

### DIFF
--- a/developer-cli/Commands/PullPlatformPlatformChangesCommand.cs
+++ b/developer-cli/Commands/PullPlatformPlatformChangesCommand.cs
@@ -273,7 +273,7 @@ public class PullPlatformPlatformChangesCommand : Command
         var pullRequestNumber = GetPullRequestNumber(commit, pattern);
         var updatedMessage = $"PlatformPlatform PR {pullRequestNumber} - {fullCommitMessage
             .Replace($" (#{pullRequestNumber})", "")
-            .Replace("\"", "\"\"").TrimEnd()}";
+            .Replace("\"", "\\\"").TrimEnd()}";
         ProcessHelper.StartProcess($"""git commit -m "{updatedMessage}" """, Configuration.SourceCodeFolder);
 
         if (fullCommitMessage.Contains("Downstream") && !AnsiConsole.Confirm($"{fullCommitMessage.EscapeMarkup()}{Environment.NewLine}[red]Before we continue, please follow the instructions described for Downstream Projects, and press enter to continue?[/]"))
@@ -475,7 +475,12 @@ public class PullPlatformPlatformChangesCommand : Command
         AnsiConsole.MarkupLine(pullRequestDescription);
         AnsiConsole.Confirm("Copy the above text as a description and use it for the pull request description. Continue?");
 
-        ProcessHelper.StartProcess($"git push {DefaultRemote} {PullRequestBranchName}", Configuration.SourceCodeFolder, true);
+        var pushResult = ProcessHelper.StartProcess($"git push {DefaultRemote} {PullRequestBranchName}", Configuration.SourceCodeFolder, true, exitOnError: false);
+        if (pushResult.Contains("error: "))
+        {
+            AnsiConsole.MarkupLine("[red]An error occured when pushing commits. Is your local branch out of sync with origin?[/]");
+            Environment.Exit(0);
+        }
 
         var githubUri = GithubHelper.GetGithubUri(DefaultRemote);
         var githubInfo = GithubHelper.GetGithubInfo(githubUri);

--- a/developer-cli/Installation/Configuration.cs
+++ b/developer-cli/Installation/Configuration.cs
@@ -125,7 +125,7 @@ public static class Configuration
 
         internal static bool IsAliasRegisteredMacOs()
         {
-            if (!File.Exists(GetShellInfo().ProfilePath))
+            if (string .IsNullOrEmpty(GetShellInfo().ProfilePath))
             {
                 AnsiConsole.MarkupLine($"[red]Your shell [bold]{GetShellInfo().ShellName}[/] is not supported.[/]");
                 return false;
@@ -142,7 +142,7 @@ public static class Configuration
                 return;
             }
 
-            File.AppendAllLines(GetShellInfo().ProfilePath, new[] { AliasLineRepresentation });
+            File.AppendAllLines(GetShellInfo().ProfilePath, [AliasLineRepresentation]);
         }
 
         public static void DeleteAlias()

--- a/developer-cli/Utilities/GitHelper.cs
+++ b/developer-cli/Utilities/GitHelper.cs
@@ -8,7 +8,7 @@ public static class GitHelper
     public static Commit[] ToCommits(this string consoleOutput)
     {
         return consoleOutput
-            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Split("\n", StringSplitOptions.RemoveEmptyEntries)
             .Select(s => s.Split(' ', 3))
             .Select(s => new Commit(s[0], s[1], s[2]))
             .ToArray();


### PR DESCRIPTION
### Summary & Motivation

Fix multiple issues in the `pull-platformplatform-changes` CLI command on Windows:

- Commit parsing failed due to incorrect handling of new line characters. Previously, the command split Git output using `Environment.NewLine`, which worked on Mac but not on Windows, where Git outputs `\n` instead of `\r\n`. This has been corrected to ensure proper commit recognition across operating systems.
- Fix an issue where parsing pull request descriptions containing double quotation marks (`"`) caused the command to exit without an error. The CLI now correctly handles these cases.
- Improve error handling by adding a proper error message when pushing changes to origin fails, providing better feedback to the user.

Additionally, fix a bug in the `install` command on newly installed macOS systems. Previously, the installation failed if the shell configuration files for ZSH or Bash did not exist.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
