### PR TITLE
Show API error messages and reset retry count when resending login code 

### DIFF
--- a/application/account-management/Core/Features/EmailConfirmations/Domain/EmailConfirmation.cs
+++ b/application/account-management/Core/Features/EmailConfirmations/Domain/EmailConfirmation.cs
@@ -75,6 +75,7 @@ public sealed class EmailConfirmation : AggregateRoot<EmailConfirmationId>
 
         ValidUntil = TimeProvider.System.GetUtcNow().AddSeconds(ValidForSeconds);
         OneTimePasswordHash = oneTimePasswordHash;
+        RetryCount = 0;
         ResendCount++;
     }
 }

--- a/application/account-management/WebApp/routes/login/verify.tsx
+++ b/application/account-management/WebApp/routes/login/verify.tsx
@@ -128,11 +128,12 @@ export function CompleteLoginForm() {
           <Form
             onSubmit={mutationSubmitter(resendLoginCodeMutation, {
               path: { emailConfirmationId: emailConfirmationId }
-            })}
+            })} validationErrors={resendLoginCodeMutation.error?.errors}
             className="inline"
           >
             <input type="hidden" name="id" value={loginId} />
             <input type="hidden" name="emailConfirmationId" value={emailConfirmationId} />
+            <FormErrorMessage error={resendLoginCodeMutation.error} />
             <Button
               type="submit"
               variant="link"

--- a/application/account-management/WebApp/routes/signup/verify.tsx
+++ b/application/account-management/WebApp/routes/signup/verify.tsx
@@ -124,10 +124,11 @@ export function CompleteSignupForm() {
           <Form
             onSubmit={mutationSubmitter(resendSignupCodeMutation, {
               path: { emailConfirmationId: emailConfirmationId }
-            })}
+            })} validationErrors={resendSignupCodeMutation.error?.errors}
             className="inline"
           >
             <input type="hidden" name="emailConfirmationId" value={emailConfirmationId} />
+            <FormErrorMessage error={resendSignupCodeMutation.error} />
             <Button
               type="submit"
               variant="link"


### PR DESCRIPTION
### Summary & Motivation  
Ensure that API error messages are properly displayed in the frontend when a user resends the login verification code. Additionally, reset the retry count upon generating a new verification code, allowing the user three more attempts to enter the correct code after receiving a new verification code. This improves user experience by providing clearer feedback and preventing unnecessary lockouts.  

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
