### PR TITLE
Allow multiple rules on a single property

### DIFF
--- a/application/shared-kernel/SharedKernel/ApiResults/ApiResult.cs
+++ b/application/shared-kernel/SharedKernel/ApiResults/ApiResult.cs
@@ -47,7 +47,11 @@ public class ApiResult(ResultBase result, string? routePrefix = null, IDictionar
                 {
                     {
                         "errors",
-                        result.Errors.ToDictionary(e => JsonNamingPolicy.CamelCase.ConvertName(e.PropertyName), e => new[] { e.Message })
+                        result.Errors.GroupBy(e => e.PropertyName)
+                            .ToDictionary(
+                                g => JsonNamingPolicy.CamelCase.ConvertName(g.Key),
+                                g => g.Select(e => e.Message).ToArray()
+                            )
                     }
                 }
                 : null

--- a/application/shared-kernel/Tests/ApiAssertionExtensions.cs
+++ b/application/shared-kernel/Tests/ApiAssertionExtensions.cs
@@ -130,8 +130,11 @@ public static class ApiAssertionExtensions
                 actualErrorsJson.GetRawText(), SharedDependencyConfiguration.DefaultJsonSerializerOptions
             );
 
-            var expectedErrorsDictionary = expectedErrors
-                .ToDictionary(e => JsonNamingPolicy.CamelCase.ConvertName(e.PropertyName), e => new[] { e.Message });
+            var expectedErrorsDictionary = expectedErrors.GroupBy(e => e.PropertyName)
+                .ToDictionary(
+                    g => JsonNamingPolicy.CamelCase.ConvertName(g.Key),
+                    g => g.Select(e => e.Message).ToArray()
+                );
 
             actualErrors.Should().BeEquivalentTo(expectedErrorsDictionary);
         }


### PR DESCRIPTION
### Summary & Motivation

When a command or query has multiple validation rules on a single key, adding the error messages to the dictionary causes:
> An item with the same key has already been added. Key: 'PropertyName'

This change groups validation errors by `PropertyName` and adds all error messages to the errors dictionary.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
