### PR TITLE
Add bulk user deletion functionality and refactor user management UI

### DIFF
--- a/application/account-management/Api/Endpoints/UserEndpoints.cs
+++ b/application/account-management/Api/Endpoints/UserEndpoints.cs
@@ -26,6 +26,10 @@ public sealed class UserEndpoints : IEndpoints
             => await mediator.Send(new DeleteUserCommand(id))
         );
 
+        group.MapPost("/bulk-delete", async Task<ApiResult> (BulkDeleteUsersCommand command, IMediator mediator)
+            => await mediator.Send(command)
+        );
+
         group.MapPut("/{id}/change-user-role", async Task<ApiResult> (UserId id, ChangeUserRoleCommand command, IMediator mediator)
             => await mediator.Send(command with { Id = id })
         );

--- a/application/account-management/Core/Features/TelemetryEvents.cs
+++ b/application/account-management/Core/Features/TelemetryEvents.cs
@@ -66,8 +66,11 @@ public sealed class GravatarUpdated(long size)
 public sealed class UserCreated(UserId userId, bool gravatarProfileFound)
     : TelemetryEvent(("user_id", userId), ("gravatar_profile_found", gravatarProfileFound));
 
-public sealed class UserDeleted(UserId userId)
-    : TelemetryEvent(("user_id", userId));
+public sealed class UserDeleted(UserId userId, bool bulkDeletion = false)
+    : TelemetryEvent(("user_id", userId), ("bulk_deletion", bulkDeletion));
+
+public sealed class UsersBulkDeleted(int count)
+    : TelemetryEvent(("count", count));
 
 public sealed class UserInviteAccepted(UserId userId, int inviteAcceptedTimeInMinutes)
     : TelemetryEvent(("user_id", userId), ("invite_accepted_time_in_minutes", inviteAcceptedTimeInMinutes));

--- a/application/account-management/Core/Features/Users/Commands/BulkDeleteUsers.cs
+++ b/application/account-management/Core/Features/Users/Commands/BulkDeleteUsers.cs
@@ -1,0 +1,63 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using PlatformPlatform.AccountManagement.Features.Users.Domain;
+using PlatformPlatform.SharedKernel.Cqrs;
+using PlatformPlatform.SharedKernel.Domain;
+using PlatformPlatform.SharedKernel.ExecutionContext;
+using PlatformPlatform.SharedKernel.Telemetry;
+
+namespace PlatformPlatform.AccountManagement.Features.Users.Commands;
+
+[PublicAPI]
+public sealed record BulkDeleteUsersCommand(UserId[] UserIds) : ICommand, IRequest<Result>;
+
+public sealed class BulkDeleteUsersValidator : AbstractValidator<BulkDeleteUsersCommand>
+{
+    public BulkDeleteUsersValidator()
+    {
+        RuleFor(x => x.UserIds)
+            .NotEmpty()
+            .WithMessage("At least one user must be selected for deletion.")
+            .Must(ids => ids.Length <= 100)
+            .WithMessage("Cannot delete more than 100 users at once.");
+    }
+}
+
+public sealed class BulkDeleteUsersHandler(
+    IUserRepository userRepository,
+    IExecutionContext executionContext,
+    ITelemetryEventsCollector events
+) : IRequestHandler<BulkDeleteUsersCommand, Result>
+{
+    public async Task<Result> Handle(BulkDeleteUsersCommand command, CancellationToken cancellationToken)
+    {
+        if (executionContext.UserInfo.Role != UserRole.Owner.ToString())
+        {
+            return Result.Forbidden("Only owners are allowed to delete other users.");
+        }
+
+        if (command.UserIds.Contains(executionContext.UserInfo.Id))
+        {
+            return Result.Forbidden("You cannot delete yourself.");
+        }
+
+        var usersToDelete = await userRepository.GetByIdsAsync(command.UserIds, cancellationToken);
+
+        var missingUserIds = command.UserIds.Where(id => !usersToDelete.Select(u => u.Id).Contains(id)).ToArray();
+        if (missingUserIds.Length > 0)
+        {
+            return Result.NotFound($"Users with ids '{string.Join(", ", missingUserIds.Select(id => id.ToString()))}' not found.");
+        }
+
+        userRepository.BulkRemove(usersToDelete);
+
+        foreach (var userId in command.UserIds)
+        {
+            events.CollectEvent(new UserDeleted(userId, true));
+        }
+
+        events.CollectEvent(new UsersBulkDeleted(command.UserIds.Length));
+
+        return Result.Success();
+    }
+}

--- a/application/account-management/Core/Features/Users/Domain/UserRepository.cs
+++ b/application/account-management/Core/Features/Users/Domain/UserRepository.cs
@@ -6,7 +6,7 @@ using PlatformPlatform.SharedKernel.Persistence;
 
 namespace PlatformPlatform.AccountManagement.Features.Users.Domain;
 
