### PR TITLE
Update all UI texts to consistently use sentence case instead of title case

### DIFF
--- a/.ai-rules/frontend/translations.md
+++ b/.ai-rules/frontend/translations.md
@@ -8,6 +8,8 @@ When implementing translations in the frontend, follow these rules very carefull
 2. Use t\`...\` for string translations.
 3. Always use plain English text in translation markers.
 4. Never hardcode text without proper translation wrappers.
+5. Use "Sentence case" for everything (Buttons, Menus, Headings, etc.)
+6. Never change the `*.po` files directly they are auto generated based on the uses of `<Trans>...</Trans>` and t\`...\`
 
 ## Example 1 - Component Translation
 

--- a/application/account-management/WebApp/routes/admin/account/-components/DeleteAccountConfirmation.tsx
+++ b/application/account-management/WebApp/routes/admin/account/-components/DeleteAccountConfirmation.tsx
@@ -13,8 +13,8 @@ export default function DeleteAccountConfirmation({ isOpen, onOpenChange }: Read
     <Modal isOpen={isOpen} onOpenChange={onOpenChange} isDismissable={true}>
       <AlertDialog
         variant="destructive"
-        actionLabel={t`Delete Account`}
-        title={t`Delete Account`}
+        actionLabel={t`Delete account`}
+        title={t`Delete account`}
         onAction={() => onOpenChange(false)}
       >
         <Trans>

--- a/application/account-management/WebApp/routes/admin/account/index.tsx
+++ b/application/account-management/WebApp/routes/admin/account/index.tsx
@@ -45,7 +45,7 @@ export function AccountSettings() {
           <div className="20 mb-4 flex w-full items-center justify-between space-x-2 sm:mt-4">
             <div className="mt-3 flex flex-col gap-2 font-semibold text-3xl text-foreground">
               <h1>
-                <Trans>Account Settings</Trans>
+                <Trans>Account settings</Trans>
               </h1>
               <p className="font-normal text-muted-foreground text-sm">
                 <Trans>Manage your account here.</Trans>
@@ -97,7 +97,7 @@ export function AccountSettings() {
 
               <Button variant="destructive" onPress={() => setIsDeleteModalOpen(true)} className="w-fit">
                 <Trash2 />
-                <Trans>Delete Account</Trans>
+                <Trans>Delete account</Trans>
               </Button>
             </div>
           </div>

--- a/application/account-management/WebApp/routes/admin/index.tsx
+++ b/application/account-management/WebApp/routes/admin/index.tsx
@@ -34,7 +34,7 @@ export default function Home() {
             aria-label={t`View users`}
           >
             <div className="text-foreground text-sm">
-              <Trans>Total Users</Trans>
+              <Trans>Total users</Trans>
             </div>
             <div className="text-muted-foreground text-sm">
               <Trans>Add more in the Users menu</Trans>
@@ -54,7 +54,7 @@ export default function Home() {
             aria-label={t`View active users`}
           >
             <div className="text-foreground text-sm">
-              <Trans>Active Users</Trans>
+              <Trans>Active users</Trans>
             </div>
             <div className="text-muted-foreground text-sm">
               <Trans>Active users in the past 30 days</Trans>
@@ -70,7 +70,7 @@ export default function Home() {
             aria-label={t`View invited users`}
           >
             <div className="text-foreground text-sm">
-              <Trans>Invited Users</Trans>
+              <Trans>Invited users</Trans>
             </div>
             <div className="text-muted-foreground text-sm">
               <Trans>Users who haven't confirmed their email</Trans>

--- a/application/account-management/WebApp/routes/admin/users/-components/InviteUserModal.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/InviteUserModal.tsx
@@ -36,7 +36,7 @@ export default function InviteUserModal({ isOpen, onOpenChange }: Readonly<Invit
       <Dialog>
         <XIcon onClick={closeDialog} className="absolute top-2 right-2 h-10 w-10 p-2 hover:bg-muted" />
         <Heading slot="title" className="text-2xl">
-          <Trans>Invite User</Trans>
+          <Trans>Invite user</Trans>
         </Heading>
         <p className="text-muted-foreground text-sm">
           <Trans>Invite users and assign them roles. They will appear once they log in.</Trans>

--- a/application/account-management/WebApp/routes/admin/users/-components/UserQuerying.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/UserQuerying.tsx
@@ -89,7 +89,7 @@ export function UserQuerying() {
             onSelectionChange={(userRole) => {
               updateFilter({ userRole: (userRole as UserRole) || undefined });
             }}
-            label={t`User Role`}
+            label={t`User role`}
             placeholder={t`Any role`}
             className="w-[150px]"
           >
@@ -108,7 +108,7 @@ export function UserQuerying() {
             onSelectionChange={(userStatus) => {
               updateFilter({ userStatus: (userStatus as UserStatus) || undefined });
             }}
-            label={t`User Status`}
+            label={t`User status`}
             placeholder={t`Any status`}
             className="w-[150px]"
           >

--- a/application/account-management/WebApp/routes/admin/users/-components/UserTable.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/UserTable.tsx
@@ -128,7 +128,7 @@ export function UserTable() {
         blur={false}
         isDismissable={true}
       >
-        <AlertDialog title={t`Change User Role`}>
+        <AlertDialog title={t`Change user role`}>
           <p className="text-muted-foreground text-sm">
             <Trans>
               Select a new role for{" "}
@@ -142,7 +142,7 @@ export function UserTable() {
           <div className="mt-4 flex flex-col gap-4">
             <Select
               autoFocus={true}
-              aria-label={t`User Role`}
+              aria-label={t`User role`}
               selectedKey={userToChangeRole?.role}
               onSelectionChange={(key) => handleUserRoleChange(key as UserRole)}
               className="flex w-full flex-col"
@@ -164,7 +164,7 @@ export function UserTable() {
         isDismissable={true}
       >
         <AlertDialog
-          title={t`Delete User`}
+          title={t`Delete user`}
           variant="destructive"
           actionLabel={t`Delete`}
           cancelLabel={t`Cancel`}
@@ -255,7 +255,7 @@ export function UserTable() {
                       <Menu>
                         <MenuItem id="viewProfile">
                           <UserIcon className="h-4 w-4" />
-                          <Trans>View Profile</Trans>
+                          <Trans>View profile</Trans>
                         </MenuItem>
                         <MenuItem
                           id="changeRole"
@@ -264,7 +264,7 @@ export function UserTable() {
                         >
                           <PencilIcon className="h-4 w-4 group-disabled:text-muted-foreground" />
                           <span className="group-disabled:text-muted-foreground">
-                            <Trans>Change Role</Trans>
+                            <Trans>Change role</Trans>
                           </span>
                         </MenuItem>
                         <MenuSeparator />

--- a/application/account-management/WebApp/routes/admin/users/index.tsx
+++ b/application/account-management/WebApp/routes/admin/users/index.tsx
@@ -41,7 +41,7 @@ export default function UsersPage() {
             <Trans>Users</Trans>
           </Breadcrumb>
           <Breadcrumb>
-            <Trans>All Users</Trans>
+            <Trans>All users</Trans>
           </Breadcrumb>
         </TopMenu>
         <div className="20 mb-4 flex w-full items-center justify-between space-x-2 sm:mt-4">
@@ -55,7 +55,7 @@ export default function UsersPage() {
           </div>
           <Button variant="primary" onPress={() => setIsInviteModalOpen(true)}>
             <PlusIcon className="h-4 w-4" />
-            <Trans>Invite Users</Trans>
+            <Trans>Invite users</Trans>
           </Button>
         </div>
         <UserQuerying />

--- a/application/account-management/WebApp/routes/signup/index.tsx
+++ b/application/account-management/WebApp/routes/signup/index.tsx
@@ -116,7 +116,7 @@ export function StartSignupForm() {
           </Link>
           <DotIcon className="h-4 w-4" />
           <Link href="/">
-            <Trans>Privacy Policies</Trans>
+            <Trans>Privacy policies</Trans>
           </Link>
         </div>
       </div>

--- a/application/account-management/WebApp/shared/components/userModals/UserProfileModal.tsx
+++ b/application/account-management/WebApp/shared/components/userModals/UserProfileModal.tsx
@@ -225,7 +225,7 @@ function UserProfileDialog({ onOpenChange, onIsLoadingChange }: Readonly<Profile
           />
         </div>
         <TextField name="email" label={t`Email`} value={user?.email} />
-        <TextField name="title" label={t`Title`} defaultValue={user?.title} placeholder={t`E.g., Software Engineer`} />
+        <TextField name="title" label={t`Title`} defaultValue={user?.title} placeholder={t`E.g., Software engineer`} />
 
         <FormErrorMessage error={saveMutation.error} />
 

--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -19,7 +19,7 @@ msgstr "Konto"
 msgid "Account name"
 msgstr "Kontonavn"
 
-msgid "Account Settings"
+msgid "Account settings"
 msgstr "Kontoindstillinger"
 
 msgid "Actions"
@@ -28,14 +28,14 @@ msgstr "Handlinger"
 msgid "Active"
 msgstr "Aktiv"
 
-msgid "Active Users"
+msgid "Active users"
 msgstr "Aktive brugere"
 
 msgid "Active users in the past 30 days"
 msgstr "Aktive brugere i de sidste 30 dage"
 
 msgid "Add more in the Users menu"
-msgstr "Tilføj flere i brugermenuen"
+msgstr "Tilføj flere i Brugere menuen"
 
 msgid "Add profile picture"
 msgstr "Tilføj profilbillede"
@@ -43,7 +43,7 @@ msgstr "Tilføj profilbillede"
 msgid "Admin"
 msgstr "Admin"
 
-msgid "All Users"
+msgid "All users"
 msgstr "Alle brugere"
 
 #. placeholder {0}: error.message
@@ -72,10 +72,10 @@ msgstr "Annuller"
 msgid "Change profile picture"
 msgstr "Skift profilbillede"
 
-msgid "Change Role"
+msgid "Change role"
 msgstr "Skift rolle"
 
-msgid "Change User Role"
+msgid "Change user role"
 msgstr "Skift brugerrolle"
 
 msgid "Continue"
@@ -93,10 +93,10 @@ msgstr "Farezone"
 msgid "Delete"
 msgstr "Slet"
 
-msgid "Delete Account"
+msgid "Delete account"
 msgstr "Slet konto"
 
-msgid "Delete User"
+msgid "Delete user"
 msgstr "Slet bruger"
 
 msgid "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."
@@ -114,7 +114,7 @@ msgstr "Har du ikke en konto? <0>Opret en</0>"
 msgid "E.g., Alex"
 msgstr "F.eks. Alex"
 
-msgid "E.g., Software Engineer"
+msgid "E.g., Software engineer"
 msgstr "F.eks., Softwareingeniør"
 
 msgid "E.g., Taylor"
@@ -165,16 +165,16 @@ msgstr "Hjem"
 msgid "Image must be smaller than 1 MB."
 msgstr "Billedet skal være mindre end 1 MB."
 
-msgid "Invite User"
+msgid "Invite user"
 msgstr "Inviter bruger"
 
-msgid "Invite Users"
-msgstr "Inviter Brugere"
+msgid "Invite users"
+msgstr "Inviter brugere"
 
 msgid "Invite users and assign them roles. They will appear once they log in."
 msgstr "Inviter brugere og tildel dem roller. De vil blive vist, når de logger ind."
 
-msgid "Invited Users"
+msgid "Invited users"
 msgstr "Inviterede brugere"
 
 msgid "Last name"
@@ -246,7 +246,7 @@ msgstr "Forhåndsvisning af avatar"
 msgid "Previous"
 msgstr "Forrige"
 
-msgid "Privacy Policies"
+msgid "Privacy policies"
 msgstr "Fortrolighedspolitikker"
 
 msgid "Profile picture"
@@ -319,7 +319,7 @@ msgstr "Skift kollapset menu"
 msgid "Toggle theme"
 msgstr "Skift tema"
 
-msgid "Total Users"
+msgid "Total users"
 msgstr "Totalt antal brugere"
 
 msgid "Try again"
@@ -337,10 +337,10 @@ msgstr "Brugerprofil"
 msgid "User profile menu"
 msgstr "Brugerprofilmenu"
 
-msgid "User Role"
+msgid "User role"
 msgstr "Brugerrolle"
 
-msgid "User Status"
+msgid "User status"
 msgstr "Brugerstatus"
 
 msgid "user@email.com"
@@ -364,7 +364,7 @@ msgstr "Se aktive brugere"
 msgid "View invited users"
 msgstr "Se inviterede brugere"
 
-msgid "View Profile"
+msgid "View profile"
 msgstr "Se profil"
 
 msgid "View users"

--- a/application/account-management/WebApp/shared/translations/locale/en-US.po
+++ b/application/account-management/WebApp/shared/translations/locale/en-US.po
@@ -19,8 +19,8 @@ msgstr "Account"
 msgid "Account name"
 msgstr "Account name"
 
-msgid "Account Settings"
-msgstr "Account Settings"
+msgid "Account settings"
+msgstr "Account settings"
 
 msgid "Actions"
 msgstr "Actions"
@@ -28,8 +28,8 @@ msgstr "Actions"
 msgid "Active"
 msgstr "Active"
 
-msgid "Active Users"
-msgstr "Active Users"
+msgid "Active users"
+msgstr "Active users"
 
 msgid "Active users in the past 30 days"
 msgstr "Active users in the past 30 days"
@@ -43,8 +43,8 @@ msgstr "Add profile picture"
 msgid "Admin"
 msgstr "Admin"
 
-msgid "All Users"
-msgstr "All Users"
+msgid "All users"
+msgstr "All users"
 
 #. placeholder {0}: error.message
 msgid "An error occurred while processing your request. {0}"
@@ -72,11 +72,11 @@ msgstr "Cancel"
 msgid "Change profile picture"
 msgstr "Change profile picture"
 
-msgid "Change Role"
-msgstr "Change Role"
+msgid "Change role"
+msgstr "Change role"
 
-msgid "Change User Role"
-msgstr "Change User Role"
+msgid "Change user role"
+msgstr "Change user role"
 
 msgid "Continue"
 msgstr "Continue"
@@ -93,11 +93,11 @@ msgstr "Danger zone"
 msgid "Delete"
 msgstr "Delete"
 
-msgid "Delete Account"
-msgstr "Delete Account"
+msgid "Delete account"
+msgstr "Delete account"
 
-msgid "Delete User"
-msgstr "Delete User"
+msgid "Delete user"
+msgstr "Delete user"
 
 msgid "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."
 msgstr "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."
@@ -114,8 +114,8 @@ msgstr "Don't have an account? <0>Create one</0>"
 msgid "E.g., Alex"
 msgstr "E.g., Alex"
 
-msgid "E.g., Software Engineer"
-msgstr "E.g., Software Engineer"
+msgid "E.g., Software engineer"
+msgstr "E.g., Software engineer"
 
 msgid "E.g., Taylor"
 msgstr "E.g., Taylor"
@@ -165,17 +165,17 @@ msgstr "Home"
 msgid "Image must be smaller than 1 MB."
 msgstr "Image must be smaller than 1 MB."
 
-msgid "Invite User"
-msgstr "Invite User"
+msgid "Invite user"
+msgstr "Invite user"
 
-msgid "Invite Users"
-msgstr "Invite Users"
+msgid "Invite users"
+msgstr "Invite users"
 
 msgid "Invite users and assign them roles. They will appear once they log in."
 msgstr "Invite users and assign them roles. They will appear once they log in."
 
-msgid "Invited Users"
-msgstr "Invited Users"
+msgid "Invited users"
+msgstr "Invited users"
 
 msgid "Last name"
 msgstr "Last name"
@@ -246,8 +246,8 @@ msgstr "Preview avatar"
 msgid "Previous"
 msgstr "Previous"
 
-msgid "Privacy Policies"
-msgstr "Privacy Policies"
+msgid "Privacy policies"
+msgstr "Privacy policies"
 
 msgid "Profile picture"
 msgstr "Profile picture"
@@ -319,8 +319,8 @@ msgstr "Toggle collapsed menu"
 msgid "Toggle theme"
 msgstr "Toggle theme"
 
-msgid "Total Users"
-msgstr "Total Users"
+msgid "Total users"
+msgstr "Total users"
 
 msgid "Try again"
 msgstr "Try again"
@@ -337,11 +337,11 @@ msgstr "User profile"
 msgid "User profile menu"
 msgstr "User profile menu"
 
-msgid "User Role"
-msgstr "User Role"
+msgid "User role"
+msgstr "User role"
 
-msgid "User Status"
-msgstr "User Status"
+msgid "User status"
+msgstr "User status"
 
 msgid "user@email.com"
 msgstr "user@email.com"
@@ -364,8 +364,8 @@ msgstr "View active users"
 msgid "View invited users"
 msgstr "View invited users"
 
-msgid "View Profile"
-msgstr "View Profile"
+msgid "View profile"
+msgstr "View profile"
 
 msgid "View users"
 msgstr "View users"

--- a/application/account-management/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/account-management/WebApp/shared/translations/locale/nl-NL.po
@@ -19,7 +19,7 @@ msgstr "Account"
 msgid "Account name"
 msgstr "Accountnaam"
 
-msgid "Account Settings"
+msgid "Account settings"
 msgstr "Accountinstellingen"
 
 msgid "Actions"
@@ -28,14 +28,14 @@ msgstr "Acties"
 msgid "Active"
 msgstr "Actief"
 
-msgid "Active Users"
+msgid "Active users"
 msgstr "Actieve gebruikers"
 
 msgid "Active users in the past 30 days"
 msgstr "Actieve gebruikers in de afgelopen 30 dagen"
 
 msgid "Add more in the Users menu"
-msgstr "Nieuwe toevoegen via het gebruikersmenu"
+msgstr "Nieuwe toevoegen via het Gebruikers menu"
 
 msgid "Add profile picture"
 msgstr "Profielfoto toevoegen"
@@ -43,7 +43,7 @@ msgstr "Profielfoto toevoegen"
 msgid "Admin"
 msgstr "Beheerder"
 
-msgid "All Users"
+msgid "All users"
 msgstr "Alle gebruikers"
 
 #. placeholder {0}: error.message
@@ -72,10 +72,10 @@ msgstr "Annuleren"
 msgid "Change profile picture"
 msgstr "Profielfoto wijzigen"
 
-msgid "Change Role"
+msgid "Change role"
 msgstr "Rol wijzigen"
 
-msgid "Change User Role"
+msgid "Change user role"
 msgstr "Gebruikersrol wijzigen"
 
 msgid "Continue"
@@ -93,10 +93,10 @@ msgstr "Gevaarzone"
 msgid "Delete"
 msgstr "Verwijderen"
 
-msgid "Delete Account"
+msgid "Delete account"
 msgstr "Account verwijderen"
 
-msgid "Delete User"
+msgid "Delete user"
 msgstr "Gebruiker verwijderen"
 
 msgid "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."
@@ -114,8 +114,8 @@ msgstr "Heb je geen account? <0>Maak er één aan</0>"
 msgid "E.g., Alex"
 msgstr "Bijv., Alex"
 
-msgid "E.g., Software Engineer"
-msgstr "Bijv., Software Engineer"
+msgid "E.g., Software engineer"
+msgstr "Bijv., Software engineer"
 
 msgid "E.g., Taylor"
 msgstr "Bijv., Taylor"
@@ -165,16 +165,16 @@ msgstr "Home"
 msgid "Image must be smaller than 1 MB."
 msgstr "Afbeelding moet kleiner zijn dan 1 MB."
 
-msgid "Invite User"
+msgid "Invite user"
 msgstr "Gebruiker uitnodigen"
 
-msgid "Invite Users"
+msgid "Invite users"
 msgstr "Gebruikers uitnodigen"
 
 msgid "Invite users and assign them roles. They will appear once they log in."
 msgstr "Nodig gebruikers uit en wijs hen rollen toe. Ze verschijnen zodra ze inloggen."
 
-msgid "Invited Users"
+msgid "Invited users"
 msgstr "Uitgenodigde gebruikers"
 
 msgid "Last name"
@@ -246,7 +246,7 @@ msgstr "Voorbeeld avatar"
 msgid "Previous"
 msgstr "Vorige"
 
-msgid "Privacy Policies"
+msgid "Privacy policies"
 msgstr "Privacybeleid"
 
 msgid "Profile picture"
@@ -319,7 +319,7 @@ msgstr "Ingeklapt menu wisselen"
 msgid "Toggle theme"
 msgstr "Thema wisselen"
 
-msgid "Total Users"
+msgid "Total users"
 msgstr "Totale gebruikers"
 
 msgid "Try again"
@@ -337,10 +337,10 @@ msgstr "Gebruikersprofiel"
 msgid "User profile menu"
 msgstr "Gebruikersprofielmenu"
 
-msgid "User Role"
+msgid "User role"
 msgstr "Gebruikersrol"
 
-msgid "User Status"
+msgid "User status"
 msgstr "Gebruikersstatus"
 
 msgid "user@email.com"
@@ -364,7 +364,7 @@ msgstr "Actieve gebruikers bekijken"
 msgid "View invited users"
 msgstr "Uitgenodigde gebruikers bekijken"
 
-msgid "View Profile"
+msgid "View profile"
 msgstr "Profiel bekijken"
 
 msgid "View users"

--- a/application/back-office/WebApp/shared/components/SharedSideMenu.tsx
+++ b/application/back-office/WebApp/shared/components/SharedSideMenu.tsx
@@ -16,7 +16,7 @@ export function SharedSideMenu({ children, ariaLabel }: Readonly<SharedSideMenuP
 
       <SideMenuSpacer />
 
-      <MenuButton icon={BoxIcon} label={t`Account Management`} href="/admin" forceReload={true} />
+      <MenuButton icon={BoxIcon} label={t`Account management`} href="/admin" forceReload={true} />
     </SideMenu>
   );
 }

--- a/application/back-office/WebApp/shared/translations/locale/da-DK.po
+++ b/application/back-office/WebApp/shared/translations/locale/da-DK.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: @lingui/cli\n"
 
-msgid "Account Management"
+msgid "Account management"
 msgstr "Kontoadministration"
 
 msgid "Help"

--- a/application/back-office/WebApp/shared/translations/locale/en-US.po
+++ b/application/back-office/WebApp/shared/translations/locale/en-US.po
@@ -13,8 +13,8 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-msgid "Account Management"
-msgstr "Account Management"
+msgid "Account management"
+msgstr "Account management"
 
 msgid "Help"
 msgstr "Help"

--- a/application/back-office/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/back-office/WebApp/shared/translations/locale/nl-NL.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: @lingui/cli\n"
 
-msgid "Account Management"
+msgid "Account management"
 msgstr "Accountbeheer"
 
 msgid "Help"


### PR DESCRIPTION
### Summary & motivation

Update all UI text to consistently use `Sentence case` instead of `Title Case` for a more modern and consistent interface. This change affects:

- Buttons (e.g. "Delete account" instead of "Delete Account")
- Menu items (e.g. "View profile" instead of "View Profile")
- Headings (e.g. "Account settings" instead of "Account Settings")
- Form labels (e.g. "User role" instead of "User Role")
- Placeholders (e.g. "Software engineer" instead of "Software Engineer")

The change also updates the translation AI rules to explicitly specify that buttons, menus, and headings must use sentence case.

### Downstream projects

For maintainers of downstream projects, you should:

1. Update your UI text

Look in your `.po` files and identify all places you use `Title Case`, then find the places in your code where the translation is coming from and change these to `Sentence case`.

2. Update translations

After updating the text, run `pp translate` from your project root directory to update all translation files.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
