### PR TITLE
Move database migrations to CI/CD with SQL preview on pull requests and approval workflow

### DIFF
--- a/.github/workflows/_deploy-container.yml
+++ b/.github/workflows/_deploy-container.yml
@@ -3,6 +3,18 @@ name: Deploy Container
 on:
   workflow_call:
     inputs:
+      azure_environment:
+        required: true
+        type: string
+      cluster_location_acronym:
+        required: true
+        type: string
+      service_principal_id:
+        required: true
+        type: string
+      subscription_id:
+        required: true
+        type: string
       image_name:
         required: true
         type: string
@@ -23,24 +35,23 @@ on:
         type: string
 
 jobs:
-  stage:
-    name: Staging
+  deploy:
+    name: Deploy
     runs-on: ubuntu-24.04
-    # environment: "staging"  # Manual approval disabled
-    if: ${{ vars.STAGING_CLUSTER_ENABLED == 'true' && github.ref == 'refs/heads/main' }}
+    environment: ${{ inputs.azure_environment == 'prod' && 'production' || 'staging' }}
     env:
       UNIQUE_PREFIX: ${{ vars.UNIQUE_PREFIX }}
-      ENVIRONMENT: "stage"
-      CLUSTER_LOCATION_ACRONYM: ${{ vars.STAGING_CLUSTER_LOCATION_ACRONYM }}
-      SERVICE_PRINCIPAL_ID: ${{ vars.STAGING_SERVICE_PRINCIPAL_ID }}
+      ENVIRONMENT: ${{ inputs.azure_environment }}
+      CLUSTER_LOCATION_ACRONYM: ${{ inputs.cluster_location_acronym }}
+      SERVICE_PRINCIPAL_ID: ${{ inputs.service_principal_id }}
       TENANT_ID: ${{ vars.TENANT_ID }}
-      SUBSCRIPTION_ID: ${{ vars.STAGING_SUBSCRIPTION_ID }}
+      SUBSCRIPTION_ID: ${{ inputs.subscription_id }}
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Download artifacts
+      - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifacts_name }}
@@ -56,10 +67,26 @@ jobs:
       - name: Login to ACR
         run: az acr login --name ${{ env.UNIQUE_PREFIX }}${{ env.ENVIRONMENT }}
 
+      # For production, import image from staging instead of building
+      - name: Import Container Image from Staging to Production
+        if: inputs.azure_environment == 'prod'
+        run: |
+          STAGING_REGISTRY_ID="/subscriptions/${{ vars.STAGING_SUBSCRIPTION_ID }}/resourceGroups/${{ env.UNIQUE_PREFIX }}-stage/providers/Microsoft.ContainerRegistry/registries/${{ env.UNIQUE_PREFIX }}stage"
+          
+          az acr import \
+            --name ${{ env.UNIQUE_PREFIX }}${{ env.ENVIRONMENT }} \
+            --source ${{ inputs.image_name }}:${{ inputs.version }} \
+            --image ${{ inputs.image_name }}:${{ inputs.version }} \
+            --registry "$STAGING_REGISTRY_ID" \
+            --force
+
+      # For staging, build and push the image
       - name: Setup Docker Buildx
+        if: inputs.azure_environment == 'stage'
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push container image
+      - name: Build and Push Container Image
+        if: inputs.azure_environment == 'stage'
         working-directory: ${{ inputs.docker_context }}
         run: |
           docker buildx create --use
@@ -70,70 +97,6 @@ jobs:
             -f ${{ inputs.docker_file }} \
             --push .
           docker buildx rm
-
-      - name: Deploy Container
-        run: |
-          SUFFIX=$(echo "${{ inputs.version }}" | sed 's/\./-/g')
-          az containerapp update --name ${{ inputs.image_name }} --resource-group "${{ env.UNIQUE_PREFIX }}-${{ env.ENVIRONMENT }}-${{ env.CLUSTER_LOCATION_ACRONYM }}" --image "${{ env.UNIQUE_PREFIX }}${{ env.ENVIRONMENT }}.azurecr.io/${{ inputs.image_name }}:${{ inputs.version }}" --revision-suffix $SUFFIX
-
-          echo "Waiting for the new revision to be active..."
-          for i in {1..10}; do
-            sleep 15
-
-            RUNNING_STATUS=$(az containerapp revision list --name ${{ inputs.image_name }} --resource-group "${{ env.UNIQUE_PREFIX }}-${{ env.ENVIRONMENT }}-${{ env.CLUSTER_LOCATION_ACRONYM }}" --query "[?contains(name, '$SUFFIX')].properties.runningState" --output tsv)
-            HEALTH_STATUS=$(az containerapp revision list --name ${{ inputs.image_name }} --resource-group "${{ env.UNIQUE_PREFIX }}-${{ env.ENVIRONMENT }}-${{ env.CLUSTER_LOCATION_ACRONYM }}" --query "[?contains(name, '$SUFFIX')].properties.healthState" --output tsv)
-            if [[ "$HEALTH_STATUS" == "Healthy" ]]; then
-              echo "New revision is healthy. Running state: $RUNNING_STATUS"
-              exit 0
-            fi
-            if [[ "$HEALTH_STATUS" == "Unhealthy" ]]; then
-              echo "New revision is Unhealthy. Running state: $RUNNING_STATUS"
-              exit 1
-            fi
-            
-            echo "($i) Waiting for revision to become active. Running state: $RUNNING_STATUS"
-          done
-          echo "New revision did not become active in time. Running state: $RUNNING_STATUS"
-          exit 1
-
-  prod1:
-    name: Production
-    needs: stage
-    environment: "production" # Force a manual approval
-    runs-on: ubuntu-24.04
-    if: ${{ vars.PRODUCTION_CLUSTER1_ENABLED == 'true' && github.ref == 'refs/heads/main' }}
-    env:
-      UNIQUE_PREFIX: ${{ vars.UNIQUE_PREFIX }}
-      ENVIRONMENT: "prod"
-      STAGING_ENVIRONMENT: "stage"
-      CLUSTER_LOCATION_ACRONYM: ${{ vars.PRODUCTION_CLUSTER1_LOCATION_ACRONYM }}
-      SERVICE_PRINCIPAL_ID: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_ID }}
-      TENANT_ID: ${{ vars.TENANT_ID }}
-      SUBSCRIPTION_ID: ${{ vars.PRODUCTION_SUBSCRIPTION_ID }}
-      STAGING_SUBSCRIPTION_ID: ${{ vars.STAGING_SUBSCRIPTION_ID }}
-
-    steps:
-          
-      - name: Login to Azure
-        uses: azure/login@v2
-        with:
-          client-id: ${{ env.SERVICE_PRINCIPAL_ID }}
-          tenant-id: ${{ env.TENANT_ID }}
-          subscription-id: ${{ env.SUBSCRIPTION_ID }}
-
-      - name: Login to ACR
-        run: az acr login --name ${{ env.UNIQUE_PREFIX }}${{ env.ENVIRONMENT }}
-
-      - name: Import Container Image from Staging to Production
-        run: |
-          STAGING_REGISTRY_ID="/subscriptions/${{ env.STAGING_SUBSCRIPTION_ID }}/resourceGroups/${{ env.UNIQUE_PREFIX }}-${{ env.STAGING_ENVIRONMENT }}/providers/Microsoft.ContainerRegistry/registries/${{ env.UNIQUE_PREFIX }}${{ env.STAGING_ENVIRONMENT }}"
-          
-          az acr import \
-            --name ${{ env.UNIQUE_PREFIX }}${{ env.ENVIRONMENT }} \
-            --source ${{ inputs.image_name }}:${{ inputs.version }} \
-            --image ${{ inputs.image_name }}:${{ inputs.version }} \
-            --registry "$STAGING_REGISTRY_ID" \
-            --force
 
       - name: Deploy Container
         run: |

--- a/.github/workflows/_deploy-infrastructure.yml
+++ b/.github/workflows/_deploy-infrastructure.yml
@@ -1,18 +1,24 @@
-name: Plan and Deploy Infrastructure
+name: Deploy Infrastructure
 
 on:
   workflow_call:
     inputs:
-      github_environment:
-        required: true
-        type: string
-      include_shared_environment_resources:
-        required: true
-        type: boolean
-      unique_prefix:
-        required: true
-        type: string
       azure_environment:
+        required: true
+        type: string
+      cluster_location_acronym:
+        required: true
+        type: string
+      service_principal_id:
+        required: true
+        type: string
+      subscription_id:
+        required: true
+        type: string
+      tenant_id:
+        required: true
+        type: string
+      unique_prefix:
         required: true
         type: string
       shared_location:
@@ -21,25 +27,10 @@ on:
       cluster_location:
         required: true
         type: string
-      cluster_location_acronym:
-        required: true
-        type: string
-      sql_admin_object_id:
-        required: true
-        type: string
       domain_name:
         required: true
         type: string
-      service_principal_id:
-        required: true
-        type: string
-      tenant_id:
-        required: true
-        type: string
-      subscription_id:
-        required: true
-        type: string
-      deployment_enabled:
+      sql_admin_object_id:
         required: true
         type: string
       production_service_principal_object_id:
@@ -49,7 +40,7 @@ on:
 
 jobs:
   plan:
-    name: "Planning"
+    name: Plan
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
@@ -70,7 +61,6 @@ jobs:
           subscription-id: ${{ inputs.subscription_id }}
 
       - name: Plan Shared Environment Resources
-        if: ${{ inputs.include_shared_environment_resources == true }}
         run: bash ./cloud-infrastructure/environment/deploy-environment.sh ${{ inputs.unique_prefix }} ${{ inputs.azure_environment }} ${{ inputs.shared_location }} ${{ inputs.production_service_principal_object_id }} --plan
 
       - name: Plan Cluster Resources
@@ -78,11 +68,12 @@ jobs:
         run: bash ./cloud-infrastructure/cluster/deploy-cluster.sh ${{ inputs.unique_prefix }} ${{ inputs.azure_environment }} ${{ inputs.cluster_location }} ${{ inputs.cluster_location_acronym }} ${{ inputs.sql_admin_object_id }} ${{ inputs.domain_name }} --plan
   
   deploy:
-    name: "Deploying"
-    if: ${{ inputs.deployment_enabled == 'true' && github.ref == 'refs/heads/main' }}
+    name: Deploy
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: plan
-    environment: "${{ inputs.github_environment }}"
+    environment: ${{ inputs.azure_environment == 'prod' && 'production' || 'staging' }}
     runs-on: ubuntu-24.04
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -102,7 +93,6 @@ jobs:
           subscription-id: ${{ inputs.subscription_id }}
 
       - name: Deploy Shared Environment Resources
-        if: ${{ inputs.include_shared_environment_resources == true }}
         run: bash ./cloud-infrastructure/environment/deploy-environment.sh ${{ inputs.unique_prefix }} ${{ inputs.azure_environment }} ${{ inputs.shared_location }} ${{ inputs.production_service_principal_object_id }} --apply
 
       - name: Deploy Cluster Resources
@@ -116,7 +106,7 @@ jobs:
           tenant-id: ${{ inputs.tenant_id }}
           subscription-id: ${{ inputs.subscription_id }}
 
-      - name: Install Microsoft sqlcmd tool
+      - name: Install Microsoft sqlcmd Utility
         run: |
           curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc &&
           sudo add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/22.04/prod.list)" &&

--- a/.github/workflows/_migrate-database.yml
+++ b/.github/workflows/_migrate-database.yml
@@ -1,0 +1,214 @@
+name: Migrate Database
+
+on:
+  workflow_call:
+    inputs:
+      azure_environment:
+        required: true
+        type: string
+      cluster_location_acronym:
+        required: true
+        type: string
+      service_principal_id:
+        required: true
+        type: string
+      subscription_id:
+        required: true
+        type: string
+      database_name:
+        required: true
+        type: string
+      relative_project_path:
+        description: "Relative path to the project containing the migrations"
+        required: true
+        type: string
+      relative_startup_project:
+        description: "Relative path to the startup project"
+        required: true
+        type: string
+      db_context:
+        required: true
+        type: string
+      apply_migrations:
+        required: true
+        type: boolean
+
+    outputs:
+      has_migrations_to_apply:
+        value: ${{ jobs.plan-migrations.outputs.has_migrations_to_apply }}
+
+concurrency:
+  group: ${{ inputs.database_name }}-${{ inputs.azure_environment }}-migrations
+  cancel-in-progress: false
+
+jobs:
+  plan-migrations:
+    name: Plan
+    runs-on: ubuntu-24.04
+    outputs:
+      has_migrations_to_apply: ${{ steps.generate-migration-script.outputs.has_migrations_to_apply }}
+    env:
+      UNIQUE_PREFIX: ${{ vars.UNIQUE_PREFIX }}
+      TENANT_ID: ${{ vars.TENANT_ID }}
+      RESOURCE_GROUP_NAME: ${{ vars.UNIQUE_PREFIX }}-${{ inputs.azure_environment }}-${{ inputs.cluster_location_acronym }}
+      SQL_SERVER_NAME: ${{ vars.UNIQUE_PREFIX }}-${{ inputs.azure_environment }}-${{ inputs.cluster_location_acronym }}
+      SQL_SERVER_FQDN: ${{ vars.UNIQUE_PREFIX }}-${{ inputs.azure_environment }}-${{ inputs.cluster_location_acronym }}.database.windows.net
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore .NET Tools
+        working-directory: application
+        run: dotnet tool restore
+
+      - name: Build Backend Solution
+        working-directory: application
+        run: dotnet build ${{ inputs.relative_startup_project }}
+
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ inputs.service_principal_id }}
+          tenant-id: ${{ env.TENANT_ID }}
+          subscription-id: ${{ inputs.subscription_id }}
+
+      - name: Open Firewall
+        working-directory: cloud-infrastructure/cluster
+        env:
+          RESOURCE_GROUP_NAME: ${{ env.RESOURCE_GROUP_NAME }}
+          SQL_SERVER_NAME: ${{ env.SQL_SERVER_NAME }}
+          SQL_DATABASE_NAME: ${{ inputs.database_name }}
+        run: bash ./firewall.sh open
+
+      - name: Generate Script for Pending Migrations
+        id: generate-migration-script
+        working-directory: application
+        run: |
+          CONNECTION_STRING="Server=tcp:${{ env.SQL_SERVER_FQDN }},1433;Database=${{ inputs.database_name }};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;Authentication=Active Directory Default;"
+          
+          echo "Checking for pending migrations..."        
+          MIGRATION_INFO=$(dotnet ef migrations list \
+            --project ${{ inputs.relative_project_path }} \
+            --startup-project ${{ inputs.relative_startup_project }} \
+            --context ${{ inputs.db_context }} \
+            --connection "$CONNECTION_STRING" \
+            --no-build \
+            --json 2>/dev/null || echo '[]')
+          
+          MIGRATION_JSON=$(echo "$MIGRATION_INFO" | sed -n '/^[{[]/,$p')
+          PENDING_MIGRATIONS_JSON=$(echo "$MIGRATION_JSON" | jq '[.[] | select(.applied == false)]')
+          PENDING_MIGRATIONS_COUNT=$(echo "$PENDING_MIGRATIONS_JSON" | jq '. | length')
+          LAST_APPLIED_MIGRATION=$(echo "$MIGRATION_JSON" | jq -r '[.[] | select(.applied == true) | .id] | sort | last // "0"')
+          
+          if [ "$PENDING_MIGRATIONS_COUNT" -gt "0" ]; then
+            LAST_PENDING_MIGRATION=$(echo "$PENDING_MIGRATIONS_JSON" | jq -r '.[-1].id')
+            echo "$PENDING_MIGRATIONS_COUNT pending migration(s) detected:"
+            echo "$PENDING_MIGRATIONS_JSON"
+            echo "Generating migration script from $LAST_APPLIED_MIGRATION to $LAST_PENDING_MIGRATION..."
+
+            dotnet ef migrations script \
+              "$LAST_APPLIED_MIGRATION" "$LAST_PENDING_MIGRATION" \
+              --project ${{ inputs.relative_project_path }} \
+              --startup-project ${{ inputs.relative_startup_project }} \
+              --context ${{ inputs.db_context }} \
+              --idempotent \
+              --no-build \
+              --output migration.sql
+            
+            echo "has_migrations_to_apply=true" >> $GITHUB_OUTPUT
+          else
+            echo "No pending migrations detected."
+            echo "Here is a list of all migrations:"
+            echo "$MIGRATION_JSON"
+            echo "has_migrations_to_apply=false" >> $GITHUB_OUTPUT
+          fi
+        
+      - name: Close Firewall
+        if: always()
+        working-directory: cloud-infrastructure/cluster
+        env:
+          RESOURCE_GROUP_NAME: ${{ env.RESOURCE_GROUP_NAME }}
+          SQL_SERVER_NAME: ${{ env.SQL_SERVER_NAME }}
+          SQL_DATABASE_NAME: ${{ inputs.database_name }}
+        run: bash ./firewall.sh close
+
+      - name: Upload Migration Script
+        if: steps.generate-migration-script.outputs.has_migrations_to_apply == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-script-${{ inputs.azure_environment }}-${{ inputs.cluster_location_acronym }}
+          path: application/migration.sql
+
+  apply-migrations:
+    name: Deploy
+    needs: plan-migrations
+    if: needs.plan-migrations.outputs.has_migrations_to_apply == 'true' && inputs.apply_migrations
+    runs-on: ubuntu-24.04
+    environment:
+      name: ${{ inputs.azure_environment == 'prod' && 'production' || 'staging' }}
+      url: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+
+    env:
+      UNIQUE_PREFIX: ${{ vars.UNIQUE_PREFIX }}
+      TENANT_ID: ${{ vars.TENANT_ID }}
+      RESOURCE_GROUP_NAME: ${{ vars.UNIQUE_PREFIX }}-${{ inputs.azure_environment }}-${{ inputs.cluster_location_acronym }}
+      SQL_SERVER_NAME: ${{ vars.UNIQUE_PREFIX }}-${{ inputs.azure_environment }}-${{ inputs.cluster_location_acronym }}
+      SQL_SERVER_FQDN: ${{ vars.UNIQUE_PREFIX }}-${{ inputs.azure_environment }}-${{ inputs.cluster_location_acronym }}.database.windows.net
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ inputs.service_principal_id }}
+          tenant-id: ${{ env.TENANT_ID }}
+          subscription-id: ${{ inputs.subscription_id }}
+
+      - name: Download Migration Script
+        uses: actions/download-artifact@v4
+        with:
+          name: migration-script-${{ inputs.azure_environment }}-${{ inputs.cluster_location_acronym }}
+          path: .
+
+      - name: Install Microsoft sqlcmd Utility
+        run: |
+          curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc &&
+          sudo add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/22.04/prod.list)" &&
+          sudo apt-get update &&
+          sudo apt-get install -y sqlcmd
+
+      - name: Open Firewall
+        working-directory: cloud-infrastructure/cluster
+        env:
+          RESOURCE_GROUP_NAME: ${{ env.RESOURCE_GROUP_NAME }}
+          SQL_SERVER_NAME: ${{ env.SQL_SERVER_NAME }}
+          SQL_DATABASE_NAME: ${{ inputs.database_name }}
+        run: bash ./firewall.sh open
+
+      - name: Apply Migrations
+        run: |
+          echo "Applying migrations to ${{ inputs.database_name }} database on ${{ env.SQL_SERVER_FQDN }}..."
+          sqlcmd -S "tcp:${{ env.SQL_SERVER_FQDN }},1433" -d "${{ inputs.database_name }}" --authentication-method=ActiveDirectoryDefault --exit-on-error -i migration.sql
+          echo "Migrations applied successfully!"
+
+      - name: Display Migration Summary
+        uses: actions/github-script@v7
+        with:
+          script: core.summary.addRaw(`✅ Migrations successfully applied to \`${{ inputs.database_name }}\` database on \`${{ inputs.azure_environment }}\`.`).write();
+
+      - name: Close Firewall
+        if: always()
+        working-directory: cloud-infrastructure/cluster
+        env:
+          RESOURCE_GROUP_NAME: ${{ env.RESOURCE_GROUP_NAME }}
+          SQL_SERVER_NAME: ${{ env.SQL_SERVER_NAME }}
+          SQL_DATABASE_NAME: ${{ inputs.database_name }}
+        run: bash ./firewall.sh close