-public interface IUserRepository : ICrudRepository<User, UserId>
+public interface IUserRepository : ICrudRepository<User, UserId>, IBulkRemoveRepository<User>
 {
     Task<User?> GetByIdUnfilteredAsync(UserId id, CancellationToken cancellationToken);
 
@@ -19,6 +19,8 @@ public interface IUserRepository : ICrudRepository<User, UserId>
     Task<int> CountTenantUsersAsync(TenantId tenantId, CancellationToken cancellationToken);
 
     Task<(int TotalUsers, int ActiveUsers, int PendingUsers)> GetUserSummaryAsync(CancellationToken cancellationToken);
+
+    Task<User[]> GetByIdsAsync(UserId[] ids, CancellationToken cancellationToken);
 
     Task<(User[] Users, int TotalItems, int TotalPages)> Search(
         string? search,
@@ -74,6 +76,11 @@ internal sealed class UserRepository(AccountManagementDbContext accountManagemen
     public Task<int> CountTenantUsersAsync(TenantId tenantId, CancellationToken cancellationToken)
     {
         return DbSet.CountAsync(u => u.TenantId == tenantId, cancellationToken);
+    }
+
+    public async Task<User[]> GetByIdsAsync(UserId[] ids, CancellationToken cancellationToken)
+    {
+        return await DbSet.Where(u => ids.Contains(u.Id)).ToArrayAsync(cancellationToken);
     }
 
     public async Task<(int TotalUsers, int ActiveUsers, int PendingUsers)> GetUserSummaryAsync(CancellationToken cancellationToken)

--- a/application/account-management/Tests/Users/BulkDeleteUsersTests.cs
+++ b/application/account-management/Tests/Users/BulkDeleteUsersTests.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using PlatformPlatform.AccountManagement.Database;
+using PlatformPlatform.AccountManagement.Features.Users.Commands;
+using PlatformPlatform.AccountManagement.Features.Users.Domain;
+using PlatformPlatform.SharedKernel.Domain;
+using PlatformPlatform.SharedKernel.Tests;
+using PlatformPlatform.SharedKernel.Tests.Persistence;
+using PlatformPlatform.SharedKernel.Validation;
+using Xunit;
+
+namespace PlatformPlatform.AccountManagement.Tests.Users;
+
+public sealed class BulkDeleteUsersTests : EndpointBaseTest<AccountManagementDbContext>
+{
+    [Fact]
+    public async Task BulkDeleteUsers_WhenUsersExist_ShouldDeleteUsers()
+    {
+        // Arrange
+        var userIds = new List<UserId>();
+        for (var i = 0; i < 3; i++)
+        {
+            var userId = UserId.NewId();
+            userIds.Add(userId);
+            Connection.Insert("Users", [
+                    ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
+                    ("Id", userId.ToString()),
+                    ("CreatedAt", DateTime.UtcNow.AddMinutes(-10)),
+                    ("ModifiedAt", null),
+                    ("Email", Faker.Internet.Email()),
+                    ("FirstName", Faker.Person.FirstName),
+                    ("LastName", Faker.Person.LastName),
+                    ("Title", "Test User"),
+                    ("Role", UserRole.Member.ToString()),
+                    ("EmailConfirmed", true),
+                    ("Avatar", JsonSerializer.Serialize(new Avatar())),
+                    ("Locale", "en-US")
+                ]
+            );
+        }
+
+        var command = new BulkDeleteUsersCommand(userIds.ToArray());
+
+        // Act
+        var response = await AuthenticatedOwnerHttpClient.PostAsJsonAsync("/api/account-management/users/bulk-delete", command);
+
+        // Assert
+        response.ShouldHaveEmptyHeaderAndLocationOnSuccess();
+        foreach (var userId in userIds)
+        {
+            Connection.RowExists("Users", userId.ToString()).Should().BeFalse();
+        }
+
+        TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(4);
+        foreach (var @event in TelemetryEventsCollectorSpy.CollectedEvents.Take(3))
+        {
+            @event.GetType().Name.Should().Be("UserDeleted");
+            @event.Properties.Should().ContainKey("event.bulk_deletion");
+            @event.Properties["event.bulk_deletion"].Should().Be("True");
+        }
+
+        TelemetryEventsCollectorSpy.CollectedEvents[3].GetType().Name.Should().Be("UsersBulkDeleted");
+        TelemetryEventsCollectorSpy.CollectedEvents[3].Properties["event.count"].Should().Be("3");
+
+        TelemetryEventsCollectorSpy.AreAllEventsDispatched.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task BulkDeleteUsers_WhenUserDoesNotExist_ShouldReturnNotFound()
+    {
+        // Arrange
+        var unknownUserId = UserId.NewId();
+        var command = new BulkDeleteUsersCommand([unknownUserId]);
+
+        // Act
+        var response = await AuthenticatedOwnerHttpClient.PostAsJsonAsync("/api/account-management/users/bulk-delete", command);
+
+        // Assert
+        await response.ShouldHaveErrorStatusCode(HttpStatusCode.NotFound, $"Users with ids '{unknownUserId}' not found.");
+    }
+
+    [Fact]
+    public async Task BulkDeleteUsers_WhenDeletingOwnUser_ShouldReturnForbidden()
+    {
+        // Arrange
+        var command = new BulkDeleteUsersCommand([DatabaseSeeder.Tenant1Owner.Id]);
+
+        // Act
+        var response = await AuthenticatedOwnerHttpClient.PostAsJsonAsync("/api/account-management/users/bulk-delete", command);
+
+        // Assert
+        await response.ShouldHaveErrorStatusCode(HttpStatusCode.Forbidden, "You cannot delete yourself.");
+    }
+
+    [Fact]
+    public async Task BulkDeleteUsers_WhenNotOwner_ShouldReturnForbidden()
+    {
+        // Arrange
+        var command = new BulkDeleteUsersCommand([DatabaseSeeder.Tenant1Owner.Id]);
+
+        // Act
+        var response = await AuthenticatedMemberHttpClient.PostAsJsonAsync("/api/account-management/users/bulk-delete", command);
+
+        // Assert
+        await response.ShouldHaveErrorStatusCode(HttpStatusCode.Forbidden, "Only owners are allowed to delete other users.");
+    }
+
+    [Fact]
+    public async Task BulkDeleteUsers_WhenEmptyUserIds_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var command = new BulkDeleteUsersCommand([]);
+
+        // Act
+        var response = await AuthenticatedOwnerHttpClient.PostAsJsonAsync("/api/account-management/users/bulk-delete", command);
+
+        // Assert
+        var expectedErrors = new[]
+        {
+            new ErrorDetail("UserIds", "At least one user must be selected for deletion.")
+        };
+        await response.ShouldHaveErrorStatusCode(HttpStatusCode.BadRequest, expectedErrors);
+    }
+}

--- a/application/account-management/WebApp/routes/admin/users/-components/ChangeUserRoleDialog.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/ChangeUserRoleDialog.tsx
@@ -1,0 +1,64 @@
+import { UserRole, api, type components } from "@/shared/lib/api/client";
+import { getUserRoleLabel } from "@/shared/lib/api/userRole";
+import { t } from "@lingui/core/macro";
+import { Trans } from "@lingui/react/macro";
+import { AlertDialog } from "@repo/ui/components/AlertDialog";
+import { Modal } from "@repo/ui/components/Modal";
+import { Select, SelectItem } from "@repo/ui/components/Select";
+import { useCallback } from "react";
+
+type UserDetails = components["schemas"]["UserDetails"];
+
+interface ChangeUserRoleDialogProps {
+  user: UserDetails | null;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onSuccess: () => void;
+}
+
+export function ChangeUserRoleDialog({ user, isOpen, onOpenChange, onSuccess }: Readonly<ChangeUserRoleDialogProps>) {
+  const changeUserRoleMutation = api.useMutation("put", "/api/account-management/users/{id}/change-user-role");
+
+  const handleUserRoleChange = useCallback(
+    async (newUserRole: UserRole) => {
+      if (!user) {
+        return null;
+      }
+
+      await changeUserRoleMutation.mutateAsync({ params: { path: { id: user.id } }, body: { userRole: newUserRole } });
+
+      onOpenChange(false);
+      onSuccess();
+    },
+    [user, changeUserRoleMutation, onOpenChange, onSuccess]
+  );
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange} blur={false} isDismissable={true}>
+      <AlertDialog title={t`Change user role`}>
+        <p className="text-muted-foreground text-sm">
+          <Trans>
+            Select a new role for{" "}
+            <b>{user ? `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email : ""}</b>
+          </Trans>
+        </p>
+
+        <div className="mt-4 flex flex-col gap-4">
+          <Select
+            autoFocus={true}
+            aria-label={t`User role`}
+            selectedKey={user?.role}
+            onSelectionChange={(key) => handleUserRoleChange(key as UserRole)}
+            className="flex w-full flex-col"
+          >
+            {Object.values(UserRole).map((userRole) => (
+              <SelectItem id={userRole} key={userRole}>
+                {getUserRoleLabel(userRole)}
+              </SelectItem>
+            ))}
+          </Select>
+        </div>
+      </AlertDialog>
+    </Modal>
+  );
+}

--- a/application/account-management/WebApp/routes/admin/users/-components/DeleteUserDialog.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/DeleteUserDialog.tsx
@@ -1,0 +1,58 @@
+import { api, type components } from "@/shared/lib/api/client";
+import { t } from "@lingui/core/macro";
+import { Trans } from "@lingui/react/macro";
+import { AlertDialog } from "@repo/ui/components/AlertDialog";
+import { Modal } from "@repo/ui/components/Modal";
+import { useCallback } from "react";
+
+type UserDetails = components["schemas"]["UserDetails"];
+
+interface DeleteUserDialogProps {
+  users: UserDetails[];
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onSuccess: () => void;
+}
+
+export function DeleteUserDialog({ users, isOpen, onOpenChange, onSuccess }: Readonly<DeleteUserDialogProps>) {
+  const isSingleUser = users.length === 1;
+  const user = users[0];
+
+  const bulkDeleteUsersMutation = api.useMutation("post", "/api/account-management/users/bulk-delete");
+  const deleteUserMutation = api.useMutation("delete", "/api/account-management/users/{id}");
+
+  const handleDelete = useCallback(async () => {
+    if (isSingleUser) {
+      await deleteUserMutation.mutateAsync({ params: { path: { id: user.id } } });
+    } else {
+      const userIds = users.map((user) => user.id);
+      await bulkDeleteUsersMutation.mutateAsync({ body: { userIds: userIds } });
+    }
+
+    onOpenChange(false);
+    onSuccess();
+  }, [users, isSingleUser, user, deleteUserMutation, bulkDeleteUsersMutation, onOpenChange, onSuccess]);
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange} blur={false} isDismissable={true}>
+      <AlertDialog
+        title={isSingleUser ? t`Delete user` : t`Delete users`}
+        variant="destructive"
+        actionLabel={t`Delete`}
+        cancelLabel={t`Cancel`}
+        onAction={handleDelete}
+      >
+        {isSingleUser ? (
+          <Trans>
+            Are you sure you want to delete{" "}
+            <b>{`${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email}?</b>
+          </Trans>
+        ) : (
+          <Trans>
+            Are you sure you want to delete <b>{users.length} users</b>?
+          </Trans>
+        )}
+      </AlertDialog>
+    </Modal>
+  );
+}

