### PR TITLE
Implement ASP.NET Core antiforgery protection with cryptographic double-submit pattern  

### DIFF
--- a/application/account-management/Api/Endpoints/UserEndpoints.cs
+++ b/application/account-management/Api/Endpoints/UserEndpoints.cs
@@ -45,7 +45,7 @@ public sealed class UserEndpoints : IEndpoints
 
         group.MapPost("/me/update-avatar", async Task<ApiResult> (IFormFile file, IMediator mediator)
             => await mediator.Send(new UpdateAvatarCommand(file.OpenReadStream(), file.ContentType))
-        ).DisableAntiforgery(); // Disable anti-forgery until we implement it
+        );
 
         group.MapDelete("/me/remove-avatar", async Task<ApiResult> (IMediator mediator)
             => await mediator.Send(new RemoveAvatarCommand())

--- a/application/account-management/Tests/EndpointBaseTest.cs
+++ b/application/account-management/Tests/EndpointBaseTest.cs
@@ -105,6 +105,10 @@ public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : 
         var memberAccessToken = AccessTokenGenerator.Generate(DatabaseSeeder.Tenant1Member.Adapt<UserInfo>());
         AuthenticatedMemberHttpClient = _webApplicationFactory.CreateClient();
         AuthenticatedMemberHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", memberAccessToken);
+
+        // Set the environment variable to bypass antiforgery validation on the server. ASP.NET uses a cryptographic
+        // double-submit pattern that encrypts the user's ClaimUid in the token, which is complex to replicate in tests
+        Environment.SetEnvironmentVariable("BypassAntiforgeryValidation", "true");
     }
 
     protected SqliteConnection Connection { get; }

--- a/application/account-management/WebApp/shared/lib/api/client.ts
+++ b/application/account-management/WebApp/shared/lib/api/client.ts
@@ -11,6 +11,23 @@ const apiClient = createFetchClient<paths>({
 });
 apiClient.use(createAuthenticationMiddleware());
 
+// Add middleware to include antiforgery token only for non-GET requests
+apiClient.use({
+  onRequest: (params) => {
+    const request = params.request;
+    if (request instanceof Request && request.method !== "GET") {
+      request.headers.set("x-xsrf-token", getAntiforgeryToken());
+    }
+    return request;
+  }
+});
+
+// Get the antiforgery token from the meta tag
+const getAntiforgeryToken = () => {
+  const metaTag = document.querySelector('meta[name="antiforgeryToken"]');
+  return metaTag?.getAttribute("content") ?? "";
+};
+
 export const api = createClient(apiClient);
 
 export type Schemas = components["schemas"];

--- a/application/back-office/Tests/EndpointBaseTest.cs
+++ b/application/back-office/Tests/EndpointBaseTest.cs
@@ -105,6 +105,10 @@ public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : 
         var memberAccessToken = AccessTokenGenerator.Generate(DatabaseSeeder.Tenant1Member.Adapt<UserInfo>());
         AuthenticatedMemberHttpClient = _webApplicationFactory.CreateClient();
         AuthenticatedMemberHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", memberAccessToken);
+
+        // Set the environment variable to bypass antiforgery validation on the server. ASP.NET uses a cryptographic
+        // double-submit pattern that encrypts the user's ClaimUid in the token, which is complex to replicate in tests
+        Environment.SetEnvironmentVariable("BypassAntiforgeryValidation", "true");
     }
 
     protected SqliteConnection Connection { get; }

--- a/application/shared-kernel/SharedKernel/Antiforgery/AntiforgeryMiddleware.cs
+++ b/application/shared-kernel/SharedKernel/Antiforgery/AntiforgeryMiddleware.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Http;
+
+namespace PlatformPlatform.SharedKernel.Antiforgery;
+
+public sealed class AntiforgeryMiddleware(IAntiforgery antiforgery, ILogger<AntiforgeryMiddleware> logger) : IMiddleware
+{
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        if (context.GetEndpoint()?.Metadata.GetMetadata<IAntiforgeryMetadata>()?.RequiresValidation == false)
+        {
+            // Skip validation for endpoints with disabled antiforgery
+            await next(context);
+            return;
+        }
+
+        if (!await antiforgery.IsRequestValidAsync(context))
+        {
+            var traceId = Activity.Current?.Id ?? context.TraceIdentifier;
+
+            logger.LogWarning(
+                "Antiforgery validation failed for {Method} {Path}. TraceId: {TraceId}",
+                context.Request.Method,
+                context.Request.Path,
+                traceId
+            );
+
+            await Results.Problem(
+                title: "Invalid Antiforgery Token",
+                detail: "Antiforgery validation failed for request.",
+                statusCode: StatusCodes.Status400BadRequest,
+                extensions: new Dictionary<string, object?> { { "traceId", traceId } }
+            ).ExecuteAsync(context);
+
+            return;
+        }
+
+        await next(context);
+    }
+}

