### PR TITLE
Upgrade NuGet dependencies, including Aspire 9.1, and remove hack for starting AppHost

### DIFF
--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -1,11 +1,7 @@
-using System.Diagnostics;
 using AppHost;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Projects;
-
-// Detect if Aspire ports from the previous run are released. See https://github.com/dotnet/aspire/issues/6704
-EnsureDeveloperControlPaneIsNotRunning();
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -91,30 +87,6 @@ builder
 await builder.Build().RunAsync();
 
 return;
-
-void EnsureDeveloperControlPaneIsNotRunning()
-{
-    const string processName = "dcpctrl"; // The Aspire Developer Control Pane process name
-
-    var process = Process.GetProcesses()
-        .SingleOrDefault(p => p.ProcessName.Contains(processName, StringComparison.OrdinalIgnoreCase));
-
-    if (process == null) return;
-
-    Console.WriteLine($"Shutting down developer control pane from previous run. Process: {process.ProcessName} (ID: {process.Id})");
-
-    Thread.Sleep(TimeSpan.FromSeconds(5)); // Allow Docker containers to shut down to avoid orphaned containers
-
-    try
-    {
-        process.Kill();
-        Console.WriteLine($"Process {process.Id} killed successfully.");
-    }
-    catch (Exception ex)
-    {
-        Console.WriteLine($"Failed to kill process {process.Id}: {ex.Message}");
-    }
-}
 
 void CreateBlobContainer(string containerName)
 {

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -5,21 +5,22 @@
     <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="8.0.1" />
-    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="9.0.0" />
-    <PackageVersion Include="Aspire.Hosting" Version="9.0.0" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.0.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure" Version="9.0.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="9.0.0" />
-    <PackageVersion Include="Aspire.Hosting.NodeJs" Version="9.0.0" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="9.1.0" />
+    <PackageVersion Include="Aspire.Hosting" Version="9.1.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.1.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure" Version="9.1.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="9.1.0" />
+    <PackageVersion Include="Aspire.Hosting.NodeJs" Version="9.1.0" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.1.0" />
     <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.2.2" />
     <PackageVersion Include="Azure.Communication.Email" Version="1.0.1" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
-    <PackageVersion Include="Bogus" Version="35.6.1" />
-    <PackageVersion Include="FluentAssertions" Version="7.1.0" /> <!-- Do not upgrade FluentAssertions to version 8 or higher, as this requires a license for commercial projects -->
+    <PackageVersion Include="Bogus" Version="35.6.2" />
+    <PackageVersion Include="FluentAssertions" Version="7.2.0" />
+    <!-- Do not upgrade FluentAssertions to version 8 or higher, as this requires a license for commercial projects -->
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="IdGen" Version="3.0.7" />
@@ -28,30 +29,30 @@
     <PackageVersion Include="MediatR" Version="12.4.1" />
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
     <PackageVersion Include="Meziantou.Xunit.ParallelTestFramework" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.1">
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.1.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.23" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.23" />
     <PackageVersion Include="NJsonSchema" Version="11.1.0" />
@@ -62,19 +63,19 @@
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.0.4" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.0.20" />
     <PackageVersion Include="Scrutor" Version="5.0.2" />
-    <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0" />
+    <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/application/account-management/Tests/Authentication/StartLoginTests.cs
+++ b/application/account-management/Tests/Authentication/StartLoginTests.cs
@@ -26,7 +26,7 @@ public sealed class StartLoginTests : EndpointBaseTest<AccountManagementDbContex
         response.EnsureSuccessStatusCode();
         var responseBody = await response.DeserializeResponse<StartLoginResponse>();
         responseBody.Should().NotBeNull();
-        responseBody!.ValidForSeconds.Should().Be(300);
+        responseBody.ValidForSeconds.Should().Be(300);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(1);
         TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("LoginStarted");
@@ -97,7 +97,7 @@ public sealed class StartLoginTests : EndpointBaseTest<AccountManagementDbContex
         response.EnsureSuccessStatusCode();
         var responseBody = await response.DeserializeResponse<StartLoginResponse>();
         responseBody.Should().NotBeNull();
-        responseBody!.ValidForSeconds.Should().Be(300);
+        responseBody.ValidForSeconds.Should().Be(300);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Should().BeEmpty();
 

--- a/application/account-management/Tests/Signups/StartSignupTests.cs
+++ b/application/account-management/Tests/Signups/StartSignupTests.cs
@@ -30,7 +30,7 @@ public sealed class StartSignupTests : EndpointBaseTest<AccountManagementDbConte
         response.EnsureSuccessStatusCode();
         var responseBody = await response.DeserializeResponse<StartSignupResponse>();
         responseBody.Should().NotBeNull();
-        responseBody!.EmailConfirmationId.ToString().Should().NotBeNullOrEmpty();
+        responseBody.EmailConfirmationId.ToString().Should().NotBeNullOrEmpty();
         responseBody.ValidForSeconds.Should().Be(300);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(1);

--- a/application/account-management/Tests/Users/GetUsersTests.cs
+++ b/application/account-management/Tests/Users/GetUsersTests.cs
@@ -64,7 +64,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
         response.ShouldBeSuccessfulGetRequest();
         var userResponse = await response.DeserializeResponse<GetUsersResponse>();
         userResponse.Should().NotBeNull();
-        userResponse!.TotalCount.Should().Be(1);
+        userResponse.TotalCount.Should().Be(1);
         userResponse.Users.First().Email.Should().Be(Email);
     }
 
