### PR TITLE
Configure global query cache invalidation for TanStack

### DIFF
--- a/application/account-management/WebApp/routes/__root.tsx
+++ b/application/account-management/WebApp/routes/__root.tsx
@@ -1,10 +1,11 @@
+import { queryClient } from "@/shared/lib/api/client";
 import { AuthenticationProvider } from "@repo/infrastructure/auth/AuthenticationProvider";
 import { ErrorPage } from "@repo/infrastructure/errorComponents/ErrorPage";
 import { NotFound } from "@repo/infrastructure/errorComponents/NotFoundPage";
 import { ReactAriaRouterProvider } from "@repo/infrastructure/router/ReactAriaRouterProvider";
 import { useInitializeLocale } from "@repo/infrastructure/translations/useInitializeLocale";
 import { ThemeModeProvider } from "@repo/ui/theme/mode/ThemeMode";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { Outlet, createRootRoute, useNavigate } from "@tanstack/react-router";
 
 export const Route = createRootRoute({
@@ -12,8 +13,6 @@ export const Route = createRootRoute({
   errorComponent: ErrorPage,
   notFoundComponent: NotFound
 });
-
-const queryClient = new QueryClient();
 
 function Root() {
   const navigate = useNavigate();

--- a/application/account-management/WebApp/routes/admin/users/-components/ChangeUserRoleDialog.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/ChangeUserRoleDialog.tsx
@@ -13,10 +13,9 @@ interface ChangeUserRoleDialogProps {
   user: UserDetails | null;
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
-  onSuccess: () => void;
 }
 
-export function ChangeUserRoleDialog({ user, isOpen, onOpenChange, onSuccess }: Readonly<ChangeUserRoleDialogProps>) {
+export function ChangeUserRoleDialog({ user, isOpen, onOpenChange }: Readonly<ChangeUserRoleDialogProps>) {
   const changeUserRoleMutation = api.useMutation("put", "/api/account-management/users/{id}/change-user-role");
 
   const handleUserRoleChange = useCallback(
@@ -28,9 +27,8 @@ export function ChangeUserRoleDialog({ user, isOpen, onOpenChange, onSuccess }: 
       await changeUserRoleMutation.mutateAsync({ params: { path: { id: user.id } }, body: { userRole: newUserRole } });
 
       onOpenChange(false);
-      onSuccess();
     },
-    [user, changeUserRoleMutation, onOpenChange, onSuccess]
+    [user, changeUserRoleMutation, onOpenChange]
   );
 
   return (

--- a/application/account-management/WebApp/routes/admin/users/-components/DeleteUserDialog.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/DeleteUserDialog.tsx
@@ -11,10 +11,9 @@ interface DeleteUserDialogProps {
   users: UserDetails[];
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
-  onSuccess: () => void;
 }
 
-export function DeleteUserDialog({ users, isOpen, onOpenChange, onSuccess }: Readonly<DeleteUserDialogProps>) {
+export function DeleteUserDialog({ users, isOpen, onOpenChange }: Readonly<DeleteUserDialogProps>) {
   const isSingleUser = users.length === 1;
   const user = users[0];
 
@@ -30,8 +29,7 @@ export function DeleteUserDialog({ users, isOpen, onOpenChange, onSuccess }: Rea
     }
 
     onOpenChange(false);
-    onSuccess();
-  }, [users, isSingleUser, user, deleteUserMutation, bulkDeleteUsersMutation, onOpenChange, onSuccess]);
+  }, [users, isSingleUser, user, deleteUserMutation, bulkDeleteUsersMutation, onOpenChange]);
 
   return (
     <Modal isOpen={isOpen} onOpenChange={onOpenChange} blur={false} isDismissable={true}>

--- a/application/account-management/WebApp/routes/admin/users/-components/InviteUserDialog.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/InviteUserDialog.tsx
@@ -10,7 +10,7 @@ import { Modal } from "@repo/ui/components/Modal";
 import { TextField } from "@repo/ui/components/TextField";
 import { mutationSubmitter } from "@repo/ui/forms/mutationSubmitter";
 import { XIcon } from "lucide-react";
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 
 interface InviteUserDialogProps {
   isOpen: boolean;
@@ -18,23 +18,18 @@ interface InviteUserDialogProps {
 }
 
 export default function InviteUserDialog({ isOpen, onOpenChange }: Readonly<InviteUserDialogProps>) {
-  const closeDialog = useCallback(() => {
-    onOpenChange(false);
-  }, [onOpenChange]);
-
   const inviteUserMutation = api.useMutation("post", "/api/account-management/users/invite");
 
   useEffect(() => {
     if (inviteUserMutation.isSuccess) {
-      closeDialog();
-      window.location.reload();
+      onOpenChange(false);
     }
-  }, [inviteUserMutation.isSuccess, closeDialog]);
+  }, [inviteUserMutation.isSuccess, onOpenChange]);
 
   return (
     <Modal isOpen={isOpen} onOpenChange={onOpenChange} isDismissable={true}>
       <Dialog>
-        <XIcon onClick={closeDialog} className="absolute top-2 right-2 h-10 w-10 p-2 hover:bg-muted" />
+        <XIcon onClick={() => onOpenChange(false)} className="absolute top-2 right-2 h-10 w-10 p-2 hover:bg-muted" />
         <Heading slot="title" className="text-2xl">
           <Trans>Invite user</Trans>
         </Heading>
@@ -58,7 +53,7 @@ export default function InviteUserDialog({ isOpen, onOpenChange }: Readonly<Invi
           />
           <FormErrorMessage error={inviteUserMutation.error} />
           <div className="mt-6 flex justify-end gap-4">
-            <Button type="reset" onPress={closeDialog} variant="secondary">
+            <Button type="reset" onPress={() => onOpenChange(false)} variant="secondary">
               <Trans>Cancel</Trans>
             </Button>
             <Button type="submit" isDisabled={inviteUserMutation.isPending}>

--- a/application/account-management/WebApp/routes/admin/users/-components/UserTable.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/UserTable.tsx
@@ -11,7 +11,7 @@ import { Pagination } from "@repo/ui/components/Pagination";
 import { Cell, Column, Row, Table, TableHeader } from "@repo/ui/components/Table";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { EllipsisVerticalIcon, PencilIcon, Trash2Icon, UserIcon } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Selection, SortDescriptor } from "react-aria-components";
 import { MenuTrigger, TableBody } from "react-aria-components";
 import { ChangeUserRoleDialog } from "./ChangeUserRoleDialog";
@@ -22,10 +22,9 @@ type UserDetails = components["schemas"]["UserDetails"];
 interface UserTableProps {
   selectedUsers: UserDetails[];
   onSelectedUsersChange: (users: UserDetails[]) => void;
-  onRefreshNeeded: () => void;
 }
 
-export function UserTable({ selectedUsers, onSelectedUsersChange, onRefreshNeeded }: Readonly<UserTableProps>) {
+export function UserTable({ selectedUsers, onSelectedUsersChange }: Readonly<UserTableProps>) {
   const navigate = useNavigate();
   const { search, userRole, userStatus, startDate, endDate, orderBy, sortOrder, pageOffset } = useSearch({
     strict: false
@@ -84,14 +83,9 @@ export function UserTable({ selectedUsers, onSelectedUsersChange, onRefreshNeede
     [navigate]
   );
 
-  const handleDelete = useCallback(() => {
-    if (!userToDelete) {
-      return;
-    }
-    onSelectedUsersChange(selectedUsers.filter((user) => user.id !== userToDelete.id));
-    onRefreshNeeded();
-    setUserToDelete(null);
-  }, [userToDelete, onRefreshNeeded, onSelectedUsersChange, selectedUsers]);
+  useEffect(() => {
+    onSelectedUsersChange([]);
+  }, [onSelectedUsersChange]);
 
   const handleSelectionChange = useCallback(
     (keys: Selection) => {
@@ -118,14 +112,12 @@ export function UserTable({ selectedUsers, onSelectedUsersChange, onRefreshNeede
         user={userToChangeRole}
         isOpen={userToChangeRole !== null}
         onOpenChange={(isOpen) => !isOpen && setUserToChangeRole(null)}
-        onSuccess={onRefreshNeeded}
       />
 
       <DeleteUserDialog
         users={userToDelete ? [userToDelete] : []}
         isOpen={userToDelete !== null}
         onOpenChange={(isOpen) => !isOpen && setUserToDelete(null)}
-        onSuccess={handleDelete}
       />
 
       <div className="flex h-full w-full flex-col gap-2">

--- a/application/account-management/WebApp/routes/admin/users/-components/UserToolbar.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/UserToolbar.tsx
@@ -2,7 +2,7 @@ import type { components } from "@/shared/lib/api/client";
 import { Trans } from "@lingui/react/macro";
 import { Button } from "@repo/ui/components/Button";
 import { PlusIcon, Trash2Icon } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { DeleteUserDialog } from "./DeleteUserDialog";
 import InviteUserDialog from "./InviteUserDialog";
 import { UserQuerying } from "./UserQuerying";
@@ -11,18 +11,11 @@ type UserDetails = components["schemas"]["UserDetails"];
 
 interface UserToolbarProps {
   selectedUsers: UserDetails[];
-  onUsersDeleted: () => void;
-  onRefreshNeeded: () => void;
 }
 
-export function UserToolbar({ selectedUsers, onUsersDeleted, onRefreshNeeded }: Readonly<UserToolbarProps>) {
+export function UserToolbar({ selectedUsers }: Readonly<UserToolbarProps>) {
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-
-  const handleUsersDeleted = useCallback(() => {
-    onUsersDeleted();
-    onRefreshNeeded();
-  }, [onUsersDeleted, onRefreshNeeded]);
 
   return (
     <div className="mt-4 mb-4 flex items-center justify-between gap-2">
@@ -46,12 +39,7 @@ export function UserToolbar({ selectedUsers, onUsersDeleted, onRefreshNeeded }: 
         )}
       </div>
       <InviteUserDialog isOpen={isInviteModalOpen} onOpenChange={setIsInviteModalOpen} />
-      <DeleteUserDialog
-        users={selectedUsers}
-        isOpen={isDeleteModalOpen}
-        onOpenChange={setIsDeleteModalOpen}
-        onSuccess={handleUsersDeleted}
-      />
+      <DeleteUserDialog users={selectedUsers} isOpen={isDeleteModalOpen} onOpenChange={setIsDeleteModalOpen} />
     </div>
   );
 }

--- a/application/account-management/WebApp/routes/admin/users/index.tsx
+++ b/application/account-management/WebApp/routes/admin/users/index.tsx
@@ -5,7 +5,7 @@ import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { Breadcrumb } from "@repo/ui/components/Breadcrumbs";
 import { createFileRoute } from "@tanstack/react-router";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { z } from "zod";
 import { UserTable } from "./-components/UserTable";
 import { UserToolbar } from "./-components/UserToolbar";
@@ -30,11 +30,6 @@ export const Route = createFileRoute("/admin/users/")({
 
 export default function UsersPage() {
   const [selectedUsers, setSelectedUsers] = useState<UserDetails[]>([]);
-  const [refreshKey, setRefreshKey] = useState(0);
-
-  const handleRefresh = useCallback(() => {
-    setRefreshKey((prev) => prev + 1);
-  }, []);
 
   return (
     <div className="flex h-full w-full gap-4">
@@ -59,17 +54,8 @@ export default function UsersPage() {
           </div>
         </div>
 
-        <UserToolbar
-          selectedUsers={selectedUsers}
-          onUsersDeleted={() => setSelectedUsers([])}
-          onRefreshNeeded={handleRefresh}
-        />
-        <UserTable
-          key={refreshKey}
-          selectedUsers={selectedUsers}
-          onSelectedUsersChange={setSelectedUsers}
-          onRefreshNeeded={handleRefresh}
-        />
+        <UserToolbar selectedUsers={selectedUsers} />
+        <UserTable selectedUsers={selectedUsers} onSelectedUsersChange={setSelectedUsers} />
       </div>
     </div>
   );

--- a/application/account-management/WebApp/shared/components/AvatarButton.tsx
+++ b/application/account-management/WebApp/shared/components/AvatarButton.tsx
@@ -20,15 +20,14 @@ export default function AvatarButton({ "aria-label": ariaLabel }: Readonly<{ "ar
     }
   }, [userInfo]);
 
-  const logoutMutation = api.useMutation("post", "/api/account-management/authentication/logout");
+  const logoutMutation = api.useMutation("post", "/api/account-management/authentication/logout", {
+    onSuccess: () => {
+      window.location.href = createLoginUrlWithReturnPath(loginPath);
+    }
+  });
 
   if (!userInfo) {
     return null;
-  }
-
-  async function logout() {
-    await logoutMutation.mutateAsync({});
-    window.location.href = createLoginUrlWithReturnPath(loginPath);
   }
 
   return (
@@ -53,7 +52,7 @@ export default function AvatarButton({ "aria-label": ariaLabel }: Readonly<{ "ar
             <Trans>Edit profile</Trans>
           </MenuItem>
           <MenuSeparator />
-          <MenuItem id="logout" onAction={logout}>
+          <MenuItem id="logout" onAction={() => logoutMutation.mutate({})}>
             <LogOutIcon size={16} /> <Trans>Log out</Trans>
           </MenuItem>
         </Menu>

--- a/application/account-management/WebApp/shared/lib/api/client.ts
+++ b/application/account-management/WebApp/shared/lib/api/client.ts
@@ -1,5 +1,6 @@
 import { createAuthenticationMiddleware } from "@repo/infrastructure/auth/AuthenticationMiddleware";
 import { createAntiforgeryMiddleware } from "@repo/infrastructure/http/antiforgeryTokenHandler";
+import { MutationCache, QueryClient } from "@tanstack/react-query";
 import createFetchClient from "openapi-fetch";
 import createClient from "openapi-react-query";
 import type { components, paths } from "./api.generated";
@@ -16,3 +17,11 @@ apiClient.use(createAntiforgeryMiddleware());
 export const api = createClient(apiClient);
 
 export type Schemas = components["schemas"];
+
+export const queryClient = new QueryClient({
+  mutationCache: new MutationCache({
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+    }
+  })
+});

--- a/application/back-office/WebApp/routes/__root.tsx
+++ b/application/back-office/WebApp/routes/__root.tsx
@@ -4,7 +4,7 @@ import { NotFound } from "@repo/infrastructure/errorComponents/NotFoundPage";
 import { ReactAriaRouterProvider } from "@repo/infrastructure/router/ReactAriaRouterProvider";
 import { useInitializeLocale } from "@repo/infrastructure/translations/useInitializeLocale";
 import { ThemeModeProvider } from "@repo/ui/theme/mode/ThemeMode";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MutationCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Outlet, createRootRoute, useNavigate } from "@tanstack/react-router";
 
 export const Route = createRootRoute({
@@ -13,7 +13,13 @@ export const Route = createRootRoute({
   notFoundComponent: NotFound
 });
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  mutationCache: new MutationCache({
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+    }
+  })
+});
 
 function Root() {
   const navigate = useNavigate();

--- a/application/back-office/WebApp/shared/lib/api/client.ts
+++ b/application/back-office/WebApp/shared/lib/api/client.ts
@@ -1,5 +1,6 @@
 import { createAuthenticationMiddleware } from "@repo/infrastructure/auth/AuthenticationMiddleware";
 import { createAntiforgeryMiddleware } from "@repo/infrastructure/http/antiforgeryTokenHandler";
+import { MutationCache, QueryClient } from "@tanstack/react-query";
 import createFetchClient from "openapi-fetch";
 import createClient from "openapi-react-query";
 import type { components, paths } from "./api.generated";
@@ -16,3 +17,11 @@ apiClient.use(createAntiforgeryMiddleware());
 export const api = createClient(apiClient);
 
 export type Schemas = components["schemas"];
+
+export const queryClient = new QueryClient({
+  mutationCache: new MutationCache({
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+    }
+  })
+});


### PR DESCRIPTION
### Summary & motivation

Configure TanStack's global query cache invalidation to automatically refresh data after mutations, eliminating the need for manual cache management. When mutation endpoints (`POST`, `PUT`, `DELETE`) are called, all data in the active UI is automatically refreshed. While this may result in too many `GET` calls, it significantly simplifies the frontend code and ensures the UI is always up-to-date.

- Configure `QueryClient` with `MutationCache` to invalidate all queries on successful mutations
- Remove manual query refetching and state updates after mutations in user management
- Simplify component props by removing redundant refresh callbacks
- Simplify logout logic by using TanStack's `onSuccess` for redirect trigger

### Downstream projects

This change introduces a recommended pattern for handling cache invalidation in downstream projects. While projects can implement their own cache invalidation strategy, this approach is recommended for its simplicity and effectiveness.

1. Copy `WebApp/shared/lib/api/client.ts` from either `account-management` or `back-office` to your self-contained system
2. Clean up components by removing any manual query invalidation, refresh callbacks, and state updates that are now handled by the global cache invalidation
### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
