### PR TITLE
Make user summary dashboard interactive and update date filters

### DIFF
--- a/application/account-management/Core/Features/Users/Domain/UserRepository.cs
+++ b/application/account-management/Core/Features/Users/Domain/UserRepository.cs
@@ -132,12 +132,12 @@ internal sealed class UserRepository(AccountManagementDbContext accountManagemen
 
         if (startDate is not null)
         {
-            users = users.Where(u => u.CreatedAt >= startDate);
+            users = users.Where(u => u.ModifiedAt >= startDate);
         }
 
         if (endDate is not null)
         {
-            users = users.Where(u => u.CreatedAt < endDate.Value.AddDays(1));
+            users = users.Where(u => u.ModifiedAt < endDate.Value.AddDays(1));
         }
 
         users = orderBy switch

--- a/application/account-management/WebApp/routes/admin/index.tsx
+++ b/application/account-management/WebApp/routes/admin/index.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
-import { useApi } from "@/shared/lib/api/client";
+import { useApi, UserStatus } from "@/shared/lib/api/client";
 import { TopMenu } from "@/shared/components/topMenu";
 import { SharedSideMenu } from "@/shared/components/SharedSideMenu";
 
@@ -27,7 +28,11 @@ export default function Home() {
           </div>
         </div>
         <div className="flex flex-row">
-          <div className="text-muted-foreground p-6 bg-white rounded-xl shadow-md w-1/3">
+          <Link
+            to="/admin/users"
+            className="text-muted-foreground p-6 bg-white rounded-xl shadow-md w-1/3 hover:bg-muted/80 transition-colors"
+            aria-label={t`View users`}
+          >
             <div className="text-sm text-gray-800">
               <Trans>Total Users</Trans>
             </div>
@@ -37,8 +42,17 @@ export default function Home() {
             <div className="py-2 text-black text-2xl font-semibold">
               {data?.totalUsers ? <p>{data.totalUsers}</p> : <p>-</p>}
             </div>
-          </div>
-          <div className="p-6 bg-white rounded-xl shadow-md w-1/3 mx-6">
+          </Link>
+          <Link
+            to="/admin/users"
+            search={{
+              userStatus: UserStatus.Active,
+              startDate: new Date(new Date().setDate(new Date().getDate() - 30)).toISOString().slice(0, 10),
+              endDate: new Date().toISOString().slice(0, 10)
+            }}
+            className="p-6 bg-white rounded-xl shadow-md w-1/3 mx-6 hover:bg-muted/80 transition-colors"
+            aria-label={t`View active users`}
+          >
             <div className="text-sm text-gray-800">
               <Trans>Active Users</Trans>
             </div>
@@ -48,8 +62,13 @@ export default function Home() {
             <div className="py-2 text-black text-2xl font-semibold">
               {data?.activeUsers ? <p>{data.activeUsers}</p> : <p>-</p>}
             </div>
-          </div>
-          <div className="p-6 bg-white rounded-xl shadow-md w-1/3">
+          </Link>
+          <Link
+            to="/admin/users"
+            search={{ userStatus: UserStatus.Pending }}
+            className="p-6 bg-white rounded-xl shadow-md w-1/3 hover:bg-muted/80 transition-colors"
+            aria-label={t`View invited users`}
+          >
             <div className="text-sm text-gray-800">
               <Trans>Invited Users</Trans>
             </div>
@@ -59,7 +78,7 @@ export default function Home() {
             <div className="py-2 text-black text-2xl font-semibold">
               {data?.pendingUsers ? <p>{data.pendingUsers}</p> : <p>-</p>}
             </div>
-          </div>
+          </Link>
         </div>
       </div>
     </div>

--- a/application/account-management/WebApp/routes/admin/index.tsx
+++ b/application/account-management/WebApp/routes/admin/index.tsx
@@ -30,16 +30,16 @@ export default function Home() {
         <div className="flex flex-row">
           <Link
             to="/admin/users"
-            className="text-muted-foreground p-6 bg-white rounded-xl shadow-md w-1/3 hover:bg-muted/80 transition-colors"
+            className="p-6 bg-muted/50 rounded-xl w-1/3 hover:bg-accent transition-all"
             aria-label={t`View users`}
           >
-            <div className="text-sm text-gray-800">
+            <div className="text-sm text-foreground">
               <Trans>Total Users</Trans>
             </div>
-            <div className="text-sm text-gray-500">
+            <div className="text-sm text-muted-foreground">
               <Trans>Add more in the Users menu</Trans>
             </div>
-            <div className="py-2 text-black text-2xl font-semibold">
+            <div className="py-2 text-foreground text-2xl font-semibold">
               {data?.totalUsers ? <p>{data.totalUsers}</p> : <p>-</p>}
             </div>
           </Link>
@@ -50,32 +50,32 @@ export default function Home() {
               startDate: new Date(new Date().setDate(new Date().getDate() - 30)).toISOString().slice(0, 10),
               endDate: new Date().toISOString().slice(0, 10)
             }}
-            className="p-6 bg-white rounded-xl shadow-md w-1/3 mx-6 hover:bg-muted/80 transition-colors"
+            className="p-6 bg-muted/50 rounded-xl w-1/3 mx-6 hover:bg-accent transition-all"
             aria-label={t`View active users`}
           >
-            <div className="text-sm text-gray-800">
+            <div className="text-sm text-foreground">
               <Trans>Active Users</Trans>
             </div>
-            <div className="text-sm text-gray-500">
+            <div className="text-sm text-muted-foreground">
               <Trans>Active users in the past 30 days</Trans>
             </div>
-            <div className="py-2 text-black text-2xl font-semibold">
+            <div className="py-2 text-foreground text-2xl font-semibold">
               {data?.activeUsers ? <p>{data.activeUsers}</p> : <p>-</p>}
             </div>
           </Link>
           <Link
             to="/admin/users"
             search={{ userStatus: UserStatus.Pending }}
-            className="p-6 bg-white rounded-xl shadow-md w-1/3 hover:bg-muted/80 transition-colors"
+            className="p-6 bg-muted/50 rounded-xl w-1/3 hover:bg-accent transition-all"
             aria-label={t`View invited users`}
           >
-            <div className="text-sm text-gray-800">
+            <div className="text-sm text-foreground">
               <Trans>Invited Users</Trans>
             </div>
-            <div className="text-sm text-gray-500">
+            <div className="text-sm text-muted-foreground">
               <Trans>Users who haven't confirmed their email</Trans>
             </div>
-            <div className="py-2 text-black text-2xl font-semibold">
+            <div className="py-2 text-foreground text-2xl font-semibold">
               {data?.pendingUsers ? <p>{data.pendingUsers}</p> : <p>-</p>}
             </div>
           </Link>

--- a/application/account-management/WebApp/routes/admin/users/-components/UserQuerying.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/UserQuerying.tsx
@@ -132,7 +132,7 @@ export function UserQuerying() {
                 endDate: range?.end.toString() || undefined
               });
             }}
-            label={t`Creation date`}
+            label={t`Modified date`}
           />
         </>
       )}

