### PR TITLE
Fix routing to account-management frontend assets

### DIFF
--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -208,7 +208,7 @@ var accountManagementEnvironmentVariables = [
   }
   {
     name: 'CDN_URL'
-    value: cdnUrl
+    value: '${cdnUrl}/account-management'
   }
   {
     name: 'SENDER_EMAIL_ADDRESS'


### PR DESCRIPTION
### Summary & Motivation

Fixes an issue in production builds introduced in PR #696, which prevented the frontend assets from account-management from loading, as the CDN_URL environment variable needed to changed on the deployed container app.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
