### PR TITLE
Upgrade Entity Framework Core from 8 to 9

### DIFF
--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="9.1.0" />
     <PackageVersion Include="Aspire.Hosting.NodeJs" Version="9.1.0" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.2.2" />
+    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.1.0" />
     <PackageVersion Include="Azure.Communication.Email" Version="1.0.1" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
@@ -34,9 +34,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.12" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/application/account-management/Tests/EndpointBaseTest.cs
+++ b/application/account-management/Tests/EndpointBaseTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using PlatformPlatform.SharedKernel.Authentication;
@@ -78,7 +79,7 @@ public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : 
                 builder.ConfigureTestServices(services =>
                     {
                         // Replace the default DbContext in the WebApplication to use an in-memory SQLite database
-                        services.Remove(services.Single(d => d.ServiceType == typeof(DbContextOptions<TContext>)));
+                        services.Remove(services.Single(d => d.ServiceType == typeof(IDbContextOptionsConfiguration<TContext>)));
                         services.AddDbContext<TContext>(options => { options.UseSqlite(Connection); });
 
                         TelemetryEventsCollectorSpy = new TelemetryEventsCollectorSpy(new TelemetryEventsCollector());

--- a/application/back-office/Tests/EndpointBaseTest.cs
+++ b/application/back-office/Tests/EndpointBaseTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using PlatformPlatform.SharedKernel.Authentication.TokenGeneration;
@@ -76,7 +77,7 @@ public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : 
                 builder.ConfigureTestServices(services =>
                     {
                         // Replace the default DbContext in the WebApplication to use an in-memory SQLite database
-                        services.Remove(services.Single(d => d.ServiceType == typeof(DbContextOptions<TContext>)));
+                        services.Remove(services.Single(d => d.ServiceType == typeof(IDbContextOptionsConfiguration<TContext>)));
                         services.AddDbContext<TContext>(options => { options.UseSqlite(Connection); });
 
                         TelemetryEventsCollectorSpy = new TelemetryEventsCollectorSpy(new TelemetryEventsCollector());

--- a/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
@@ -59,8 +59,7 @@ public static class SharedInfrastructureConfiguration
             ? Environment.GetEnvironmentVariable("DATABASE_CONNECTION_STRING")
             : builder.Configuration.GetConnectionString(connectionName);
 
-        builder.Services.AddSqlServer<T>(connectionString, optionsBuilder => { optionsBuilder.UseAzureSqlDefaults(); });
-        builder.EnrichSqlServerDbContext<T>();
+        builder.Services.AddAzureSql<T>(connectionString);
 
         return builder;
     }

--- a/application/shared-kernel/SharedKernel/EntityFramework/SharedKernelDbContext.cs
+++ b/application/shared-kernel/SharedKernel/EntityFramework/SharedKernelDbContext.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using Humanizer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using PlatformPlatform.SharedKernel.Domain;
 using PlatformPlatform.SharedKernel.ExecutionContext;
 
@@ -19,6 +20,7 @@ public abstract class SharedKernelDbContext<TContext>(DbContextOptions<TContext>
     {
         optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
         optionsBuilder.AddInterceptors(new UpdateAuditableEntitiesInterceptor());
+        optionsBuilder.ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.PendingModelChangesWarning));
 
         base.OnConfiguring(optionsBuilder);
     }


### PR DESCRIPTION
### Summary & Motivation

Upgrade Entity Framework Core from version 8 to 9 to address a breaking change in how database providers are registered. In EF9, `DbContextOptions<T>` should no longer be used for replacing database providers in test configurations. Instead, `IDbContextOptionsConfiguration<T>` must be used to prevent conflicts when multiple providers are registered.

### Downstream Projects

Please update `EndpointBaseTest.cs` in your self-contained system like this:

```diff
- services.Remove(services.Single(d => d.ServiceType == typeof(DbContextOptions<TContext>)));
+ services.Remove(services.Single(d => d.ServiceType == typeof(IDbContextOptionsConfiguration<TContext>)));
```

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
