### PR TITLE
Fix error when opening URLs on Windows

### DIFF
--- a/developer-cli/Utilities/ProcessHelper.cs
+++ b/developer-cli/Utilities/ProcessHelper.cs
@@ -22,7 +22,7 @@ public static class ProcessHelper
     {
         if (Configuration.IsWindows)
         {
-            StartProcess($"start {url}");
+            StartProcess(new ProcessStartInfo { FileName = url, UseShellExecute = true });
         }
         else if (Configuration.IsMacOs)
         {


### PR DESCRIPTION
### Summary & Motivation

On Windows, the `start {url}` command fails with a `Command not found` error. With this change, the browser now opens correctly when parsing a URL.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
