### PR TITLE
Allow frontend dev server to run independently of AppHost

### DIFF
--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -41,7 +41,7 @@ builder
 CreateBlobContainer("avatars");
 
 var frontendBuild = builder
-    .AddNpmApp("frontend-build", "../")
+    .AddNpmApp("frontend-build", "../", scriptName: "app-host-start")
     .WithEnvironment("CERTIFICATE_PASSWORD", certificatePassword);
 
 var accountManagementDatabase = sqlServer

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -41,7 +41,7 @@ builder
 CreateBlobContainer("avatars");
 
 var frontendBuild = builder
-    .AddNpmApp("frontend-build", "../", scriptName: "app-host-start")
+    .AddNpmApp("frontend-build", "../", "app-host-start")
     .WithEnvironment("CERTIFICATE_PASSWORD", certificatePassword);
 
 var accountManagementDatabase = sqlServer

--- a/application/package.json
+++ b/application/package.json
@@ -10,7 +10,8 @@
     "shared-webapp/*"
   ],
   "scripts": {
-    "start": "npm install && turbo dev",
+    "app-host-start": "npm install && dotnet run frontend-dev-server --project ../developer-cli",
+    "start": "dotnet run frontend-dev-server --create-flag-file --project ../developer-cli",
     "dev": "turbo dev",
     "build": "turbo build",
     "test": "turbo test",

--- a/developer-cli/Commands/FrontendDevServerCommand.cs
+++ b/developer-cli/Commands/FrontendDevServerCommand.cs
@@ -1,0 +1,75 @@
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Text.Json;
+using PlatformPlatform.DeveloperCli.Installation;
+using PlatformPlatform.DeveloperCli.Utilities;
+using Spectre.Console;
+
+namespace PlatformPlatform.DeveloperCli.Commands;
+
+public class FrontendDevServerCommand : Command
+{
+    public FrontendDevServerCommand() : base("frontend-dev-server", "Run the frontend development server")
+    {
+        AddOption(new Option<string?>(
+                ["<solution-name>", "--solution-name", "-s"],
+                "The name of the self-contained system to run"
+            )
+        );
+        AddOption(new Option<bool>(["--create-flag-file"], "Create a flag file to prevent another frontend server from starting"));
+
+        Handler = CommandHandler.Create<string?, bool>(Execute);
+    }
+
+    private int Execute(string? solutionName, bool createFlagFile)
+    {
+        Prerequisite.Ensure(Prerequisite.Node);
+
+        if (File.Exists(Configuration.FrontendDevServerFlagFile))
+        {
+            AnsiConsole.WriteLine($"Frontend development server is already running. If you believe this to be mistake, delete the flag file {Configuration.FrontendDevServerFlagFile}");
+            return 0;
+        }
+
+        var solutionFile = SolutionHelper.GetSolution(solutionName);
+
+        var environmentVariables = new Dictionary<string, string>();
+
+        // CERTIFICATE_PASSWORD is set by AppHost, but when running standalone we need to set it up
+        if (Environment.GetEnvironmentVariable("CERTIFICATE_PASSWORD") == null)
+        {
+            environmentVariables.Add("CERTIFICATE_PASSWORD", GetCertificatePasswordFromAppHost(solutionFile));
+        }
+
+        if (createFlagFile)
+        {
+            File.WriteAllBytes(Configuration.FrontendDevServerFlagFile, Array.Empty<byte>());
+
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => File.Delete(Configuration.FrontendDevServerFlagFile);
+
+            Console.CancelKeyPress += (_, e) =>
+            {
+                e.Cancel = true; // Prevent immediate termination, so the flag file gets deleted
+                File.Delete(Configuration.FrontendDevServerFlagFile);
+            };
+        }
+
+        ProcessHelper.StartProcess("npm run dev", solutionFile.Directory?.FullName, throwOnError: false, exitOnError: false, environmentVariables: environmentVariables);
+        return 0;
+    }
+
+    private static string GetCertificatePasswordFromAppHost(FileInfo solutionFile)
+    {
+        var secretsJson = ProcessHelper.StartProcess("dotnet user-secrets list -p AppHost --json", solutionFile.Directory?.FullName, true);
+
+        var secrets = JsonSerializer.Deserialize<Dictionary<string, string>>(secretsJson, new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip });
+        if (secrets?.ContainsKey("certificate-password") != true)
+        {
+            AnsiConsole.WriteLine("[red]Could not get certificate password from AppHost user secrets. Start by running the frontend development server as part of AppHost, and then try again.[/]");
+            Environment.Exit(1);
+        }
+
+        var secret = secrets["certificate-password"];
+        return secret;
+    }
+}

--- a/developer-cli/Installation/Configuration.cs
+++ b/developer-cli/Installation/Configuration.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -32,6 +34,8 @@ public static class Configuration
     public static bool IsDebugMode => Environment.ProcessPath!.Contains("debug");
 
     private static string ConfigFile => Path.Combine(PublishFolder, $"{AliasName}.json");
+
+    public static readonly string FrontendDevServerFlagFile = Path.Combine(PublishFolder, $"{AliasName}-frontend-dev-server-running");
 
     public static bool VerboseLogging { get; set; }
 

--- a/developer-cli/Utilities/ProcessHelper.cs
+++ b/developer-cli/Utilities/ProcessHelper.cs
@@ -39,7 +39,8 @@ public static class ProcessHelper
         string? solutionFolder,
         bool redirectOutput = false,
         bool useShellExecute = false,
-        bool createNoWindow = false
+        bool createNoWindow = false,
+        Dictionary<string, string>? environmentVariables = null
     )
     {
         var originalFileName = command.Split(' ')[0];
@@ -55,6 +56,14 @@ public static class ProcessHelper
             CreateNoWindow = createNoWindow
         };
 
+        if (environmentVariables != null)
+        {
+            foreach (var keyValuePair in environmentVariables)
+            {
+                processStartInfo.EnvironmentVariables.Add(keyValuePair.Key, keyValuePair.Value);
+            }
+        }
+
         if (solutionFolder is not null)
         {
             processStartInfo.WorkingDirectory = solutionFolder;
@@ -69,10 +78,10 @@ public static class ProcessHelper
         bool redirectOutput = false,
         bool waitForExit = true,
         bool exitOnError = true,
-        bool throwOnError = false
-    )
+        bool throwOnError = false,
+        Dictionary<string, string>? environmentVariables = null)
     {
-        var processStartInfo = CreateProcessStartInfo(command, solutionFolder, redirectOutput);
+        var processStartInfo = CreateProcessStartInfo(command, solutionFolder, redirectOutput, environmentVariables: environmentVariables);
         return StartProcess(processStartInfo, waitForExit: waitForExit, exitOnError: exitOnError, throwOnError: throwOnError);
     }
 


### PR DESCRIPTION
### Summary & Motivation

AppHost starts all projects by default, giving new developers a great one-command-for-everything experience. This includes the frontend development server (`turbo dev`), which builds and serves all our web apps.

This has drawbacks for frontend developers, as the output from the server is quite useful, and they typically have it running in a terminal they keep visible on their screen. This change adds an option for frontend developers to do just that, while retaining the same simple default setup where AppHost runs everything. It also has the added benefit that the development server is kept running despite AppHost re-runs, speeding things up a bit.

To start the frontend server independently, run from the application folder:

```
npm run start
```

before starting AppHost

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