--- a/.github/workflows/_migrate-database.yml
+++ b/.github/workflows/_migrate-database.yml
@@ -47,6 +47,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       has_migrations_to_apply: ${{ steps.generate-migration-script.outputs.has_migrations_to_apply }}
+      migration_json: ${{ steps.generate-migration-script.outputs.migration_json }}
     env:
       UNIQUE_PREFIX: ${{ vars.UNIQUE_PREFIX }}
       TENANT_ID: ${{ vars.TENANT_ID }}
@@ -122,6 +123,14 @@ jobs:
               --output migration.sql
             
             echo "has_migrations_to_apply=true" >> $GITHUB_OUTPUT
+            
+            echo "migration_script<<EOF" >> $GITHUB_OUTPUT
+            cat migration.sql >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            
+            echo "migration_json<<EOF" >> $GITHUB_OUTPUT
+            echo "$PENDING_MIGRATIONS_JSON" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
           else
             echo "No pending migrations detected."
             echo "Here is a list of all migrations:"
@@ -145,6 +154,48 @@ jobs:
           name: migration-script-${{ inputs.azure_environment }}-${{ inputs.cluster_location_acronym }}
           path: application/migration.sql
 
+      - name: Generate Migration Information
+        id: migration-info
+        if: steps.generate-migration-script.outputs.has_migrations_to_apply == 'true'
+        uses: actions/github-script@v7
+        env:
+          MIGRATION_JSON: ${{ steps.generate-migration-script.outputs.migration_json }}
+          MIGRATION_SCRIPT: ${{ steps.generate-migration-script.outputs.migration_script }}
+        with:
+          script: |
+            const migrationJson = JSON.parse(process.env.MIGRATION_JSON);
+            
+            const migrationsList = migrationJson.map(m => `- ${m.name} (${m.id})`).join('\n');
+            
+            const migrationInfo = `## Approve Database Migration \`${{ inputs.database_name }}\` database on \`${{ inputs.azure_environment }}\`
+
+            The following pending migration(s) will be applied to the database when approved:
+            ${migrationsList}
+            
+            ### Migration Script
+            \`\`\`sql
+            ${process.env.MIGRATION_SCRIPT}
+            \`\`\`
+            `;
+            
+            console.log(migrationInfo);
+            
+            core.setOutput('markdown', migrationInfo);
+
+      - name: Add Migration Information to Pull Request
+        if: github.event_name == 'pull_request' && steps.generate-migration-script.outputs.has_migrations_to_apply == 'true'
+        uses: actions/github-script@v7
+        env:
+          MIGRATION_INFO: ${{ steps.migration-info.outputs.markdown }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: process.env.MIGRATION_INFO
+            });
   apply-migrations:
     name: Deploy
     needs: plan-migrations

--- a/.github/workflows/_migrate-database.yml
+++ b/.github/workflows/_migrate-database.yml
@@ -196,6 +196,15 @@ jobs:
               repo: context.repo.repo,
               body: process.env.MIGRATION_INFO
             });
+
+      - name: Add Migration Information to Summary
+        if: steps.generate-migration-script.outputs.has_migrations_to_apply == 'true' && inputs.azure_environment == 'prod'
+        uses: actions/github-script@v7
+        env:
+          MIGRATION_INFO: ${{ steps.migration-info.outputs.markdown }}
+        with:
+          script: core.summary.addRaw(process.env.MIGRATION_INFO).write();
+
   apply-migrations:
     name: Deploy
     needs: plan-migrations

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -1,4 +1,4 @@
-name: Account Management - Build and Deploy
+name: Account Management
 
 on:
   push:

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -11,6 +11,8 @@ on:
       - "application/account-management/**"
       - ".github/workflows/account-management.yml"
       - ".github/workflows/_deploy-container.yml"
+      - ".github/workflows/_migrate-database.yml"
+      - ".github/workflows/_preview-migrations.yml"
       - "!**.md"
   pull_request:
     paths:
@@ -20,12 +22,15 @@ on:
       - "application/account-management/**"
       - ".github/workflows/account-management.yml"
       - ".github/workflows/_deploy-container.yml"
+      - ".github/workflows/_migrate-database.yml"
+      - ".github/workflows/_preview-migrations.yml"
       - "!**.md"
   workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
+  pull-requests: write
 
 jobs:
   build-and-test:
@@ -33,12 +38,14 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.generate_version.outputs.version }}
+      deploy_staging: ${{ steps.determine_deployment.outputs.deploy_staging }}
+      deploy_production: ${{ steps.determine_deployment.outputs.deploy_production }}
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Generate version
+      - name: Generate Version
         id: generate_version
         run: |
           # Strip leading 0s of Hours and Minutes after midnight