--- a/application/account-management/WebApp/routes/admin/users/-components/InviteUserDialog.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/InviteUserDialog.tsx
@@ -12,12 +12,12 @@ import { mutationSubmitter } from "@repo/ui/forms/mutationSubmitter";
 import { XIcon } from "lucide-react";
 import { useCallback, useEffect } from "react";
 
-type InviteUserModalProps = {
+interface InviteUserDialogProps {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
-};
+}
 
-export default function InviteUserModal({ isOpen, onOpenChange }: Readonly<InviteUserModalProps>) {
+export default function InviteUserDialog({ isOpen, onOpenChange }: Readonly<InviteUserDialogProps>) {
   const closeDialog = useCallback(() => {
     onOpenChange(false);
   }, [onOpenChange]);

--- a/application/account-management/WebApp/routes/admin/users/-components/UserQuerying.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/UserQuerying.tsx
@@ -72,7 +72,7 @@ export function UserQuerying() {
   }, [search, updateFilter]);
 
   return (
-    <div className="mt-4 mb-4 flex items-center gap-2">
+    <div className="flex items-center gap-2">
       <SearchField
         placeholder={t`Search`}
         value={search}

--- a/application/account-management/WebApp/routes/admin/users/-components/UserTable.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/UserTable.tsx
@@ -15,12 +15,19 @@ import { Cell, Column, Row, Table, TableHeader } from "@repo/ui/components/Table
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { EllipsisVerticalIcon, PencilIcon, Trash2Icon, UserIcon } from "lucide-react";
 import { useCallback, useState } from "react";
-import type { SortDescriptor } from "react-aria-components";
+import type { Selection, SortDescriptor } from "react-aria-components";
 import { MenuTrigger, TableBody } from "react-aria-components";
+import { DeleteUserDialog } from "./DeleteUserDialog";
 
 type UserDetails = components["schemas"]["UserDetails"];
 
-export function UserTable() {
+interface UserTableProps {
+  selectedUsers: UserDetails[];
+  onSelectedUsersChange: (users: UserDetails[]) => void;
+  onRefreshNeeded: () => void;
+}
+
+export function UserTable({ selectedUsers, onSelectedUsersChange, onRefreshNeeded }: Readonly<UserTableProps>) {
   const navigate = useNavigate();
   const { search, userRole, userStatus, startDate, endDate, orderBy, sortOrder, pageOffset } = useSearch({
     strict: false
@@ -31,8 +38,6 @@ export function UserTable() {
     column: orderBy ?? "email",
     direction: sortOrder === "Ascending" ? "ascending" : "descending"
   }));
-
-  const [refreshKey, setRefreshKey] = useState(0);
 
   const { data: users, isLoading } = api.useQuery("get", "/api/account-management/users", {
     params: {
@@ -46,8 +51,7 @@ export function UserTable() {
         SortOrder: sortOrder,
         PageOffset: pageOffset
       }
-    },
-    key: refreshKey
+    }
   });
 
   const [userToDelete, setUserToDelete] = useState<UserDetails | null>(null);
@@ -82,18 +86,14 @@ export function UserTable() {
     [navigate]
   );
 
-  const deleteUserMutation = api.useMutation("delete", "/api/account-management/users/{id}");
-
-  const handleDelete = useCallback(async () => {
+  const handleDelete = useCallback(() => {
     if (!userToDelete) {
       return;
     }
-
-    await deleteUserMutation.mutateAsync({ params: { path: { id: userToDelete.id } } });
-
-    setRefreshKey((prev) => prev + 1);
+    onSelectedUsersChange(selectedUsers.filter((user) => user.id !== userToDelete.id));
+    onRefreshNeeded();
     setUserToDelete(null);
-  }, [userToDelete, deleteUserMutation]);
+  }, [userToDelete, onRefreshNeeded, onSelectedUsersChange, selectedUsers]);
 
   const changeUserRoleMutation = api.useMutation("put", "/api/account-management/users/{id}/change-user-role");
 
@@ -108,10 +108,23 @@ export function UserTable() {
         body: { userRole: newUserRole }
       });
 
-      setRefreshKey((prev) => prev + 1);
+      onRefreshNeeded();
       setUserToChangeRole(null);
     },
-    [userToChangeRole, changeUserRoleMutation]
+    [userToChangeRole, changeUserRoleMutation, onRefreshNeeded]
+  );
+
+  const handleSelectionChange = useCallback(
+    (keys: Selection) => {
+      if (keys === "all") {
+        onSelectedUsersChange(users?.users ?? []);
+      } else {
+        const selectedKeys = typeof keys === "string" ? new Set([keys]) : keys;
+        const selectedUsersList = users?.users.filter((user) => selectedKeys.has(user.id)) ?? [];
+        onSelectedUsersChange(selectedUsersList);
+      }
+    },
+    [users?.users, onSelectedUsersChange]
   );
 
   if (isLoading) {
@@ -157,31 +170,20 @@ export function UserTable() {
         </AlertDialog>
       </Modal>
 
-      <Modal
+      <DeleteUserDialog
+        users={userToDelete ? [userToDelete] : []}
         isOpen={userToDelete !== null}
-        onOpenChange={() => setUserToDelete(null)}
-        blur={false}
-        isDismissable={true}
-      >
-        <AlertDialog
-          title={t`Delete user`}
-          variant="destructive"
-          actionLabel={t`Delete`}
-          cancelLabel={t`Cancel`}
-          onAction={handleDelete}
-        >
-          <Trans>
-            Are you sure you want to delete{" "}
-            <b>{`${userToDelete?.firstName ?? ""} ${userToDelete?.lastName ?? ""}`.trim() || userToDelete?.email}?</b>
-          </Trans>
-        </AlertDialog>
-      </Modal>
+        onOpenChange={(isOpen) => !isOpen && setUserToDelete(null)}
+        onSuccess={handleDelete}
+      />
 
       <div className="flex h-full w-full flex-col gap-2">
         <Table
           key={`${search}-${userRole}-${userStatus}-${startDate}-${endDate}-${orderBy}-${sortOrder}`}
           selectionMode="multiple"
           selectionBehavior="toggle"
+          selectedKeys={selectedUsers.map((user) => user.id)}
+          onSelectionChange={handleSelectionChange}
           sortDescriptor={sortDescriptor}
           onSortChange={handleSortChange}
           aria-label={t`Users`}
@@ -208,7 +210,7 @@ export function UserTable() {
           </TableHeader>
           <TableBody>
             {users?.users.map((user) => (
-              <Row key={user.id}>
+              <Row key={user.id} id={user.id}>
                 <Cell>
                   <div className="flex h-14 items-center gap-2">
                     <Avatar
@@ -243,12 +245,21 @@ export function UserTable() {
                     <Button
                       variant="icon"
                       className="opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-100"
-                      onPress={() => setUserToDelete(user)}
+                      onPress={() => {
+                        onSelectedUsersChange([user]);
+                        setUserToDelete(user);
+                      }}
                       isDisabled={user.id === userInfo?.id}
                     >
                       <Trash2Icon className="h-5 w-5 text-muted-foreground" />
                     </Button>
-                    <MenuTrigger>
+                    <MenuTrigger
+                      onOpenChange={(isOpen) => {
+                        if (isOpen) {
+                          onSelectedUsersChange([user]);
+                        }
+                      }}
+                    >
                       <Button variant="icon" aria-label={t`Menu`}>
                         <EllipsisVerticalIcon className="h-5 w-5 text-muted-foreground" />
                       </Button>

--- a/application/account-management/WebApp/routes/admin/users/-components/UserToolbar.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/UserToolbar.tsx
@@ -1,0 +1,46 @@
+import type { components } from "@/shared/lib/api/client";
+import { Trans } from "@lingui/react/macro";
+import { Button } from "@repo/ui/components/Button";
+import { Trash2Icon } from "lucide-react";
+import { useCallback, useState } from "react";
+import { DeleteUserDialog } from "./DeleteUserDialog";
+import { UserQuerying } from "./UserQuerying";
+
+type UserDetails = components["schemas"]["UserDetails"];
+
+interface UserToolbarProps {
+  selectedUsers: UserDetails[];
+  onUsersDeleted: () => void;
+  onRefreshNeeded: () => void;
+}
+
+export function UserToolbar({ selectedUsers, onUsersDeleted, onRefreshNeeded }: Readonly<UserToolbarProps>) {
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  const handleUsersDeleted = useCallback(() => {
+    onUsersDeleted();
+    onRefreshNeeded();
+  }, [onUsersDeleted, onRefreshNeeded]);
+
+  return (
+    <div className="mt-4 mb-4 flex items-center justify-between gap-2">
+      <UserQuerying />
+      <div className="mt-6 flex items-center gap-2">
+        {selectedUsers.length > 0 && (
+          <Button variant="destructive" onPress={() => setIsDeleteModalOpen(true)}>
+            <Trash2Icon className="h-5 w-5" />
+            <span className="hidden sm:inline">
+              <Trans>Delete {selectedUsers.length === 1 ? "user" : `${selectedUsers.length} users`}</Trans>
+            </span>
+          </Button>
+        )}
+      </div>
+      <DeleteUserDialog
+        users={selectedUsers}
+        isOpen={isDeleteModalOpen}
+        onOpenChange={setIsDeleteModalOpen}
+        onSuccess={handleUsersDeleted}
+      />
+    </div>
+  );
+}

--- a/application/account-management/WebApp/routes/admin/users/-components/UserToolbar.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/UserToolbar.tsx
@@ -1,9 +1,10 @@
 import type { components } from "@/shared/lib/api/client";
 import { Trans } from "@lingui/react/macro";
 import { Button } from "@repo/ui/components/Button";
-import { Trash2Icon } from "lucide-react";
+import { PlusIcon, Trash2Icon } from "lucide-react";
 import { useCallback, useState } from "react";
 import { DeleteUserDialog } from "./DeleteUserDialog";
+import InviteUserDialog from "./InviteUserDialog";
 import { UserQuerying } from "./UserQuerying";
 
 type UserDetails = components["schemas"]["UserDetails"];
@@ -15,6 +16,7 @@ interface UserToolbarProps {
 }
 
 export function UserToolbar({ selectedUsers, onUsersDeleted, onRefreshNeeded }: Readonly<UserToolbarProps>) {
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const handleUsersDeleted = useCallback(() => {
@@ -26,6 +28,14 @@ export function UserToolbar({ selectedUsers, onUsersDeleted, onRefreshNeeded }: 
     <div className="mt-4 mb-4 flex items-center justify-between gap-2">
       <UserQuerying />
       <div className="mt-6 flex items-center gap-2">
+        {selectedUsers.length === 0 && (
+          <Button variant="primary" onPress={() => setIsInviteModalOpen(true)}>
+            <PlusIcon className="h-5 w-5" />
+            <span className="hidden sm:inline">
+              <Trans>Invite users</Trans>
+            </span>
+          </Button>
+        )}
         {selectedUsers.length > 0 && (
           <Button variant="destructive" onPress={() => setIsDeleteModalOpen(true)}>
             <Trash2Icon className="h-5 w-5" />
@@ -35,6 +45,7 @@ export function UserToolbar({ selectedUsers, onUsersDeleted, onRefreshNeeded }: 
           </Button>
         )}
       </div>
+      <InviteUserDialog isOpen={isInviteModalOpen} onOpenChange={setIsInviteModalOpen} />
       <DeleteUserDialog
         users={selectedUsers}
         isOpen={isDeleteModalOpen}

--- a/application/account-management/WebApp/routes/admin/users/index.tsx
+++ b/application/account-management/WebApp/routes/admin/users/index.tsx
@@ -4,12 +4,9 @@ import { SortOrder, SortableUserProperties, UserRole, UserStatus, type component
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { Breadcrumb } from "@repo/ui/components/Breadcrumbs";
-import { Button } from "@repo/ui/components/Button";
 import { createFileRoute } from "@tanstack/react-router";
-import { PlusIcon } from "lucide-react";
 import { useCallback, useState } from "react";
 import { z } from "zod";
-import InviteUserModal from "./-components/InviteUserModal";
 import { UserTable } from "./-components/UserTable";
 import { UserToolbar } from "./-components/UserToolbar";
 
@@ -32,7 +29,6 @@ export const Route = createFileRoute("/admin/users/")({
 });
 
 export default function UsersPage() {
-  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
   const [selectedUsers, setSelectedUsers] = useState<UserDetails[]>([]);
   const [refreshKey, setRefreshKey] = useState(0);
 
@@ -61,10 +57,6 @@ export default function UsersPage() {
               <Trans>Manage your users and permissions here.</Trans>
             </p>
           </div>
-          <Button variant="primary" onPress={() => setIsInviteModalOpen(true)}>
-            <PlusIcon className="h-4 w-4" />
-            <Trans>Invite users</Trans>
-          </Button>
         </div>
 
         <UserToolbar
@@ -79,7 +71,6 @@ export default function UsersPage() {
           onRefreshNeeded={handleRefresh}
         />
       </div>
-      <InviteUserModal isOpen={isInviteModalOpen} onOpenChange={setIsInviteModalOpen} />
     </div>
   );
 }

--- a/application/account-management/WebApp/routes/admin/users/index.tsx
+++ b/application/account-management/WebApp/routes/admin/users/index.tsx
@@ -1,17 +1,19 @@
 import { SharedSideMenu } from "@/shared/components/SharedSideMenu";
 import { TopMenu } from "@/shared/components/topMenu";
-import { SortOrder, SortableUserProperties, UserRole, UserStatus } from "@/shared/lib/api/client";
+import { SortOrder, SortableUserProperties, UserRole, UserStatus, type components } from "@/shared/lib/api/client";
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { Breadcrumb } from "@repo/ui/components/Breadcrumbs";
 import { Button } from "@repo/ui/components/Button";
 import { createFileRoute } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { z } from "zod";
 import InviteUserModal from "./-components/InviteUserModal";
-import { UserQuerying } from "./-components/UserQuerying";
 import { UserTable } from "./-components/UserTable";
+import { UserToolbar } from "./-components/UserToolbar";
+
+type UserDetails = components["schemas"]["UserDetails"];
 
 const userPageSearchSchema = z.object({
   search: z.string().optional(),
@@ -31,6 +33,12 @@ export const Route = createFileRoute("/admin/users/")({
 
 export default function UsersPage() {
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
+  const [selectedUsers, setSelectedUsers] = useState<UserDetails[]>([]);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshKey((prev) => prev + 1);
+  }, []);
 
   return (
     <div className="flex h-full w-full gap-4">
@@ -58,8 +66,18 @@ export default function UsersPage() {
             <Trans>Invite users</Trans>
           </Button>
         </div>
-        <UserQuerying />
-        <UserTable />
+
+        <UserToolbar
+          selectedUsers={selectedUsers}
+          onUsersDeleted={() => setSelectedUsers([])}
+          onRefreshNeeded={handleRefresh}
+        />
+        <UserTable
+          key={refreshKey}
+          selectedUsers={selectedUsers}
+          onSelectedUsersChange={setSelectedUsers}
+          onRefreshNeeded={handleRefresh}
+        />
       </div>
       <InviteUserModal isOpen={isInviteModalOpen} onOpenChange={setIsInviteModalOpen} />
     </div>

--- a/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
+++ b/application/account-management/WebApp/shared/lib/api/AccountManagement.Api.json
@@ -552,6 +552,38 @@
         }
       }
     },
+    "/api/account-management/users/bulk-delete": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "PostApiAccountManagementUsersBulkDelete",
+        "requestBody": {
+          "x-name": "command",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkDeleteUsersCommand"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/account-management/users/{id}/change-user-role": {
       "put": {
         "tags": [
@@ -1202,6 +1234,18 @@
           "pendingUsers": {
             "type": "integer",
             "format": "int32"
+          }
+        }
+      },
+      "BulkDeleteUsersCommand": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "userIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserId"
+            }
           }
         }
       },

--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -287,7 +287,7 @@ msgstr "Skærmbilleder af dashboard-projektet med mobilversioner"
 msgid "Search"
 msgstr "Søg"
 
-#. placeholder {0}: `${userToChangeRole?.firstName ?? ""} ${userToChangeRole?.lastName ?? ""}`.trim() || userToChangeRole?.email
+#. placeholder {0}: user ? `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email : ""
 msgid "Select a new role for <0>{0}</0>"
 msgstr "Vælg en ny rolle for <0>{0}</0>"
 

--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -56,7 +56,11 @@ msgstr "Enhver rolle"
 msgid "Any status"
 msgstr "Enhver status"
 
-#. placeholder {0}: `${userToDelete?.firstName ?? ""} ${userToDelete?.lastName ?? ""}`.trim() || userToDelete?.email
+#. placeholder {0}: users.length
+msgid "Are you sure you want to delete <0>{0} users</0>?"
+msgstr "Er du sikker på, at du vil slette <0>{0} brugere</0>?"
+
+#. placeholder {0}: `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email
 msgid "Are you sure you want to delete <0>{0}?</0>"
 msgstr "Er du sikker på, at du vil slette <0>{0}?</0>"
 
@@ -93,11 +97,18 @@ msgstr "Farezone"
 msgid "Delete"
 msgstr "Slet"
 
+#. placeholder {0}: selectedUsers.length === 1 ? "user" : `${selectedUsers.length} users`
+msgid "Delete {0}"
+msgstr "Slet {0}"
+
 msgid "Delete account"
 msgstr "Slet konto"
 
 msgid "Delete user"
 msgstr "Slet bruger"
+
+msgid "Delete users"
+msgstr "Slet brugere"
 
 msgid "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."
 msgstr "Sletning af kontoen og alle tilknyttede data. Denne handling kan ikke fortrydes, så fortsæt med forsigtighed."

--- a/application/account-management/WebApp/shared/translations/locale/en-US.po
+++ b/application/account-management/WebApp/shared/translations/locale/en-US.po
@@ -56,7 +56,11 @@ msgstr "Any role"
 msgid "Any status"
 msgstr "Any status"
 
-#. placeholder {0}: `${userToDelete?.firstName ?? ""} ${userToDelete?.lastName ?? ""}`.trim() || userToDelete?.email
+#. placeholder {0}: users.length
+msgid "Are you sure you want to delete <0>{0} users</0>?"
+msgstr "Are you sure you want to delete <0>{0} users</0>?"
+
+#. placeholder {0}: `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email
 msgid "Are you sure you want to delete <0>{0}?</0>"
 msgstr "Are you sure you want to delete <0>{0}?</0>"
 
@@ -93,11 +97,18 @@ msgstr "Danger zone"
 msgid "Delete"
 msgstr "Delete"
 
+#. placeholder {0}: selectedUsers.length === 1 ? "user" : `${selectedUsers.length} users`
+msgid "Delete {0}"
+msgstr "Delete {0}"
+
 msgid "Delete account"
 msgstr "Delete account"
 
 msgid "Delete user"
 msgstr "Delete user"
+
+msgid "Delete users"
+msgstr "Delete users"
 
 msgid "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."
 msgstr "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."

--- a/application/account-management/WebApp/shared/translations/locale/en-US.po
+++ b/application/account-management/WebApp/shared/translations/locale/en-US.po
@@ -287,7 +287,7 @@ msgstr "Screenshots of the dashboard project with mobile versions"
 msgid "Search"
 msgstr "Search"
 
-#. placeholder {0}: `${userToChangeRole?.firstName ?? ""} ${userToChangeRole?.lastName ?? ""}`.trim() || userToChangeRole?.email
+#. placeholder {0}: user ? `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email : ""
 msgid "Select a new role for <0>{0}</0>"
 msgstr "Select a new role for <0>{0}</0>"
 

--- a/application/account-management/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/account-management/WebApp/shared/translations/locale/nl-NL.po
@@ -287,7 +287,7 @@ msgstr "Schermafbeeldingen van het dashboardproject met mobiele versies"
 msgid "Search"
 msgstr "Zoeken"
 
-#. placeholder {0}: `${userToChangeRole?.firstName ?? ""} ${userToChangeRole?.lastName ?? ""}`.trim() || userToChangeRole?.email
+#. placeholder {0}: user ? `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email : ""
 msgid "Select a new role for <0>{0}</0>"
 msgstr "Selecteer een nieuwe rol voor <0>{0}</0>"
 

--- a/application/account-management/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/account-management/WebApp/shared/translations/locale/nl-NL.po
@@ -56,7 +56,11 @@ msgstr "Elke rol"
 msgid "Any status"
 msgstr "Elke status"
 
-#. placeholder {0}: `${userToDelete?.firstName ?? ""} ${userToDelete?.lastName ?? ""}`.trim() || userToDelete?.email
+#. placeholder {0}: users.length
+msgid "Are you sure you want to delete <0>{0} users</0>?"
+msgstr "Weet je zeker dat je <0>{0} gebruikers</0> wilt verwijderen?"
+
+#. placeholder {0}: `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email
 msgid "Are you sure you want to delete <0>{0}?</0>"
 msgstr "Weet je zeker dat je <0>{0}?</0> wilt verwijderen?"
 
@@ -93,11 +97,18 @@ msgstr "Gevaarzone"
 msgid "Delete"
 msgstr "Verwijderen"
 
+#. placeholder {0}: selectedUsers.length === 1 ? "user" : `${selectedUsers.length} users`
+msgid "Delete {0}"
+msgstr "Verwijder {0}"
+
 msgid "Delete account"
 msgstr "Account verwijderen"
 
 msgid "Delete user"
 msgstr "Gebruiker verwijderen"
+
+msgid "Delete users"
+msgstr "Gebruikers verwijderen"
 
 msgid "Deleting the account and all associated data. This action cannot be undone, so please proceed with caution."
 msgstr "Het account en alle bijbehorende gegevens worden verwijderd. Deze actie kan niet ongedaan worden gemaakt, dus ga voorzichtig te werk."

--- a/application/shared-kernel/SharedKernel/Domain/IBulkRemoveRepository.cs
+++ b/application/shared-kernel/SharedKernel/Domain/IBulkRemoveRepository.cs
@@ -1,0 +1,6 @@
+namespace PlatformPlatform.SharedKernel.Domain;
+
+public interface IBulkRemoveRepository<in T> where T : IAggregateRoot
+{
+    void BulkRemove(T[] aggregates);
+}

--- a/application/shared-kernel/SharedKernel/Persistence/RepositoryBase.cs
+++ b/application/shared-kernel/SharedKernel/Persistence/RepositoryBase.cs
@@ -56,4 +56,9 @@ public abstract class RepositoryBase<T, TId>(DbContext context)
         ArgumentNullException.ThrowIfNull(aggregate);
         DbSet.Remove(aggregate);
     }
+
+    public void BulkRemove(T[] aggregates)
+    {
+        DbSet.RemoveRange(aggregates);
+    }
 }

--- a/application/shared-webapp/infrastructure/translations/TranslationContext.tsx
+++ b/application/shared-webapp/infrastructure/translations/TranslationContext.tsx
@@ -12,8 +12,7 @@ export type TranslationContext = {
 };
 
 export const translationContext = createContext<TranslationContext>({
-  setLocale: async () => {
-  },
+  setLocale: async () => {},
   locales: [],
   getLocaleInfo: () => {
     throw new Error("Not initialized.");


### PR DESCRIPTION
### Summary & motivation

Add support for bulk deletion of users and improve the user management interface.

- Implement backend support for bulk user deletion with validation and telemetry tracking
- Add `IBulkRemoveRepository` interface and implement it in `RepositoryBase` to support efficient bulk operations
- Create new `UserToolbar` component to manage user actions and selection
- Extract user role change and deletion logic into separate dialog components for reusability
- Rename `InviteUserModal` to `InviteUserDialog` for consistency with other UI components
- Add multi-select support to the user table to enable bulk operations
- Update translations for new bulk deletion UI elements

These changes improve the user management workflow by allowing administrators to delete multiple users at once while preserving validation, error handling, and telemetry tracking. UI components have been refactored to be more consistent and maintainable.


### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