--- a/application/shared-kernel/SharedKernel/Antiforgery/AntiforgeryMiddleware.cs
+++ b/application/shared-kernel/SharedKernel/Antiforgery/AntiforgeryMiddleware.cs
@@ -14,6 +14,13 @@ public sealed class AntiforgeryMiddleware(IAntiforgery antiforgery, ILogger<Anti
             return;
         }
 
+        if (bool.TryParse(Environment.GetEnvironmentVariable("BypassAntiforgeryValidation"), out _))
+        {
+            logger.LogDebug("Bypassing antiforgery validation due to environment variable setting");
+            await next(context);
+            return;
+        }
+
         if (!await antiforgery.IsRequestValidAsync(context))
         {
             var traceId = Activity.Current?.Id ?? context.TraceIdentifier;

--- a/application/shared-kernel/SharedKernel/Authentication/AuthenticationTokenHttpKeys.cs
+++ b/application/shared-kernel/SharedKernel/Authentication/AuthenticationTokenHttpKeys.cs
@@ -2,17 +2,18 @@ namespace PlatformPlatform.SharedKernel.Authentication;
 
 public static class AuthenticationTokenHttpKeys
 {
-    public const string RefreshTokenCookieName = "refresh_token";
-
     public const string RefreshTokenHttpHeaderKey = "x-refresh-token";
-
-    public const string AccessTokenCookieName = "access_token";
 
     public const string AccessTokenHttpHeaderKey = "x-access-token";
 
+    public const string AntiforgeryTokenHttpHeaderKey = "x-xsrf-token";
+
     public const string RefreshAuthenticationTokensHeaderKey = "x-refresh-authentication-tokens-required";
 
-    public const string AntiforgeryTokenCookieName = "xsrf_token";
+    // __Host prefix ensures the cookie is sent only to the host, requires Secure, HTTPS, Path=/ and no Domain specified
+    public const string RefreshTokenCookieName = "__Host_Refresh_Token";
 
-    public const string AntiforgeryTokenHttpHeaderKey = "x-xsrf-token";
+    public const string AccessTokenCookieName = "__Host_Access_Token";
+
+    public const string AntiforgeryTokenCookieName = "__Host_Xsrf_Token";
 }

--- a/application/shared-kernel/SharedKernel/Authentication/AuthenticationTokenHttpKeys.cs
+++ b/application/shared-kernel/SharedKernel/Authentication/AuthenticationTokenHttpKeys.cs
@@ -4,11 +4,15 @@ public static class AuthenticationTokenHttpKeys
 {
     public const string RefreshTokenCookieName = "refresh_token";
 
-    public const string AccessTokenCookieName = "access_token";
-
     public const string RefreshTokenHttpHeaderKey = "x-refresh-token";
+
+    public const string AccessTokenCookieName = "access_token";
 
     public const string AccessTokenHttpHeaderKey = "x-access-token";
 
     public const string RefreshAuthenticationTokensHeaderKey = "x-refresh-authentication-tokens-required";
+
+    public const string AntiforgeryTokenCookieName = "xsrf_token";
+
+    public const string AntiforgeryTokenHttpHeaderKey = "x-xsrf-token";
 }

--- a/application/shared-kernel/SharedKernel/Configuration/ApiDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/ApiDependencyConfiguration.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NJsonSchema.Generation;
+using PlatformPlatform.SharedKernel.Antiforgery;
 using PlatformPlatform.SharedKernel.Authentication;
 using PlatformPlatform.SharedKernel.Endpoints;
 using PlatformPlatform.SharedKernel.ExecutionContext;
@@ -55,6 +56,7 @@ public static class ApiDependencyConfiguration
             .AddExceptionHandler<GlobalExceptionHandler>()
             .AddTransient<TelemetryContextMiddleware>()
             .AddTransient<ModelBindingExceptionHandlerMiddleware>()
+            .AddTransient<AntiforgeryMiddleware>()
             .AddProblemDetails()
             .AddEndpointsApiExplorer()
             .AddApiEndpoints(assemblies)
@@ -94,6 +96,7 @@ public static class ApiDependencyConfiguration
             .UseAuthentication() // Must be above TelemetryContextMiddleware to ensure authentication happens first
             .UseAuthorization()
             .UseAntiforgery()
+            .UseMiddleware<AntiforgeryMiddleware>()
             .UseMiddleware<TelemetryContextMiddleware>() // It must be above ModelBindingExceptionHandlerMiddleware to ensure that model binding problems are annotated correctly
             .UseMiddleware<ModelBindingExceptionHandlerMiddleware>() // Enable support for proxy headers such as X-Forwarded-For and X-Forwarded-Proto. Should run before other middleware
             .UseOpenApi(options => options.Path = "/openapi/v1.json"); // Adds the OpenAPI generator that uses the ASP. NET Core API Explorer

--- a/application/shared-kernel/SharedKernel/Configuration/ApiDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/ApiDependencyConfiguration.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NJsonSchema.Generation;
+using PlatformPlatform.SharedKernel.Authentication;
 using PlatformPlatform.SharedKernel.Endpoints;
 using PlatformPlatform.SharedKernel.ExecutionContext;
 using PlatformPlatform.SharedKernel.Middleware;
@@ -59,6 +60,12 @@ public static class ApiDependencyConfiguration
             .AddApiEndpoints(assemblies)
             .AddOpenApiConfiguration(assemblies)
             .AddAuthConfiguration()
+            .AddAntiforgery(options =>
+                {
+                    options.Cookie.Name = AuthenticationTokenHttpKeys.AntiforgeryTokenCookieName;
+                    options.HeaderName = AuthenticationTokenHttpKeys.AntiforgeryTokenHttpHeaderKey;
+                }
+            )
             .AddHttpForwardHeaders();
     }
 