@@ -47,12 +54,21 @@ jobs:
           echo "Generated version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Setup Node.js environment
+      - name: Determine Deployment Conditions
+        id: determine_deployment
+        run: |
+          deploy_staging="${{ github.ref == 'refs/heads/main' && vars.STAGING_CLUSTER_ENABLED == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Deploy to Staging')) }}"
+          echo "deploy_staging=$deploy_staging" >> $GITHUB_OUTPUT
+          
+          deploy_production="${{ github.ref == 'refs/heads/main' && vars.PRODUCTION_CLUSTER1_ENABLED == 'true' }}"
+          echo "deploy_production=$deploy_production" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js Environment
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      - name: Install Node modules
+      - name: Install Node Modules
         working-directory: application
         run: npm ci
 
@@ -61,16 +77,15 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
-      - name: Restore .NET tools
+      - name: Restore .NET Tools
         working-directory: application
-        run: |
-          dotnet tool restore
+        run: dotnet tool restore
 
-      - name: Restore .NET dependencies
+      - name: Restore .NET Dependencies
         working-directory: application
-        run: dotnet restore
+        run: dotnet restore 
 
-      - name: Generate and set user secret for token signing key
+      - name: Generate and Set User Secret for Token Signing Key
         working-directory: application/shared-kernel/SharedKernel
         run: |
           # Extract UserSecretsId from the .csproj file
@@ -85,7 +100,7 @@ jobs:
           distribution: "microsoft"
           java-version: "17"
 
-      - name: Run tests with dotCover and SonarScanner reporting
+      - name: Run Tests with dotCover and SonarScanner Reporting
         working-directory: application
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -102,37 +117,37 @@ jobs:
             dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
           fi
 
-      - name: Build frontend artifacts
-        if: github.ref == 'refs/heads/main'
+      - name: Build Frontend Artifacts
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application
         run: npm run build
 
-      - name: Publish frontend artifacts
-        if: github.ref == 'refs/heads/main'
+      - name: Publish Frontend Artifacts
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/account-management/WebApp
         run: npm run publish
 
-      - name: Publish API build
-        if: github.ref == 'refs/heads/main'
+      - name: Publish API Build
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/account-management
         run: |
           dotnet publish ./Api/AccountManagement.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
-      - name: Save API artifacts
-        if: github.ref == 'refs/heads/main'
+      - name: Save API Artifacts
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: account-management-api
           path: application/account-management/Api/publish/**/*
 
-      - name: Publish Worker build
-        if: github.ref == 'refs/heads/main'
+      - name: Publish Workers Build
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/account-management
         run: |
           dotnet publish ./Workers/AccountManagement.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
-      - name: Save Workers artifacts
-        if: github.ref == 'refs/heads/main'
+      - name: Save Workers Artifacts
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: account-management-workers
@@ -140,19 +155,19 @@ jobs:
 
   code-style-and-linting:
     name: Code Style and Linting
-    if: github.ref != 'refs/heads/main'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js environment
+      - name: Setup Node.js Environment
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      - name: Install Node modules
+      - name: Install Node Modules
         working-directory: application
         run: npm ci
 
@@ -161,20 +176,19 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
-      - name: Restore .NET tools
+      - name: Restore .NET Tools
         working-directory: application
-        run: |
-          dotnet tool restore
+        run: dotnet tool restore
 
-      - name: Restore .NET dependencies
+      - name: Restore .NET Dependencies
         working-directory: application
         run: dotnet restore
 
-      - name: Build backend solution
+      - name: Build Backend Solution
         working-directory: application
         run: dotnet build account-management/AccountManagement.slnf --no-restore
 
-      - name: Run code inspections
+      - name: Run Code Inspections
         working-directory: developer-cli
         run: |
           dotnet run code-inspections -s AccountManagement.slnf | tee inspection-output.log
@@ -184,7 +198,7 @@ jobs:
             exit 1
           fi
 
-      - name: Check for code formatting issues
+      - name: Check for Code Formatting Issues
         working-directory: developer-cli
         run: |
           dotnet run code-cleanup -s AccountManagement.slnf
@@ -195,21 +209,41 @@ jobs:
             exit 1
           }
 
-      - name: Build frontend artifacts
+      - name: Build Frontend Artifacts
         working-directory: application
         run: npm run build
 
-      - name: Run check
+      - name: Run Check
         working-directory: application/account-management/WebApp
         run: npm run check
 
-  api-deploy:
-    name: Deploy API
-    if: github.ref == 'refs/heads/main'
-    needs: [build-and-test]
+  database-migrations-stage:
+    name: Database Staging
+    needs: build-and-test
+    uses: ./.github/workflows/_migrate-database.yml
+    secrets: inherit
+    with:
+      azure_environment: "stage"
+      cluster_location_acronym: ${{ vars.STAGING_CLUSTER_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.STAGING_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.STAGING_SUBSCRIPTION_ID }}
+      database_name: account-management
+      relative_project_path: account-management/Core/AccountManagement.csproj
+      relative_startup_project: account-management/Api/AccountManagement.Api.csproj
+      db_context: AccountManagementDbContext
+      apply_migrations: ${{ needs.build-and-test.outputs.deploy_staging == 'true' }}
+
+  api-stage:
+    name: API Staging
+    if: ${{ needs.build-and-test.outputs.deploy_staging == 'true' }}
+    needs: [build-and-test, database-migrations-stage]
     uses: ./.github/workflows/_deploy-container.yml
     secrets: inherit
     with:
+      azure_environment: "stage"
+      cluster_location_acronym: ${{ vars.STAGING_CLUSTER_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.STAGING_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.STAGING_SUBSCRIPTION_ID }}
       image_name: account-management-api
       version: ${{ needs.build-and-test.outputs.version }}
       artifacts_name: account-management-api
@@ -217,13 +251,70 @@ jobs:
       docker_context: ./application/account-management
       docker_file: ./Api/Dockerfile
 
-  workers-deploy:
-    name: Deploy Workers
-    if: github.ref == 'refs/heads/main'
-    needs: [build-and-test]
+  workers-stage:
+    name: Workers Staging
+    if: ${{ needs.build-and-test.outputs.deploy_staging == 'true' }}
+    needs: [build-and-test, database-migrations-stage]
     uses: ./.github/workflows/_deploy-container.yml
     secrets: inherit
     with:
+      azure_environment: "stage"
+      cluster_location_acronym: ${{ vars.STAGING_CLUSTER_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.STAGING_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.STAGING_SUBSCRIPTION_ID }}
+      image_name: account-management-workers
+      version: ${{ needs.build-and-test.outputs.version }}
+      artifacts_name: account-management-workers
+      artifacts_path: application/account-management/Workers/publish
+      docker_context: ./application/account-management
+      docker_file: ./Workers/Dockerfile
+
+  database-migrations-prod1:
+    name: Database Production
+    if: ${{ needs.build-and-test.outputs.deploy_production == 'true' }}
+    needs: [build-and-test, api-stage, workers-stage]
+    uses: ./.github/workflows/_migrate-database.yml
+    secrets: inherit
+    with:
+      azure_environment: "prod"
+      cluster_location_acronym: ${{ vars.PRODUCTION_CLUSTER1_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.PRODUCTION_SUBSCRIPTION_ID }}
+      database_name: account-management
+      relative_project_path: account-management/Core/AccountManagement.csproj
+      relative_startup_project: account-management/Api/AccountManagement.Api.csproj
+      db_context: AccountManagementDbContext
+      apply_migrations: true
+
+  api-prod1:
+    name: API Production
+    if: ${{ needs.build-and-test.outputs.deploy_production == 'true' }}
+    needs: [build-and-test, database-migrations-prod1]
+    uses: ./.github/workflows/_deploy-container.yml
+    secrets: inherit
+    with:
+      azure_environment: "prod"
+      cluster_location_acronym: ${{ vars.PRODUCTION_CLUSTER1_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.PRODUCTION_SUBSCRIPTION_ID }}
+      image_name: account-management-api
+      version: ${{ needs.build-and-test.outputs.version }}
+      artifacts_name: account-management-api
+      artifacts_path: application/account-management/Api/publish
+      docker_context: ./application/account-management
+      docker_file: ./Api/Dockerfile
+
+  workers-prod1:
+    name: Workers Production
+    if: ${{ needs.build-and-test.outputs.deploy_production == 'true' }}
+    needs: [build-and-test, database-migrations-prod1]
+    uses: ./.github/workflows/_deploy-container.yml
+    secrets: inherit
+    with:
+      azure_environment: "prod"
+      cluster_location_acronym: ${{ vars.PRODUCTION_CLUSTER1_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.PRODUCTION_SUBSCRIPTION_ID }}
       image_name: account-management-workers
       version: ${{ needs.build-and-test.outputs.version }}
       artifacts_name: account-management-workers

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -1,4 +1,4 @@
-name: App Gateway - Build and Deploy
+name: App Gateway
 
 on:
   push:

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -31,12 +31,14 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.generate_version.outputs.version }}
+      deploy_staging: ${{ steps.determine_deployment.outputs.deploy_staging }}
+      deploy_production: ${{ steps.determine_deployment.outputs.deploy_production }}
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Generate version
+      - name: Generate Version
         id: generate_version
         run: |
           # Strip leading 0s of Hours and Minutes after midnight
