### PR TITLE
Add Sequential Thinking Context Protocol and Browser Tools MCP server configuration for Cursor AI

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    }
+  }
+}

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,8 +1,13 @@
 {
-  "mcpServers": {
-    "sequential-thinking": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
-    }
-  }
+	"mcpServers": {
+		"browser-tools": {
+			"command": "npx",
+			"args": ["-y", "@agentdeskai/browser-tools-mcp@1.2.0"],
+			"enabled": true
+		},
+		"sequential-thinking": {
+			"command": "npx",
+			"args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+		}
+	}
 }

--- a/developer-cli/Commands/BrowserToolsCommand.cs
+++ b/developer-cli/Commands/BrowserToolsCommand.cs
@@ -1,0 +1,22 @@
+using System.CommandLine;
+using PlatformPlatform.DeveloperCli.Installation;
+using PlatformPlatform.DeveloperCli.Utilities;
+
+namespace DeveloperCli.Commands;
+
+public class BrowserToolsCommand : Command
+{
+    public BrowserToolsCommand() : base(name: "browser-tools", description: "Start the browser tools server for debugging")
+    {
+        this.AddAlias("bt");
+        this.SetHandler(Execute);
+    }
+
+    private void Execute()
+    {
+        ProcessHelper.StartProcessWithSystemShell(
+            "npx @agentdeskai/browser-tools-server@1.2.0",
+            Configuration.SourceCodeFolder
+        );
+    }
+}


### PR DESCRIPTION
### Summary & motivation

Add Model Context Protocol (MCP) server configuration for Cursor AI to improve AI-assisted development workflows.

This configuration is specific to Cursor. In other AI editors like Windsurf, setting up MCP servers must currently be done manually.

- Add configuration for the Sequential Thinking MCP server  
  Enables AI editors like Cursor to maintain task-aware state, improving how the assistant breaks down and sequences actions to solve large, complex tasks.

- Add configuration for the Browser Tools MCP server in the new `.cursor` folder  
  Allows Cursor to inspect Chrome-based browsers directly, making it possible to see console output, network errors, DOM state, and even take screenshots without switching context.

- Add Developer CLI command: `pp browser-tools` (or shorthand `pp bt`)  
  This is a convenient command to run the local MCP client required by Browser Tools, essentially running `npx @agentdeskai/browser-tools-server@1.2.0` behind the scenes.

For Browser Tools to work, this Chrome extension must be installed:  
[AgentDeskAI/browser-tools-mcp](https://github.com/AgentDeskAI/browser-tools-mcp)

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