--- a/application/account-management/WebApp/routes/admin/users/-components/UserTable.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/UserTable.tsx
@@ -185,7 +185,7 @@ export function UserTable() {
               <Trans>Created</Trans>
             </Column>
             <Column minWidth={65} defaultWidth={120} allowsSorting id={SortableUserProperties.ModifiedAt}>
-              <Trans>Last Seen</Trans>
+              <Trans>Modified</Trans>
             </Column>
             <Column minWidth={100} defaultWidth={75} allowsSorting id={SortableUserProperties.Role}>
               <Trans>Role</Trans>

--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -90,9 +90,6 @@ msgstr "Opret din konto"
 msgid "Created"
 msgstr "Oprettet"
 
-msgid "Creation date"
-msgstr "Oprettelsesdato"
-
 msgid "Danger zone"
 msgstr "Farezone"
 
@@ -189,9 +186,6 @@ msgstr "Inviterede brugere"
 msgid "Last name"
 msgstr "Efternavn"
 
-msgid "Last Seen"
-msgstr "Sidst set"
-
 msgid "Log in"
 msgstr "Log ind"
 
@@ -212,6 +206,12 @@ msgstr "Medlem"
 
 msgid "Menu"
 msgstr "Menu"
+
+msgid "Modified"
+msgstr "Ændret"
+
+msgid "Modified date"
+msgstr "Ændret dato"
 
 msgid "Name"
 msgstr "Navn"

--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -346,8 +346,17 @@ msgstr "Brugere, der ikke har bekræftet deres e-mail"
 msgid "Verify"
 msgstr "Bekræft"
 
+msgid "View active users"
+msgstr "Se aktive brugere"
+
+msgid "View invited users"
+msgstr "Se inviterede brugere"
+
 msgid "View Profile"
 msgstr "Se profil"
+
+msgid "View users"
+msgstr "Se brugere"
 
 msgid "Welcome home"
 msgstr "Velkommen hjem"

--- a/application/account-management/WebApp/shared/translations/locale/en-US.po
+++ b/application/account-management/WebApp/shared/translations/locale/en-US.po
@@ -90,9 +90,6 @@ msgstr "Create your account"
 msgid "Created"
 msgstr "Created"
 
-msgid "Creation date"
-msgstr "Creation date"
-
 msgid "Danger zone"
 msgstr "Danger zone"
 
@@ -189,9 +186,6 @@ msgstr "Invited Users"
 msgid "Last name"
 msgstr "Last name"
 
-msgid "Last Seen"
-msgstr "Last Seen"
-
 msgid "Log in"
 msgstr "Log in"
 
@@ -212,6 +206,12 @@ msgstr "Member"
 
 msgid "Menu"
 msgstr "Menu"
+
+msgid "Modified"
+msgstr "Modified"
+
+msgid "Modified date"
+msgstr "Modified date"
 
 msgid "Name"
 msgstr "Name"

--- a/application/account-management/WebApp/shared/translations/locale/en-US.po
+++ b/application/account-management/WebApp/shared/translations/locale/en-US.po
@@ -346,8 +346,17 @@ msgstr "Users who haven't confirmed their email"
 msgid "Verify"
 msgstr "Verify"
 
+msgid "View active users"
+msgstr "View active users"
+
+msgid "View invited users"
+msgstr "View invited users"
+
 msgid "View Profile"
 msgstr "View Profile"
+
+msgid "View users"
+msgstr "View users"
 
 msgid "Welcome home"
 msgstr "Welcome home"

--- a/application/account-management/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/account-management/WebApp/shared/translations/locale/nl-NL.po
@@ -90,9 +90,6 @@ msgstr "Maak je account aan"
 msgid "Created"
 msgstr "Aangemaakt"
 
-msgid "Creation date"
-msgstr "Aanmaakdatum"
-
 msgid "Danger zone"
 msgstr "Gevaarzone"
 
@@ -189,9 +186,6 @@ msgstr "Uitgenodigde gebruikers"
 msgid "Last name"
 msgstr "Achternaam"
 
-msgid "Last Seen"
-msgstr "Laatst gezien"
-
 msgid "Log in"
 msgstr "Inloggen"
 
@@ -212,6 +206,12 @@ msgstr "Lid"
 
 msgid "Menu"
 msgstr "Menu"
+
+msgid "Modified"
+msgstr "Gewijzigd"
+
+msgid "Modified date"
+msgstr "Gewijzigde datum"
 
 msgid "Name"
 msgstr "Naam"

--- a/application/account-management/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/account-management/WebApp/shared/translations/locale/nl-NL.po
@@ -346,8 +346,17 @@ msgstr "Gebruikers die hun e-mail niet hebben bevestigd"
 msgid "Verify"
 msgstr "Verifiëren"
 
+msgid "View active users"
+msgstr "Actieve gebruikers bekijken"
+
+msgid "View invited users"
+msgstr "Uitgenodigde gebruikers bekijken"
+
 msgid "View Profile"
 msgstr "Profiel bekijken"
+
+msgid "View users"
+msgstr "Gebruikers bekijken"
 
 msgid "Welcome home"
 msgstr "Welkom home"


### PR DESCRIPTION
### Summary & Motivation

Update the User Summary dashboard to make the Total Users, Active Users, and Invited Users cards clickable. Clicking a card now navigates to the Users page with the relevant filter applied.

Previously, the date range picker on the Users page filtered users by their creation date. This has now been changed to filter by modified date for better accuracy. The Last Seen column in the users table has also been renamed to Modified, as it was already displaying the `ModifiedAt` property.

Additionally, the User Summary dashboard has been updated so the cards correctly adapt to dark mode, aligning with the Figma design.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