@@ -45,12 +47,21 @@ jobs:
           echo "Generated version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Setup Node.js environment
+      - name: Determine Deployment Conditions
+        id: determine_deployment
+        run: |
+          deploy_staging="${{ github.ref == 'refs/heads/main' && vars.STAGING_CLUSTER_ENABLED == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Deploy to Staging')) }}"
+          echo "deploy_staging=$deploy_staging" >> $GITHUB_OUTPUT
+          
+          deploy_production="${{ github.ref == 'refs/heads/main' && vars.PRODUCTION_CLUSTER1_ENABLED == 'true' }}"
+          echo "deploy_production=$deploy_production" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js Environment
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      - name: Install Node modules
+      - name: Install Node Modules
         working-directory: application
         run: npm ci
 
@@ -59,28 +70,28 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
-      - name: Restore .NET tools
+      - name: Restore .NET Tools
         working-directory: application
-        run: |
-          dotnet tool restore
+        run: dotnet tool restore
 
-      - name: Restore .NET dependencies
+      - name: Restore .NET Dependencies
         working-directory: application
         run: dotnet restore
 
-      - name: Build backend solution
+      - name: Build Backend Solution
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application
         run: |
           dotnet build PlatformPlatform.slnx --no-restore /p:Version=${{ steps.generate_version.outputs.version }}
 
-      - name: Publish build
-        if: github.ref == 'refs/heads/main'
+      - name: Publish Build
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application
         run: |
           dotnet publish ./AppGateway/AppGateway.csproj --no-restore --configuration Release --output ./AppGateway/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
-      - name: Save artifacts
-        if: github.ref == 'refs/heads/main'
+      - name: Save Artifacts
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: app-gateway
@@ -88,19 +99,19 @@ jobs:
 
   code-style-and-linting:
     name: Code Style and Linting
-    if: github.ref != 'refs/heads/main'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js environment
+      - name: Setup Node.js Environment
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      - name: Install Node modules
+      - name: Install Node Modules
         working-directory: application
         run: npm ci
 
@@ -109,20 +120,19 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
-      - name: Restore .NET tools
+      - name: Restore .NET Tools
         working-directory: application
-        run: |
-          dotnet tool restore
+        run: dotnet tool restore
 
-      - name: Restore .NET dependencies
+      - name: Restore .NET Dependencies
         working-directory: application
         run: dotnet restore
 
-      - name: Build backend solution
+      - name: Build Backend Solution
         working-directory: application
         run: dotnet build PlatformPlatform.slnx --no-restore
 
-      - name: Run code inspections
+      - name: Run Code Inspections
         working-directory: developer-cli
         run: |
           dotnet run code-inspections | tee inspection-output.log
@@ -132,7 +142,7 @@ jobs:
             exit 1
           fi
 
-      - name: Check for code formatting issues
+      - name: Check for Code Formatting Issues
         working-directory: developer-cli
         run: |
           dotnet run code-cleanup
@@ -143,10 +153,10 @@ jobs:
             exit 1
           }
 
-  deploy:
-    name: Deploy
-    if: github.ref == 'refs/heads/main'
-    needs: [build-and-test]
+  api-stage:
+    name: Staging
+    if: ${{ needs.build-and-test.outputs.deploy_staging == 'true' }}
+    needs: build-and-test
     uses: ./.github/workflows/_deploy-container.yml
     secrets: inherit
     with:
@@ -156,3 +166,25 @@ jobs:
       artifacts_path: application/AppGateway/publish
       docker_context: ./application
       docker_file: ./AppGateway/Dockerfile
+      azure_environment: "stage"
+      cluster_location_acronym: ${{ vars.STAGING_CLUSTER_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.STAGING_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.STAGING_SUBSCRIPTION_ID }}
+
+  api-prod1:
+    name: Production
+    if: ${{ needs.build-and-test.outputs.deploy_production == 'true' }}
+    needs: [build-and-test, api-stage]
+    uses: ./.github/workflows/_deploy-container.yml
+    secrets: inherit
+    with:
+      image_name: app-gateway
+      version: ${{ needs.build-and-test.outputs.version }}
+      artifacts_name: app-gateway
+      artifacts_path: application/AppGateway/publish
+      docker_context: ./application
+      docker_file: ./AppGateway/Dockerfile
+      azure_environment: "prod"
+      cluster_location_acronym: ${{ vars.PRODUCTION_CLUSTER1_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.PRODUCTION_SUBSCRIPTION_ID }}

--- a/.github/workflows/back-office.yml
+++ b/.github/workflows/back-office.yml
@@ -1,4 +1,4 @@
-name: Back Office - Build and Deploy
+name: Back Office
 
 on:
   push:

--- a/.github/workflows/back-office.yml
+++ b/.github/workflows/back-office.yml
@@ -11,6 +11,8 @@ on:
       - "application/back-office/**"
       - ".github/workflows/back-office.yml"
       - ".github/workflows/_deploy-container.yml"
+      - ".github/workflows/_migrate-database.yml"
+      - ".github/workflows/_preview-migrations.yml"
       - "!**.md"
   pull_request:
     paths:
@@ -20,12 +22,15 @@ on:
       - "application/back-office/**"
       - ".github/workflows/back-office.yml"
       - ".github/workflows/_deploy-container.yml"
+      - ".github/workflows/_migrate-database.yml"
+      - ".github/workflows/_preview-migrations.yml"
       - "!**.md"
   workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
+  pull-requests: write
 
 jobs:
   build-and-test:
@@ -33,12 +38,14 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.generate_version.outputs.version }}
+      deploy_staging: ${{ steps.determine_deployment.outputs.deploy_staging }}
+      deploy_production: ${{ steps.determine_deployment.outputs.deploy_production }}
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Generate version
+      - name: Generate Version
         id: generate_version
         run: |
           # Strip leading 0s of Hours and Minutes after midnight
@@ -47,12 +54,21 @@ jobs:
           echo "Generated version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Setup Node.js environment
+      - name: Determine Deployment Conditions
+        id: determine_deployment
+        run: |
+          deploy_staging="${{ github.ref == 'refs/heads/main' && vars.STAGING_CLUSTER_ENABLED == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Deploy to Staging')) }}"
+          echo "deploy_staging=$deploy_staging" >> $GITHUB_OUTPUT
+          
+          deploy_production="${{ github.ref == 'refs/heads/main' && vars.PRODUCTION_CLUSTER1_ENABLED == 'true' }}"
+          echo "deploy_production=$deploy_production" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js Environment
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      - name: Install Node modules
+      - name: Install Node Modules
         working-directory: application
         run: npm ci
 
@@ -61,16 +77,15 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
-      - name: Restore .NET tools
+      - name: Restore .NET Tools
         working-directory: application
-        run: |
-          dotnet tool restore
+        run: dotnet tool restore
 
-      - name: Restore .NET dependencies
+      - name: Restore .NET Dependencies
         working-directory: application
         run: dotnet restore
 
-      - name: Generate and set user secret for token signing key
+      - name: Generate and Set User Secret for Token Signing Key
         working-directory: application/shared-kernel/SharedKernel
         run: |
           # Extract UserSecretsId from the .csproj file
@@ -85,7 +100,7 @@ jobs:
           distribution: "microsoft"
           java-version: "17"
 
-      - name: Run tests with dotCover and SonarScanner reporting
+      - name: Run Tests with dotCover and SonarScanner Reporting
         working-directory: application
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -102,37 +117,37 @@ jobs:
             dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
           fi
 