@@ -81,7 +81,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
         response.ShouldBeSuccessfulGetRequest();
         var userResponse = await response.DeserializeResponse<GetUsersResponse>();
         userResponse.Should().NotBeNull();
-        userResponse!.TotalCount.Should().Be(1);
+        userResponse.TotalCount.Should().Be(1);
         userResponse.Users.First().FirstName.Should().Be(FirstName);
     }
 
@@ -99,7 +99,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
         response.ShouldBeSuccessfulGetRequest();
         var userResponse = await response.DeserializeResponse<GetUsersResponse>();
         userResponse.Should().NotBeNull();
-        userResponse!.TotalCount.Should().Be(1);
+        userResponse.TotalCount.Should().Be(1);
         userResponse.Users.First().LastName.Should().Be(LastName);
     }
 
@@ -114,7 +114,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
         response.ShouldBeSuccessfulGetRequest();
         var userResponse = await response.DeserializeResponse<GetUsersResponse>();
         userResponse.Should().NotBeNull();
-        userResponse!.TotalCount.Should().Be(2);
+        userResponse.TotalCount.Should().Be(2);
         userResponse.Users.First().Role.Should().Be(UserRole);
     }
 
@@ -128,7 +128,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
         response.ShouldBeSuccessfulGetRequest();
         var userResponse = await response.DeserializeResponse<GetUsersResponse>();
         userResponse.Should().NotBeNull();
-        userResponse!.TotalCount.Should().Be(3);
+        userResponse.TotalCount.Should().Be(3);
         userResponse.Users.First().Role.Should().Be(UserRole.Member);
         userResponse.Users.Last().Role.Should().Be(UserRole.Owner);
     }

--- a/application/dotnet-tools.json
+++ b/application/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-sonarscanner": {
-      "version": "8.0.3",
+      "version": "9.2.1",
       "commands": ["dotnet-sonarscanner"]
     },
     "jetbrains.dotcover.globaltool": {
@@ -11,7 +11,7 @@
       "commands": ["dotnet-dotcover"]
     },
     "jetbrains.resharper.globaltools": {
-      "version": "2024.3.4",
+      "version": "2024.3.6",
       "commands": ["jb"]
     }
   }

--- a/application/shared-kernel/Tests/ApiAssertionExtensions.cs
+++ b/application/shared-kernel/Tests/ApiAssertionExtensions.cs
@@ -110,7 +110,7 @@ public static class ApiAssertionExtensions
         var problemDetails = await DeserializeProblemDetails(response);
 
         problemDetails.Should().NotBeNull();
-        problemDetails!.Status.Should().Be((int)statusCode);
+        problemDetails.Status.Should().Be((int)statusCode);
         if (StatusCodesWithLink.Contains(statusCode))
         {
             problemDetails.Type.Should().StartWith("https://tools.ietf.org/html/rfc9110#section-15.");

--- a/application/shared-kernel/Tests/Persistence/RepositoryTests.cs
+++ b/application/shared-kernel/Tests/Persistence/RepositoryTests.cs
@@ -39,7 +39,7 @@ public sealed class RepositoryTests : IDisposable
         // Assert
         var retrievedAggregate = await _testAggregateRepository.GetByIdAsync(testAggregate.Id, CancellationToken.None);
         retrievedAggregate.Should().NotBeNull();
-        retrievedAggregate!.Id.Should().Be(testAggregate.Id);
+        retrievedAggregate.Id.Should().Be(testAggregate.Id);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public sealed class RepositoryTests : IDisposable
 
         // Assert
         retrievedAggregate.Should().NotBeNull();
-        retrievedAggregate!.Id.Should().Be(testAggregate.Id);
+        retrievedAggregate.Id.Should().Be(testAggregate.Id);
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public sealed class RepositoryTests : IDisposable
         // Assert
         var updatedAggregate = await _testAggregateRepository.GetByIdAsync(testAggregate.Id, CancellationToken.None);
         updatedAggregate.Should().NotBeNull();
-        updatedAggregate!.Name.Should().NotBe(initialName);
+        updatedAggregate.Name.Should().NotBe(initialName);
         updatedAggregate.Name.Should().Be("UpdatedName");
     }
 
@@ -108,7 +108,7 @@ public sealed class RepositoryTests : IDisposable
         // Assert
         var updatedAggregate = await _testAggregateRepository.GetByIdAsync(testAggregateUpdate.Id, CancellationToken.None);
         updatedAggregate.Should().NotBeNull();
-        updatedAggregate!.Name.Should().NotBe(initialName);
+        updatedAggregate.Name.Should().NotBe(initialName);
         updatedAggregate.Name.Should().Be("UpdatedName");
     }
 

--- a/developer-cli/dotnet-tools.json
+++ b/developer-cli/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2024.3.4",
+      "version": "2024.3.6",
       "commands": ["jb"]
     }
   }


### PR DESCRIPTION
### Summary & Motivation

Upgrade to Aspire 9.1, which eliminates the need for the workaround added in Aspire 9 where restarting Aspire too quickly left the Developer Control Pane (`dcpctrl`) process running, preventing fast restarts (see https://github.com/dotnet/aspire/issues/6704). With this upgrade, starting and restarting Aspire AppHost and all dependencies is now faster than ever.

Additionally, upgrade all NuGet packages to their latest versions, except for Entity Framework Core, which remains at version 8 due to unresolved breaking changes in version 9, and Scruton, which also has unresolved breaking changes after its latest major update.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
