### PR TITLE
Fix layout issue in ComboBox, where content did not fill the whole width

### DIFF
--- a/application/shared-webapp/ui/components/ComboBox.tsx
+++ b/application/shared-webapp/ui/components/ComboBox.tsx
@@ -43,8 +43,8 @@ export function ComboBox<T extends object>({
     <AriaComboBox {...props} className={composeTailwindRenderProps(props.className, "group flex flex-col gap-1")}>
       <Label>{label}</Label>
       <FieldGroup>
-        <Input isEmbedded />
-        <Button variant="icon" className="mr-1 w-6 rounded outline-offset-0 ">
+        <Input isEmbedded className="flex-grow" />
+        <Button variant="icon" className="w-6 rounded outline-offset-0 ">
           <ChevronsUpDownIcon aria-hidden className="h-4 w-4" />
         </Button>
       </FieldGroup>


### PR DESCRIPTION
### Summary & Motivation

Fixes issue in ComboBox. It's content did not fill up the width of the containing element.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