-      - name: Build frontend artifacts
-        if: github.ref == 'refs/heads/main'
+      - name: Build Frontend Artifacts
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application
         run: npm run build
 
-      - name: Publish frontend artifacts
-        if: github.ref == 'refs/heads/main'
+      - name: Publish Frontend Artifacts
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/back-office/WebApp
         run: npm run publish
 
-      - name: Publish API build
-        if: github.ref == 'refs/heads/main'
+      - name: Publish API Build
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/back-office
         run: |
           dotnet publish ./Api/BackOffice.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
-      - name: Save API artifacts
-        if: github.ref == 'refs/heads/main'
+      - name: Save API Artifacts
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: back-office-api
           path: application/back-office/Api/publish/**/*
 
-      - name: Publish Worker build
-        if: github.ref == 'refs/heads/main'
+      - name: Publish Workers Build
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/back-office
         run: |
           dotnet publish ./Workers/BackOffice.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }}
 
-      - name: Save Workers artifacts
-        if: github.ref == 'refs/heads/main'
+      - name: Save Workers Artifacts
+        if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: back-office-workers
@@ -140,19 +155,19 @@ jobs:
 
   code-style-and-linting:
     name: Code Style and Linting
-    if: github.ref != 'refs/heads/main'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js environment
+      - name: Setup Node.js Environment
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      - name: Install Node modules
+      - name: Install Node Modules
         working-directory: application
         run: npm ci
 
@@ -161,20 +176,19 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
-      - name: Restore .NET tools
+      - name: Restore .NET Tools
         working-directory: application
-        run: |
-          dotnet tool restore
+        run: dotnet tool restore
 
-      - name: Restore .NET dependencies
+      - name: Restore .NET Dependencies
         working-directory: application
         run: dotnet restore
 
-      - name: Build backend solution
+      - name: Build Backend Solution
         working-directory: application
         run: dotnet build back-office/BackOffice.slnf --no-restore
 
-      - name: Run code inspections
+      - name: Run Code Inspections
         working-directory: developer-cli
         run: |
           dotnet run code-inspections -s BackOffice.slnf | tee inspection-output.log
@@ -184,7 +198,7 @@ jobs:
             exit 1
           fi
 
-      - name: Check for code formatting issues
+      - name: Check for Code Formatting Issues
         working-directory: developer-cli
         run: |
           dotnet run code-cleanup -s BackOffice.slnf
@@ -195,21 +209,41 @@ jobs:
             exit 1
           }
 
-      - name: Build frontend artifacts
+      - name: Build Frontend Artifacts
         working-directory: application
         run: npm run build
 
-      - name: Run check
+      - name: Run Check
         working-directory: application/back-office/WebApp
         run: npm run check
 
-  api-deploy:
-    name: Deploy API
-    if: github.ref == 'refs/heads/main'
-    needs: [build-and-test]
+  database-migrations-stage:
+    name: Database Staging
+    needs: build-and-test
+    uses: ./.github/workflows/_migrate-database.yml
+    secrets: inherit
+    with:
+      azure_environment: "stage"
+      cluster_location_acronym: ${{ vars.STAGING_CLUSTER_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.STAGING_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.STAGING_SUBSCRIPTION_ID }}
+      database_name: back-office
+      relative_project_path: back-office/Core/BackOffice.csproj
+      relative_startup_project: back-office/Api/BackOffice.Api.csproj
+      db_context: BackOfficeDbContext
+      apply_migrations: ${{ needs.build-and-test.outputs.deploy_staging == 'true' }}
+
+  api-stage:
+    name: API Staging
+    if: ${{ needs.build-and-test.outputs.deploy_staging == 'true' }}
+    needs: [build-and-test, database-migrations-stage]
     uses: ./.github/workflows/_deploy-container.yml
     secrets: inherit
     with:
+      azure_environment: "stage"
+      cluster_location_acronym: ${{ vars.STAGING_CLUSTER_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.STAGING_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.STAGING_SUBSCRIPTION_ID }}
       image_name: back-office-api
       version: ${{ needs.build-and-test.outputs.version }}
       artifacts_name: back-office-api
@@ -217,13 +251,70 @@ jobs:
       docker_context: ./application/back-office
       docker_file: ./Api/Dockerfile
 
-  workers-deploy:
-    name: Deploy Workers
-    if: github.ref == 'refs/heads/main'
-    needs: [build-and-test]
+  workers-stage:
+    name: Workers Staging
+    if: ${{ needs.build-and-test.outputs.deploy_staging == 'true' }}
+    needs: [build-and-test, database-migrations-stage]
     uses: ./.github/workflows/_deploy-container.yml
     secrets: inherit
     with:
+      azure_environment: "stage"
+      cluster_location_acronym: ${{ vars.STAGING_CLUSTER_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.STAGING_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.STAGING_SUBSCRIPTION_ID }}
+      image_name: back-office-workers
+      version: ${{ needs.build-and-test.outputs.version }}
+      artifacts_name: back-office-workers
+      artifacts_path: application/back-office/Workers/publish
+      docker_context: ./application/back-office
+      docker_file: ./Workers/Dockerfile
+
+  database-migrations-prod1:
+    name: Database Production
+    if: ${{ needs.build-and-test.outputs.deploy_production == 'true' }}
+    needs: [build-and-test, api-stage, workers-stage]
+    uses: ./.github/workflows/_migrate-database.yml
+    secrets: inherit
+    with:
+      azure_environment: "prod"
+      cluster_location_acronym: ${{ vars.PRODUCTION_CLUSTER1_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.PRODUCTION_SUBSCRIPTION_ID }}
+      database_name: back-office
+      relative_project_path: back-office/Core/BackOffice.csproj
+      relative_startup_project: back-office/Api/BackOffice.Api.csproj
+      db_context: BackOfficeDbContext
+      apply_migrations: true
+
+  api-prod1:
+    name: API Production
+    if: ${{ needs.build-and-test.outputs.deploy_production == 'true' }}
+    needs: [build-and-test, database-migrations-prod1]
+    uses: ./.github/workflows/_deploy-container.yml
+    secrets: inherit
+    with:
+      azure_environment: "prod"
+      cluster_location_acronym: ${{ vars.PRODUCTION_CLUSTER1_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.PRODUCTION_SUBSCRIPTION_ID }}
+      image_name: back-office-api
+      version: ${{ needs.build-and-test.outputs.version }}
+      artifacts_name: back-office-api
+      artifacts_path: application/back-office/Api/publish
+      docker_context: ./application/back-office
+      docker_file: ./Api/Dockerfile
+
+  workers-prod1:
+    name: Workers Production
+    if: ${{ needs.build-and-test.outputs.deploy_production == 'true' }}
+    needs: [build-and-test, database-migrations-prod1]
+    uses: ./.github/workflows/_deploy-container.yml
+    secrets: inherit
+    with:
+      azure_environment: "prod"
+      cluster_location_acronym: ${{ vars.PRODUCTION_CLUSTER1_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.PRODUCTION_SUBSCRIPTION_ID }}
       image_name: back-office-workers
       version: ${{ needs.build-and-test.outputs.version }}
       artifacts_name: back-office-workers

--- a/.github/workflows/cloud-infrastructure.yml
+++ b/.github/workflows/cloud-infrastructure.yml
@@ -1,4 +1,4 @@
-name: Cloud Infrastructure - Deployment
+name: Cloud Infrastructure
 
 on:
   push:

--- a/.github/workflows/cloud-infrastructure.yml
+++ b/.github/workflows/cloud-infrastructure.yml
@@ -24,42 +24,36 @@ permissions:
 jobs:
   stage:
     name: Staging
