### PR TITLE
Fix missing container image deployment to production by importing from staging registry

### DIFF
--- a/.github/workflows/_deploy-container.yml
+++ b/.github/workflows/_deploy-container.yml
@@ -67,7 +67,6 @@ jobs:
             --platform linux/amd64,linux/arm64 \
             --build-arg VERSION=${{ inputs.version }} \
             -t ${{ env.UNIQUE_PREFIX }}${{ env.ENVIRONMENT }}.azurecr.io/${{ inputs.image_name }}:${{ inputs.version }} \
-            -t ${{ env.UNIQUE_PREFIX }}${{ env.ENVIRONMENT }}.azurecr.io/${{ inputs.image_name }}:latest \
             -f ${{ inputs.docker_file }} \
             --push .
           docker buildx rm
@@ -106,18 +105,47 @@ jobs:
     env:
       UNIQUE_PREFIX: ${{ vars.UNIQUE_PREFIX }}
       ENVIRONMENT: "prod"
+      STAGING_ENVIRONMENT: "stage"
       CLUSTER_LOCATION_ACRONYM: ${{ vars.PRODUCTION_CLUSTER1_LOCATION_ACRONYM }}
       SERVICE_PRINCIPAL_ID: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_ID }}
+      STAGING_SERVICE_PRINCIPAL_ID: ${{ vars.STAGING_SERVICE_PRINCIPAL_ID }}
       TENANT_ID: ${{ vars.TENANT_ID }}
       SUBSCRIPTION_ID: ${{ vars.PRODUCTION_SUBSCRIPTION_ID }}
+      STAGING_SUBSCRIPTION_ID: ${{ vars.STAGING_SUBSCRIPTION_ID }}
 
     steps:
-      - name: Login to Azure
+      - name: Login to Azure (Staging)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.STAGING_SERVICE_PRINCIPAL_ID }}
+          tenant-id: ${{ env.TENANT_ID }}
+          subscription-id: ${{ env.STAGING_SUBSCRIPTION_ID }}
+          
+      - name: Get Access Token for Staging Azure Subscription
+        id: staging_tokens
+        run: |
+          STAGING_TOKEN=$(az account get-access-token --resource https://management.azure.com --query accessToken -o tsv)
+          echo "::add-mask::$STAGING_TOKEN"
+          echo "access_token=$STAGING_TOKEN" >> $GITHUB_OUTPUT
+          
+      - name: Login to Azure (Production)
         uses: azure/login@v2
         with:
           client-id: ${{ env.SERVICE_PRINCIPAL_ID }}
           tenant-id: ${{ env.TENANT_ID }}
           subscription-id: ${{ env.SUBSCRIPTION_ID }}
+
+      - name: Login to ACR
+        run: az acr login --name ${{ env.UNIQUE_PREFIX }}${{ env.ENVIRONMENT }}
+
+      - name: Import Container Image from Staging to Production
+        run: |
+          az acr import \
+            --name ${{ env.UNIQUE_PREFIX }}${{ env.ENVIRONMENT }} \
+            --source ${{ env.UNIQUE_PREFIX }}${{ env.STAGING_ENVIRONMENT }}.azurecr.io/${{ inputs.image_name }}:${{ inputs.version }} \
+            --image ${{ inputs.image_name }}:${{ inputs.version }} \
+            --password ${{ steps.staging_tokens.outputs.access_token }} \
+            --force
 
       - name: Deploy Container
         run: |


### PR DESCRIPTION
### Summary & Motivation

Fix an issue where container images were not deployed to production due to a leftover configuration from when staging and production shared a container registry. Previously, images were only pushed to the staging registry, but the production deployment did not retrieve them.

This change ensures that production images are correctly imported from the staging container registry using `az acr import`. This avoids redundant builds while ensuring that production always gets the correct image version.

Key changes:
- Removed the unused `latest` tag from the build step to prevent unintended overwrites.
- Added an `az acr import` step to pull images from the staging container registry into production.
- Introduced logic to authenticate against both staging and production Azure subscriptions.
- Masked the staging subscription token in GitHub Actions for security.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
