### PR TITLE
Enable Azure Container Apps auto-configuration for .NET data protection

### DIFF
--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -18,13 +18,13 @@ param mailSenderDisplayName string = 'PlatformPlatform'
 var storageAccountUniquePrefix = replace(resourceGroupName, '-', '')
 var tags = { environment: environment, 'managed-by': 'bicep' }
 
-resource clusterResourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+resource clusterResourceGroup 'Microsoft.Resources/resourceGroups@2024-11-01' = {
   name: resourceGroupName
   location: location
   tags: tags
 }
 
-resource existingLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
+resource existingLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
   scope: resourceGroup('${environmentResourceGroupName}')
   name: environmentResourceGroupName
 }

--- a/cloud-infrastructure/environment/main-environment.bicep
+++ b/cloud-infrastructure/environment/main-environment.bicep
@@ -8,7 +8,7 @@ param productionServicePrincipalObjectId string = ''
 
 var tags = { environment: environment, 'managed-by': 'bicep' }
 
-resource environmentResourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+resource environmentResourceGroup 'Microsoft.Resources/resourceGroups@2024-11-01' = {
   name: resourceGroupName
   location: location
   tags: tags

--- a/cloud-infrastructure/modules/communication-services.bicep
+++ b/cloud-infrastructure/modules/communication-services.bicep
@@ -43,11 +43,11 @@ resource communicationServices 'Microsoft.Communication/communicationServices@20
   }
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2021-10-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
 }
 
-resource communicationServiceConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2021-10-01' = {
+resource communicationServiceConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   parent: keyVault
   name: 'communication-services-connection-string'
   properties: {

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -71,7 +71,7 @@ var image = useQuickStartImage
 // Create a revisionSuffix that contains the version but is be unique for each deployment. E.g. "2024-4-24-1557-tzyb"
 var revisionSuffix = '${replace(containerImageTag, '.', '-')}-${substring(uniqueSuffix, 0, 4)}'
 
-resource containerApp 'Microsoft.App/containerApps@2023-05-02-preview' = {
+resource containerApp 'Microsoft.App/containerApps@2024-02-02-preview' = {
   name: name
   location: location
   tags: tags

--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -160,6 +160,11 @@ resource containerApp 'Microsoft.App/containerApps@2024-02-02-preview' = {
           identity: userAssignedIdentity.id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
       ingress: ingress
         ? {
             external: external

--- a/cloud-infrastructure/modules/container-apps-environment.bicep
+++ b/cloud-infrastructure/modules/container-apps-environment.bicep
@@ -4,7 +4,7 @@ param tags object
 param subnetId string
 param environmentResourceGroupName string
 
-resource existingLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
+resource existingLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
   scope: resourceGroup('${environmentResourceGroupName}')
   name: environmentResourceGroupName
 }
@@ -12,7 +12,7 @@ resource existingLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces
 var logAnalyticsCustomerId = existingLogAnalyticsWorkspace.properties.customerId
 var logAnalyticsSharedKey = existingLogAnalyticsWorkspace.listKeys().primarySharedKey
 
-resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-02-preview' = {
+resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2024-03-01' = {
   name: name
   location: location
   tags: tags

--- a/cloud-infrastructure/modules/log-analytics-workspace.bicep
+++ b/cloud-infrastructure/modules/log-analytics-workspace.bicep
@@ -2,7 +2,7 @@ param name string
 param location string
 param tags object
 
-resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: name
   location: location
   tags: tags

--- a/cloud-infrastructure/modules/managed-certificate.bicep
+++ b/cloud-infrastructure/modules/managed-certificate.bicep
@@ -4,11 +4,11 @@ param tags object
 param containerAppsEnvironmentName string
 param domainName string
 
-resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-02-preview' existing = {
+resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2024-03-01' existing = {
   name: containerAppsEnvironmentName
 }
 
-resource managedCertificate 'Microsoft.App/managedEnvironments/managedCertificates@2023-05-02-preview' = {
+resource managedCertificate 'Microsoft.App/managedEnvironments/managedCertificates@2024-03-01' = {
   name: name
   parent: containerAppsEnvironment
   location: location

--- a/cloud-infrastructure/modules/role-assignments-storage-blob-data-contributor.bicep
+++ b/cloud-infrastructure/modules/role-assignments-storage-blob-data-contributor.bicep
@@ -7,7 +7,7 @@ resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@
   name: userAssignedIdentityName ?? principalId
 }
 
-resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
+resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
   scope: resourceGroup()
   name: storageAccountName
 }

--- a/cloud-infrastructure/modules/role-assignments-storage-blob-data-reader.bicep
+++ b/cloud-infrastructure/modules/role-assignments-storage-blob-data-reader.bicep
@@ -7,7 +7,7 @@ resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@
   name: userAssignedIdentityName ?? principalId
 }
 
-resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
+resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
   scope: resourceGroup()
   name: storageAccountName
 }

--- a/cloud-infrastructure/modules/storage-account.bicep
+++ b/cloud-infrastructure/modules/storage-account.bicep
@@ -11,7 +11,7 @@ param containers array = [
   }
 ]
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: name
   location: location
   tags: tags
@@ -46,7 +46,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
 }
 
-resource blobContainers 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = [
+resource blobContainers 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = [
   for container in containers: {
     name: '${name}/default/${container.name}'
     properties: {

--- a/cloud-infrastructure/modules/user-assigned-managed-identity.bicep
+++ b/cloud-infrastructure/modules/user-assigned-managed-identity.bicep
@@ -21,7 +21,7 @@ module containerRegistryPermission './role-assignments-container-registry-acr-pu
   }
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2021-10-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
 }
 

--- a/cloud-infrastructure/modules/virtual-network.bicep
+++ b/cloud-infrastructure/modules/virtual-network.bicep
@@ -3,7 +3,7 @@ param location string
 param tags object
 param address string
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   name: name
   location: location
   tags: tags


### PR DESCRIPTION
### Summary & Motivation

Update Azure Container Apps infrastructure to automatically configures .NET data protection. This ensures that encryption keys used for antiforgery tokens, authentication cookies, and other protected state are securely managed and automatically shared between containers in the same Azure Container Apps Environment.

To enable this feature, the container app module now includes:

```bicep
runtime: {
  dotnet: {
    autoConfigureDataProtection: true
  }
}
```

All Bicep modules have also been upgraded to the latest stable API versions.

### Downstream projects

This infrastructure change must be merged and deployed to Azure environments before the upcoming .NET changes that rely on shared data protection keys across containers.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