-    if: ${{ vars.STAGING_CLUSTER_ENABLED == 'true' }}
+    if: ${{ github.ref == 'refs/heads/main' && vars.STAGING_CLUSTER_ENABLED == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Deploy to Staging')) }}
     uses: ./.github/workflows/_deploy-infrastructure.yml
     secrets: inherit
     with:
-      github_environment: "staging"
-      include_shared_environment_resources: true
-      unique_prefix: ${{ vars.UNIQUE_PREFIX }}
       azure_environment: "stage"
+      cluster_location_acronym: ${{ vars.STAGING_CLUSTER_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.STAGING_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.STAGING_SUBSCRIPTION_ID }}
+      tenant_id: ${{ vars.TENANT_ID }}
+      unique_prefix: ${{ vars.UNIQUE_PREFIX }}
       shared_location: ${{ vars.STAGING_SHARED_LOCATION }}
       cluster_location: ${{ vars.STAGING_CLUSTER_LOCATION }}
-      cluster_location_acronym: ${{ vars.STAGING_CLUSTER_LOCATION_ACRONYM }}
-      sql_admin_object_id: ${{ vars.STAGING_SQL_ADMIN_OBJECT_ID }}
       domain_name: ${{ vars.STAGING_DOMAIN_NAME }}
-      service_principal_id: ${{ vars.STAGING_SERVICE_PRINCIPAL_ID }}
-      tenant_id: ${{ vars.TENANT_ID }}
-      subscription_id: ${{ vars.STAGING_SUBSCRIPTION_ID }}
-      deployment_enabled: ${{ vars.STAGING_CLUSTER_ENABLED }}
+      sql_admin_object_id: ${{ vars.STAGING_SQL_ADMIN_OBJECT_ID }}
       production_service_principal_object_id: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID }}
 
   prod1:
     name: Production
     needs: stage
-    if: ${{ vars.PRODUCTION_CLUSTER1_ENABLED == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && vars.PRODUCTION_CLUSTER1_ENABLED == 'true' }}
     uses: ./.github/workflows/_deploy-infrastructure.yml
     secrets: inherit
     with:
-      github_environment: "production"
-      include_shared_environment_resources: true
-      unique_prefix: ${{ vars.UNIQUE_PREFIX }}
       azure_environment: "prod"
+      cluster_location_acronym: ${{ vars.PRODUCTION_CLUSTER1_LOCATION_ACRONYM }}
+      service_principal_id: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_ID }}
+      subscription_id: ${{ vars.PRODUCTION_SUBSCRIPTION_ID }}
+      unique_prefix: ${{ vars.UNIQUE_PREFIX }}
       shared_location: ${{ vars.PRODUCTION_SHARED_LOCATION }}
       cluster_location: ${{ vars.PRODUCTION_CLUSTER1_LOCATION }}
-      cluster_location_acronym: ${{ vars.PRODUCTION_CLUSTER1_LOCATION_ACRONYM }}
-      sql_admin_object_id: ${{ vars.PRODUCTION_SQL_ADMIN_OBJECT_ID }}
       domain_name: ${{ vars.PRODUCTION_DOMAIN_NAME }}
-      service_principal_id: ${{ vars.PRODUCTION_SERVICE_PRINCIPAL_ID }}
+      sql_admin_object_id: ${{ vars.PRODUCTION_SQL_ADMIN_OBJECT_ID }}
       tenant_id: ${{ vars.TENANT_ID }}
-      subscription_id: ${{ vars.PRODUCTION_SUBSCRIPTION_ID }}
-      deployment_enabled: ${{ vars.PRODUCTION_CLUSTER1_ENABLED }}

--- a/.github/workflows/pull-request-conventions.yml
+++ b/.github/workflows/pull-request-conventions.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check pull request title
+      - name: Check Pull Request Title
         if: always()
         env:
           PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
@@ -57,7 +57,7 @@ jobs:
           fi
           exit $EXIT_CODE
 
-      - name: Check pull request description
+      - name: Check Pull Request Description
         if: always()
         env:
           PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}
@@ -98,7 +98,7 @@ jobs:
           fi
           exit $EXIT_CODE
 
-      - name: Ensure pull request metadata
+      - name: Ensure Pull Request Metadata
         if: always()
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -127,7 +127,7 @@ jobs:
           fi
           exit $EXIT_CODE
 
-      - name: Check branch naming convention
+      - name: Check Branch Naming Convention
         if: always()
         run: |
           BRANCH_NAME="${GITHUB_HEAD_REF}"
@@ -138,7 +138,7 @@ jobs:
           fi
           echo "✅ Branch name is valid"
 
-      - name: Check for merge commits
+      - name: Check for Merge Commits
         if: always()
         run: |
           # Fetch main branch
@@ -157,7 +157,7 @@ jobs:
           fi
           echo "✅ No merge commits found"
 
-      - name: Check branch is up to date with main branch
+      - name: Check Branch is Up to Date with Main Branch
         if: always()
         run: |
           # Get the commit where the branch diverged from main
@@ -173,7 +173,7 @@ jobs:
           fi
           echo "✅ Branch is up to date with the main branch"
 
-      - name: Check commit messages
+      - name: Check Commit Messages
         if: always()
         run: |
           # Check commits between main and pull request head

--- a/.github/workflows/pull-request-conventions.yml
+++ b/.github/workflows/pull-request-conventions.yml
@@ -1,4 +1,4 @@
-name: Validate Pull Request Conventions
+name: Pull Request Conventions
 
 on:
   pull_request:

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -31,25 +31,25 @@
     <PackageVersion Include="Meziantou.Xunit.ParallelTestFramework" Version="2.3.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.2">
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.1.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
@@ -61,13 +61,13 @@
     <PackageVersion Include="NSwag.MSBuild" Version="14.2.0" />
     <PackageVersion Include="NUlid" Version="1.7.2" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.0.20" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.1.1" />
     <PackageVersion Include="Scrutor" Version="6.0.1" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4">

--- a/application/Directory.Packages.props
+++ b/application/Directory.Packages.props
@@ -35,8 +35,13 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/application/account-management/Api/AccountManagement.Api.csproj
+++ b/application/account-management/Api/AccountManagement.Api.csproj
@@ -21,6 +21,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.ApiDescription.Server">
             <IncludeAssets>runtime; build; native; contentFiles; analyzers; buildTransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/application/account-management/Core/Database/DatabaseMigrations.cs
+++ b/application/account-management/Core/Database/DatabaseMigrations.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace PlatformPlatform.AccountManagement.Database;
 
 [DbContext(typeof(AccountManagementDbContext))]
-[Migration("20250217_Initial")]
+[Migration("20250217000000_Initial")]
 public sealed class DatabaseMigrations : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/application/account-management/Directory.Build.props
+++ b/application/account-management/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <UseArtifactsOutput>true</UseArtifactsOutput>
+        <UseArtifactsOutput>false</UseArtifactsOutput>
     </PropertyGroup>
 
     <ItemGroup>

--- a/application/account-management/Workers/Program.cs
+++ b/application/account-management/Workers/Program.cs
@@ -20,9 +20,11 @@ builder.Services.AddTransient<DatabaseMigrationService<AccountManagementDbContex
 
 var host = builder.Build();
 
-// Apply migrations to the database (should be moved to GitHub Actions or similar in production)
-using var scope = host.Services.CreateScope();
-var migrationService = scope.ServiceProvider.GetRequiredService<DatabaseMigrationService<AccountManagementDbContext>>();
-migrationService.ApplyMigrations();
+if (!SharedInfrastructureConfiguration.IsRunningInAzure)
+{
+    using var scope = host.Services.CreateScope();
+    var migrationService = scope.ServiceProvider.GetRequiredService<DatabaseMigrationService<AccountManagementDbContext>>();
+    migrationService.ApplyMigrations();
+}
 
 await host.RunAsync();

--- a/application/back-office/Api/BackOffice.Api.csproj
+++ b/application/back-office/Api/BackOffice.Api.csproj
@@ -21,6 +21,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.ApiDescription.Server">
             <IncludeAssets>runtime; build; native; contentFiles; analyzers; buildTransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/application/back-office/Core/Database/DatabaseMigrations.cs
+++ b/application/back-office/Core/Database/DatabaseMigrations.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace PlatformPlatform.BackOffice.Database;
 
 [DbContext(typeof(BackOfficeDbContext))]
-[Migration("1_Initial")]
+[Migration("20250217000000_Initial")]
 public sealed class DatabaseMigrations : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/application/back-office/Directory.Build.props
+++ b/application/back-office/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <UseArtifactsOutput>true</UseArtifactsOutput>
+        <UseArtifactsOutput>false</UseArtifactsOutput>
     </PropertyGroup>
 
     <ItemGroup>

--- a/application/back-office/Workers/Program.cs
+++ b/application/back-office/Workers/Program.cs
@@ -20,9 +20,12 @@ builder.Services.AddTransient<DatabaseMigrationService<BackOfficeDbContext>>();
 
 var host = builder.Build();
 
