### PR TITLE
Fix container deployment to production by using correct Azure role and registry parameters

### DIFF
--- a/.github/workflows/_deploy-container.yml
+++ b/.github/workflows/_deploy-container.yml
@@ -108,7 +108,6 @@ jobs:
       STAGING_ENVIRONMENT: "stage"
       CLUSTER_LOCATION_ACRONYM: ${{ vars.PRODUCTION_CLUSTER1_LOCATION_ACRONYM }}
       SERVICE_PRINCIPAL_ID: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_ID }}
-      STAGING_SERVICE_PRINCIPAL_ID: ${{ vars.STAGING_SERVICE_PRINCIPAL_ID }}
       TENANT_ID: ${{ vars.TENANT_ID }}
       SUBSCRIPTION_ID: ${{ vars.PRODUCTION_SUBSCRIPTION_ID }}
       STAGING_SUBSCRIPTION_ID: ${{ vars.STAGING_SUBSCRIPTION_ID }}
@@ -127,10 +126,13 @@ jobs:
 
       - name: Import Container Image from Staging to Production
         run: |
+          STAGING_REGISTRY_ID="/subscriptions/${{ env.STAGING_SUBSCRIPTION_ID }}/resourceGroups/${{ env.UNIQUE_PREFIX }}-${{ env.STAGING_ENVIRONMENT }}/providers/Microsoft.ContainerRegistry/registries/${{ env.UNIQUE_PREFIX }}${{ env.STAGING_ENVIRONMENT }}"
+          
           az acr import \
             --name ${{ env.UNIQUE_PREFIX }}${{ env.ENVIRONMENT }} \
-            --source ${{ env.UNIQUE_PREFIX }}${{ env.STAGING_ENVIRONMENT }}.azurecr.io/${{ inputs.image_name }}:${{ inputs.version }} \
+            --source ${{ inputs.image_name }}:${{ inputs.version }} \
             --image ${{ inputs.image_name }}:${{ inputs.version }} \
+            --registry "$STAGING_REGISTRY_ID" \
             --force
 
       - name: Deploy Container

--- a/cloud-infrastructure/environment/main-environment.bicep
+++ b/cloud-infrastructure/environment/main-environment.bicep
@@ -32,6 +32,7 @@ module productionServicePrincipalAcrPull '../modules/role-assignments-container-
     containerRegistryName: containerRegistryName
     principalId: productionServicePrincipalObjectId
   }
+  dependsOn: [containerRegistry]
 }
 
 module logAnalyticsWorkspace '../modules/log-analytics-workspace.bicep' = {

--- a/cloud-infrastructure/environment/main-environment.bicep
+++ b/cloud-infrastructure/environment/main-environment.bicep
@@ -24,9 +24,9 @@ module containerRegistry '../modules/container-registry.bicep' = {
   }
 }
 
-// Grant production service principal ACR Pull access to registry if specified
-module productionServicePrincipalAcrPull '../modules/role-assignments-container-registry-acr-pull.bicep' = if (!empty(productionServicePrincipalObjectId)) {
-  name: '${resourceGroupName}-production-sp-acr-pull'
+// Grant production service principal Container Registry Data Importer access to registry if specified
+module productionServicePrincipalDataImporter '../modules/role-assignments-container-registry-data-importer.bicep' = if (!empty(productionServicePrincipalObjectId)) {
+  name: '${resourceGroupName}-production-sp-data-importer'
   scope: resourceGroup(environmentResourceGroup.name)
   params: {
     containerRegistryName: containerRegistryName

--- a/cloud-infrastructure/modules/role-assignments-container-registry-data-importer.bicep
+++ b/cloud-infrastructure/modules/role-assignments-container-registry-data-importer.bicep
@@ -1,0 +1,17 @@
+param containerRegistryName string
+param principalId string
+
+resource containerRegistryResource 'Microsoft.ContainerRegistry/registries@2023-08-01-preview' existing = {
+  name: containerRegistryName
+}
+
+var containerRegistryDataImporterDefinitionId = '577a9874-89fd-4f24-9dbd-b5034d0ad23a'
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(principalId)
+  properties: {
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', containerRegistryDataImporterDefinitionId)
+  }
+  scope: containerRegistryResource
+}


### PR DESCRIPTION
### Summary & motivation

Fix an issue preventing container images from being deployed to production due to incorrect role assignments when pulling images from the staging container registry. The previous attempt used the `ACR Pull` role, but `az acr import` requires the `Container Registry Data Importer` role instead.

Additionally:
- The `az acr import` command has been updated to use the correct `--registry` parameter, specifying the Azure Resource Manager path instead of the FQDN.
- A new Bicep module (`role-assignments-container-registry-data-importer.bicep`) has been introduced to assign the correct role.
- The role assignment for the production service principal to the staging container registry is now configured to await ACR creation to prevent deployment failures on first-time setup.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
