### PR TITLE
Fix production container image deployment by granting ACR pull access via Bicep infrastructure

### DIFF
--- a/.github/workflows/_deploy-container.yml
+++ b/.github/workflows/_deploy-container.yml
@@ -114,21 +114,8 @@ jobs:
       STAGING_SUBSCRIPTION_ID: ${{ vars.STAGING_SUBSCRIPTION_ID }}
 
     steps:
-      - name: Login to Azure (Staging)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ env.STAGING_SERVICE_PRINCIPAL_ID }}
-          tenant-id: ${{ env.TENANT_ID }}
-          subscription-id: ${{ env.STAGING_SUBSCRIPTION_ID }}
           
-      - name: Get Access Token for Staging Azure Subscription
-        id: staging_tokens
-        run: |
-          STAGING_TOKEN=$(az account get-access-token --resource https://management.azure.com --query accessToken -o tsv)
-          echo "::add-mask::$STAGING_TOKEN"
-          echo "access_token=$STAGING_TOKEN" >> $GITHUB_OUTPUT
-          
-      - name: Login to Azure (Production)
+      - name: Login to Azure
         uses: azure/login@v2
         with:
           client-id: ${{ env.SERVICE_PRINCIPAL_ID }}
@@ -144,7 +131,6 @@ jobs:
             --name ${{ env.UNIQUE_PREFIX }}${{ env.ENVIRONMENT }} \
             --source ${{ env.UNIQUE_PREFIX }}${{ env.STAGING_ENVIRONMENT }}.azurecr.io/${{ inputs.image_name }}:${{ inputs.version }} \
             --image ${{ inputs.image_name }}:${{ inputs.version }} \
-            --password ${{ steps.staging_tokens.outputs.access_token }} \
             --force
 
       - name: Deploy Container

--- a/.github/workflows/_deploy-infrastructure.yml
+++ b/.github/workflows/_deploy-infrastructure.yml
@@ -42,6 +42,10 @@ on:
       deployment_enabled:
         required: true
         type: string
+      production_service_principal_object_id:
+        required: false
+        type: string
+        default: "-"
 
 jobs:
   plan:
@@ -67,7 +71,7 @@ jobs:
 
       - name: Plan Shared Environment Resources
         if: ${{ inputs.include_shared_environment_resources == true }}
-        run: bash ./cloud-infrastructure/environment/deploy-environment.sh ${{ inputs.unique_prefix }} ${{ inputs.azure_environment }} ${{ inputs.shared_location }} --plan
+        run: bash ./cloud-infrastructure/environment/deploy-environment.sh ${{ inputs.unique_prefix }} ${{ inputs.azure_environment }} ${{ inputs.shared_location }} ${{ inputs.production_service_principal_object_id }} --plan
 
       - name: Plan Cluster Resources
         id: deploy_cluster
@@ -99,7 +103,7 @@ jobs:
 
       - name: Deploy Shared Environment Resources
         if: ${{ inputs.include_shared_environment_resources == true }}
-        run: bash ./cloud-infrastructure/environment/deploy-environment.sh ${{ inputs.unique_prefix }} ${{ inputs.azure_environment }} ${{ inputs.shared_location }} --apply
+        run: bash ./cloud-infrastructure/environment/deploy-environment.sh ${{ inputs.unique_prefix }} ${{ inputs.azure_environment }} ${{ inputs.shared_location }} ${{ inputs.production_service_principal_object_id }} --apply
 
       - name: Deploy Cluster Resources
         id: deploy_cluster

--- a/.github/workflows/cloud-infrastructure.yml
+++ b/.github/workflows/cloud-infrastructure.yml
@@ -41,6 +41,7 @@ jobs:
       tenant_id: ${{ vars.TENANT_ID }}
       subscription_id: ${{ vars.STAGING_SUBSCRIPTION_ID }}
       deployment_enabled: ${{ vars.STAGING_CLUSTER_ENABLED }}
+      production_service_principal_object_id: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID }}
 
   prod1:
     name: Production

--- a/cloud-infrastructure/environment/deploy-environment.sh
+++ b/cloud-infrastructure/environment/deploy-environment.sh
@@ -3,12 +3,19 @@
 UNIQUE_PREFIX=$1
 ENVIRONMENT=$2
 LOCATION_SHARED=$3
+PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID=$4
 
 RESOURCE_GROUP_NAME=$UNIQUE_PREFIX-$ENVIRONMENT
 CONTAINER_REGISTRY_NAME=$UNIQUE_PREFIX$ENVIRONMENT
 CURRENT_DATE=$(date +'%Y-%m-%dT%H-%M')
 DEPLOYMENT_COMMAND="az deployment sub create"
 DEPLOYMENT_PARAMETERS="-l $LOCATION_SHARED -n $CURRENT_DATE-$UNIQUE_PREFIX-$ENVIRONMENT --output table -f ./main-environment.bicep -p resourceGroupName=$RESOURCE_GROUP_NAME environment=$ENVIRONMENT containerRegistryName=$CONTAINER_REGISTRY_NAME"