-// Apply migrations to the database (should be moved to GitHub Actions or similar in production)
-using var scope = host.Services.CreateScope();
-var migrationService = scope.ServiceProvider.GetRequiredService<DatabaseMigrationService<BackOfficeDbContext>>();
-migrationService.ApplyMigrations();
+// Apply migrations to the database only when running locally
+if (!SharedInfrastructureConfiguration.IsRunningInAzure)
+{
+    using var scope = host.Services.CreateScope();
+    var migrationService = scope.ServiceProvider.GetRequiredService<DatabaseMigrationService<BackOfficeDbContext>>();
+    migrationService.ApplyMigrations();
+}
 
 await host.RunAsync();

--- a/application/dotnet-tools.json
+++ b/application/dotnet-tools.json
@@ -13,6 +13,10 @@
     "jetbrains.resharper.globaltools": {
       "version": "2024.3.6",
       "commands": ["jb"]
+    },
+    "dotnet-ef": {
+      "version": "9.0.3",
+      "commands": ["dotnet-ef"]
     }
   }
 }

--- a/application/shared-kernel/SharedKernel/SharedKernel.csproj
+++ b/application/shared-kernel/SharedKernel/SharedKernel.csproj
@@ -34,6 +34,10 @@
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
         <PackageReference Include="Microsoft.Extensions.Identity.Core" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/cloud-infrastructure/cluster/firewall.sh
+++ b/cloud-infrastructure/cluster/firewall.sh
@@ -1,11 +1,11 @@
 IP_ADDRESS=$(curl -s https://api.ipify.org)
-FIREWALL_RULE_NAME="GitHub Action Workflows - Only active when deploying"
+FIREWALL_RULE_NAME="GitHub Action Workflows - ${SQL_DATABASE_NAME} - Only active when deploying"
 
 if [[ "$1" == "open" ]]
 then
-    echo "$(date +"%Y-%m-%dT%H:%M:%S") Add the IP $IP_ADDRESS to the SQL Server firewall on server $SQL_SERVER_NAME"
+    echo "$(date +"%Y-%m-%dT%H:%M:%S") Add the IP $IP_ADDRESS to the SQL Server firewall on server $SQL_SERVER_NAME for database $SQL_DATABASE_NAME"
     az sql server firewall-rule create --resource-group $RESOURCE_GROUP_NAME --server $SQL_SERVER_NAME --name "$FIREWALL_RULE_NAME" --start-ip-address $IP_ADDRESS --end-ip-address $IP_ADDRESS
 else
-    echo "$(date +"%Y-%m-%dT%H:%M:%S") Delete the IP $IP_ADDRESS from the SQL Server firewall on server $SQL_SERVER_NAME"
+    echo "$(date +"%Y-%m-%dT%H:%M:%S") Delete the IP $IP_ADDRESS from the SQL Server firewall on server $SQL_SERVER_NAME for database $SQL_DATABASE_NAME"
     az sql server firewall-rule delete --resource-group $RESOURCE_GROUP_NAME --server $SQL_SERVER_NAME --name "$FIREWALL_RULE_NAME"
 fi

--- a/cloud-infrastructure/cluster/grant-database-permissions.sh
+++ b/cloud-infrastructure/cluster/grant-database-permissions.sh
@@ -10,6 +10,8 @@ SQL_SERVER_NAME=$RESOURCE_GROUP_NAME
 SQL_SERVER=$SQL_SERVER_NAME.database.windows.net
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
+# Export SQL_DATABASE_NAME for firewall.sh to use
+export SQL_DATABASE_NAME=$SQL_DATABASE_NAME
 trap '. ./firewall.sh close' EXIT # Ensure that the firewall is closed no matter if other commands fail
 . ./firewall.sh open
 

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -747,7 +747,8 @@ public class ConfigureContinuousDeploymentsCommand : Command
     {
         // Disable reusable workflows
         DisableActiveWorkflow("Deploy Container");
-        DisableActiveWorkflow("Plan and Deploy Infrastructure");
+        DisableActiveWorkflow("Deploy Infrastructure");
+        DisableActiveWorkflow("Migrate Database");
         return;
 
         void DisableActiveWorkflow(string workflowName)


### PR DESCRIPTION
### Summary & motivation

This change moves database migrations from Workers to GitHub Workflow actions, with a preview and approval flow for database changes:

- Create a new reusable `_migrate-database.yml` workflow that detects and applies pending migrations using .NET tools for Entity Framework Core (`dotnet ef migrations`) 
- Restructure GitHub workflows to include separate steps for previewing pending database changes with approval gates
- Modify worker services to only run migrations in local development, not in Azure environments
- Improve firewall scripts to scope rules at the database level, allowing multiple GitHub workflows to run in parallel
- Update workflow naming conventions and job titles for consistency and clarity

The CI/CD workflow has been extended from 3 jobs to 7 jobs for self-contained systems with databases:
1. The plan step runs on pull requests against the staging environment:
   - Generates a list of migrations that will be applied to staging if merged
   - Creates a full migration script that will run against staging
   - Adds both the migration list and script as a comment to the pull request for easy review 
   ![CleanShot 2025-03-25 at 01 20 25@2x](https://github.com/user-attachments/assets/b5916456-1c25-481c-b030-4298ccbf5e5f)


2. When merged to main, database changes deploy to staging without approval, and only after successful application will the API and Workers containers deploy

3. The same detection logic runs against the production environment:
   - Creates a new list of missing migrations and migration script for production (note: this script might differ from staging if production is several migrations behind)
   - Adds the migration list and SQL script to the GitHub Workflow UI for review
   - Requires admin approval for database changes only if pending migrations exist
   ![CleanShot 2025-03-25 at 01 23 42@2x](https://github.com/user-attachments/assets/045884d3-a311-4ba1-b701-01b58bcd2fe5)

4. After successfully applying database migrations to production, admin approval is still required for API and Workers container deployment

Additional improvements:
- All workflow job and step titles changed to Title Case
- Workflow names simplified (e.g., `Account Management - Deploy` to just `Account Management`)
- Logic for whether a deployment should be done to staging and production has been centralized in one variable, making it easier to temporarily change this in one place instead of having to change all jobs
- By adding a `Deploy to Staging` label to a pull request, you can now trigger a deployment of database migrations and containers to staging, allowing testing of changes without merging to main
- Updated all NuGet packages to latest versions
- Added Entity Framework Core tooling for migration management. 
- Disabled .NET 8's `UseArtifactsOutput` configuration due to incompatibility with EF tooling
- Updated migration IDs to use 14-digit timestamps as required by EF Core. `dotnet ef migrations` unfortunately does not work with custom migration IDs

While migration in PlatformPlatform is handcrafted, these changes enable the use of Entity Framework tooling in Visual Studio and Rider (just be aware of the column sizes).

### Downstream projects

Depending on the changes you have made to the GitHub workflows, this might be a small or big change. Follow the instructions carefully to update your system, and reach out if you have any questions on how to test this.

1. Update your workflow YAML files to align with the new structure

   If you made changes to `your-self-contained-system.yml`, compare it with `back-office.yml` and take note of the differences that are not purely naming. Then copy the new `back-office.yml` and manually rename all steps for your system, and reintegrate your changes.

2. Update Migration ID of all to use 14-character timestamps in `your-self-contained-system/Core/Database` from e.g. `[Migration("20250217_Initial")]` to `[Migration("20250217000000_Initial")]`

3. IMPORTANT: Before creating a pull request with these changes, manually update migration IDs in your databases on both staging and production (and on your development PC):

   ```sql
   -- For account-anagement database
   UPDATE [dbo].[__EFMigrationsHistory] 
   SET MigrationId = '20250217000000_Initial' 
   WHERE MigrationId = '20250217_Initial'
   
   -- For back-office
   UPDATE [dbo].[__EFMigrationsHistory] 
   SET MigrationId = '20250217000000_Initial' 
   WHERE MigrationId = '1_Initial'
   
   -- Add SQL for updating migration IDs in your database to be 14 digits
   ```

4. Disable the new shareable workflow "Migrate Database" in the GitHub UI for consistency with PlatformPlatform setup

5. Change `UseArtifactsOutput` in your `your-self-contained-system/Directory.Build.props` file, required by `dotnet ef` tooling:

   ```xml
   <UseArtifactsOutput>false</UseArtifactsOutput>
   ```

6. If you made changes to the `cloud-infrastructure.yml`, carefully review the changes and resolve any merge conflicts


### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