@@ -86,6 +93,7 @@ public static class ApiDependencyConfiguration
             .UseForwardedHeaders()
             .UseAuthentication() // Must be above TelemetryContextMiddleware to ensure authentication happens first
             .UseAuthorization()
+            .UseAntiforgery()
             .UseMiddleware<TelemetryContextMiddleware>() // It must be above ModelBindingExceptionHandlerMiddleware to ensure that model binding problems are annotated correctly
             .UseMiddleware<ModelBindingExceptionHandlerMiddleware>() // Enable support for proxy headers such as X-Forwarded-For and X-Forwarded-Proto. Should run before other middleware
             .UseOpenApi(options => options.Path = "/openapi/v1.json"); // Adds the OpenAPI generator that uses the ASP. NET Core API Explorer

--- a/application/shared-kernel/SharedKernel/Endpoints/TrackEndpoints.cs
+++ b/application/shared-kernel/SharedKernel/Endpoints/TrackEndpoints.cs
@@ -20,7 +20,7 @@ public class TrackEndpoints : IEndpoints
     // </summary>
     public void MapEndpoints(IEndpointRouteBuilder routes)
     {
-        routes.MapPost("/api/track", Track).AllowAnonymous();
+        routes.MapPost("/api/track", Track).AllowAnonymous().DisableAntiforgery();
     }
 
     [OpenApiIgnore]

--- a/application/shared-webapp/build/plugin/RunTimeEnvironmentPlugin.ts
+++ b/application/shared-webapp/build/plugin/RunTimeEnvironmentPlugin.ts
@@ -48,7 +48,8 @@ export function RunTimeEnvironmentPlugin<E extends {} = Record<string, unknown>>
             // Define the runtime environment variables as part of the template
             meta: {
               runtimeEnv: "%ENCODED_RUNTIME_ENV%",
-              userInfoEnv: "%ENCODED_USER_INFO_ENV%"
+              userInfoEnv: "%ENCODED_USER_INFO_ENV%",
+              antiforgeryToken: "%ANTIFORGERY_TOKEN%"
             },
             // Add the CDN URL placeholder to the script and link tags in the template file
             tags(tags) {


### PR DESCRIPTION
Implement antiforgery protection using ASP.NET Core’s built-in cryptographic double-submit pattern to prevent CSRF (Cross-Site Request Forgery) attacks. This mechanism generates a secure, `HttpOnly` cookie containing a server-side token and requires an `x-xsrf-token` Header in non-GET requests. The token includes the user's `ClaimUid` and is validated on every request that mutates data (`POST`, `PUT`, `DELETE`, etc.)

A new antiforgery middleware has been introduced to enforce this validation across the application, except for explicitly excluded endpoints like the Application Insights tracking API. The `upload-avatar` endpoint has been updated to remove the previous antiforgery bypass.

Additional security improvements:
- Antiforgery cookies now use the `__Host_` prefix. This special prefix ensures that modern browsers enforce the cookie to be sent only over HTTPS and only to the same origin, providing an additional layer of security.
- Requests failing antiforgery validation return a `400 Bad Request` response with a traceable error message.

To simplify automated testing, antiforgery validation can be disabled using an environment variable, allowing tests to run without requiring a valid token. Setting up the cryptographic double-submit pattern in tests would add unnecessary complexity.

### Downstream projects  

The `refresh_token` and `access_token` cookie names have been changed to `__Host_refresh_token` and `__Host_access_token`. As a result:
- All logged-in users will be required to reauthenticate after this release.
- The previous `refresh_token` cookie will remain orphaned in the browser but will no longer be used.

Add the following to `EndpointBaseTest.cs` to bypass antiforgery validation in test environments:

```csharp
// Set the environment variable to bypass antiforgery validation on the server. ASP.NET uses a cryptographic
// double-submit pattern that encrypts the user's ClaimUid in the token, which is complex to replicate in tests
Environment.SetEnvironmentVariable("BypassAntiforgeryValidation", "true");
```

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