+
+# Add production service principal object ID parameter if provided for ACR Pull role assignment to staging Container Registry
+if [[ "$PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID" != "-" ]]; then
+  echo "Using production service principal object ID: $PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID"
+  DEPLOYMENT_PARAMETERS="$DEPLOYMENT_PARAMETERS productionServicePrincipalObjectId=$PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID"
+fi
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 . ../deploy.sh

--- a/cloud-infrastructure/environment/main-environment.bicep
+++ b/cloud-infrastructure/environment/main-environment.bicep
@@ -4,6 +4,7 @@ param location string = deployment().location
 param resourceGroupName string
 param environment string
 param containerRegistryName string
+param productionServicePrincipalObjectId string = ''
 
 var tags = { environment: environment, 'managed-by': 'bicep' }
 
@@ -20,6 +21,16 @@ module containerRegistry '../modules/container-registry.bicep' = {
     name: containerRegistryName
     location: location
     tags: tags
+  }
+}
+
+// Grant production service principal ACR Pull access to registry if specified
+module productionServicePrincipalAcrPull '../modules/role-assignments-container-registry-acr-pull.bicep' = if (!empty(productionServicePrincipalObjectId)) {
+  name: '${resourceGroupName}-production-sp-acr-pull'
+  scope: resourceGroup(environmentResourceGroup.name)
+  params: {
+    containerRegistryName: containerRegistryName
+    principalId: productionServicePrincipalObjectId
   }
 }
 

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -509,6 +509,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
                 * PRODUCTION_SUBSCRIPTION_ID: [blue]{Config.ProductionSubscription.Id}[/]
                 * PRODUCTION_SHARED_LOCATION: [blue]{Config.ProductionLocation.SharedLocation}[/]
                 * PRODUCTION_SERVICE_PRINCIPAL_ID: [blue]{productionServicePrincipal}[/]
+                * PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID: [blue]{Config.ProductionSubscription.AppRegistration.ServicePrincipalObjectId}[/]
                 * PRODUCTION_SQL_ADMIN_OBJECT_ID: [blue]{productionSqlAdminObject}[/]
                 * PRODUCTION_DOMAIN_NAME: [blue]-[/] ([yellow]Manually changed this and triggered deployment to set up the domain[/])
 
@@ -724,6 +725,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
 
         SetGithubVariable(VariableNames.PRODUCTION_SUBSCRIPTION_ID, Config.ProductionSubscription.Id);
         SetGithubVariable(VariableNames.PRODUCTION_SERVICE_PRINCIPAL_ID, Config.ProductionSubscription.AppRegistration.ServicePrincipalId!);
+        SetGithubVariable(VariableNames.PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID, Config.ProductionSubscription.AppRegistration.ServicePrincipalObjectId!);
         SetGithubVariable(VariableNames.PRODUCTION_SHARED_LOCATION, Config.ProductionLocation.SharedLocation);
         SetGithubVariable(VariableNames.PRODUCTION_SQL_ADMIN_OBJECT_ID, Config.ProductionSubscription.SqlAdminsGroup.ObjectId!);
         SetGithubVariable(VariableNames.PRODUCTION_DOMAIN_NAME, "-");
@@ -1058,6 +1060,7 @@ public enum VariableNames
 
     PRODUCTION_SUBSCRIPTION_ID,
     PRODUCTION_SERVICE_PRINCIPAL_ID,
+    PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID,
     PRODUCTION_SHARED_LOCATION,
     PRODUCTION_SQL_ADMIN_OBJECT_ID,
     PRODUCTION_DOMAIN_NAME,


### PR DESCRIPTION
### Summary & motivation

Fix an issue where container images were not deployed to production due to incorrect federated credentials when attempting to pull images from the staging container registry. The previous approach relied on GitHub Actions federated credentials, which failed because the production workflow was not using the correct federated credential to access staging.

To resolve this, Bicep infrastructure has been updated to grant the production service principal ACR pull permissions on the staging container registry during infrastructure deployment. This ensures that production can securely pull images from staging without requiring federated identity access.

This change makes the GitHub workflow much cleaner, as there is no longer a need for production workflows to log in to staging. However, this change introduced a new challenge: the GitHub environment variable `PRODUCTION_SERVICE_PRINCIPAL_ID` could not be used for role assignment. The required Object ID is not accessible from GitHub Actions because Microsoft Entra ID cannot be queried from the workflow. To work around this, a new `PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID` environment variable has been introduced, and the `configure-continuous-deployments` CLI has been updated to create this.

### Downstream projects

To support this change, you must create a new GitHub variable named `PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID` before merging this into `main`.

#### How to obtain the required object ID:
1. **Preferred method**: Re-run `pp configure-continuous-deployments` using the Developer CLI, which will recreate all your GitHub variables (with the same values) and add the new `PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID`.
2. **Manual method**: If re-running the CLI is not feasible, retrieve the object ID manually:
   - Go to Azure Portal.
   - Navigate to **Microsoft Entra ID > Enterprise Applications** (not to be confused with App Registrations).
   - Search for `GitHub - Production - your-github-org/your-github-repo`.
   - Copy the **Object ID** and create a new `PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID` GitHub variable with this value.

If this is not set or set with wrong ID, deployment of staging infrastructure will fail with errors such as `"PrincipalTypeNotSupported"` or `"InvalidPrincipalId"`.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
