### PR TITLE
Fix foreign key constraints when deleting users and tenants 

### DIFF
--- a/application/account-management/Core/Database/Migrations/20250217000000_Initial.cs
+++ b/application/account-management/Core/Database/Migrations/20250217000000_Initial.cs
@@ -1,11 +1,11 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace PlatformPlatform.AccountManagement.Database;
+namespace PlatformPlatform.AccountManagement.Database.Migrations;
 
 [DbContext(typeof(AccountManagementDbContext))]
 [Migration("20250217000000_Initial")]
-public sealed class DatabaseMigrations : Migration
+public sealed class Initial : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)
     {

--- a/application/account-management/Core/Database/Migrations/20250402000000_CascadeDeleteLogins.cs
+++ b/application/account-management/Core/Database/Migrations/20250402000000_CascadeDeleteLogins.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace PlatformPlatform.AccountManagement.Database.Migrations;
+
+[DbContext(typeof(AccountManagementDbContext))]
+[Migration("20250402000000_CascadeDeleteLogins")]
+public sealed class CascadeDeleteLogins : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropForeignKey(
+            name: "FK_Logins_User_UserId",
+            table: "Logins");
+
+        migrationBuilder.AddForeignKey(
+            name: "FK_Logins_User_UserId",
+            table: "Logins",
+            column: "UserId",
+            principalTable: "Users",
+            principalColumn: "Id",
+            onDelete: ReferentialAction.Cascade);
+    }
+}

--- a/application/account-management/Core/Features/Authentication/Domain/LoginConfiguration.cs
+++ b/application/account-management/Core/Features/Authentication/Domain/LoginConfiguration.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using PlatformPlatform.AccountManagement.Features.EmailConfirmations.Domain;
+using PlatformPlatform.AccountManagement.Features.Users.Domain;
 using PlatformPlatform.SharedKernel.Domain;
 using PlatformPlatform.SharedKernel.EntityFramework;
 
@@ -14,5 +15,10 @@ public sealed class LoginConfiguration : IEntityTypeConfiguration<Login>
         builder.MapStronglyTypedLongId<Login, TenantId>(l => l.TenantId);
         builder.MapStronglyTypedUuid<Login, UserId>(l => l.UserId);
         builder.MapStronglyTypedUuid<Login, EmailConfirmationId>(l => l.EmailConfirmationId);
+
+        builder.HasOne<User>()
+            .WithMany()
+            .HasForeignKey(l => l.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/application/account-management/Core/Features/TelemetryEvents.cs
+++ b/application/account-management/Core/Features/TelemetryEvents.cs
@@ -48,8 +48,8 @@ public sealed class SignupStarted
 public sealed class TenantCreated(TenantId tenantId, TenantState state)
     : TelemetryEvent(("tenant_id", tenantId), ("tenant_state", state));
 
-public sealed class TenantDeleted(TenantId tenantId, TenantState tenantState)
-    : TelemetryEvent(("tenant_id", tenantId), ("tenant_state", tenantState));
+public sealed class TenantDeleted(TenantId tenantId, TenantState tenantState, int usersDeleted)
+    : TelemetryEvent(("tenant_id", tenantId), ("tenant_state", tenantState), ("users_deleted", usersDeleted));
 
 public sealed class TenantUpdated
     : TelemetryEvent;

--- a/application/account-management/Core/Features/Users/Domain/UserRepository.cs
+++ b/application/account-management/Core/Features/Users/Domain/UserRepository.cs
@@ -34,6 +34,8 @@ public interface IUserRepository : ICrudRepository<User, UserId>, IBulkRemoveRep
         int? pageSize,
         CancellationToken cancellationToken
     );
+
+    Task<User[]> GetTenantUsers(CancellationToken cancellationToken);
 }
 
 internal sealed class UserRepository(AccountManagementDbContext accountManagementDbContext, IExecutionContext executionContext)
@@ -177,5 +179,10 @@ internal sealed class UserRepository(AccountManagementDbContext accountManagemen
 
         var totalPages = (totalItems - 1) / pageSize.Value + 1;
         return (result, totalItems, totalPages);
+    }
+
+    public async Task<User[]> GetTenantUsers(CancellationToken cancellationToken)
+    {
+        return await DbSet.ToArrayAsync(cancellationToken);
     }
 }

--- a/application/back-office/Core/Database/Migrations/20250217000000_Initial.cs
+++ b/application/back-office/Core/Database/Migrations/20250217000000_Initial.cs
@@ -1,11 +1,11 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace PlatformPlatform.BackOffice.Database;
+namespace PlatformPlatform.BackOffice.Database.Migrations;
 
 [DbContext(typeof(BackOfficeDbContext))]
 [Migration("20250217000000_Initial")]
-public sealed class DatabaseMigrations : Migration
+public sealed class Initial : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)
     {


### PR DESCRIPTION
### Summary & motivation

Fix a bug where both user and tenant deletion fails due to foreign key constraints when users have login history or a tenant has users. The fix is implemented in two different ways:

1. User deletion: Add cascade delete to the `Logins` table foreign key to automatically remove login records when a user is deleted, since login history is less critical.
2. Tenant deletion: Add bulk deletion of users to properly clean up tenant data, deliberately avoiding cascade delete for better control and safety in case of accidental tenant deletion.

Additional changes:
- Track the number of users deleted in the `TenantDeleted` telemetry event to monitor the impact of tenant deletions
- Move database migrations to a `Migrations` namespace and rename files to match Entity Framework conventions
- Add a test to verify that user deletion with login history works correctly

### Downstream projects

Consider moving Entity Framework migrations to separate files in `your-self-contained-system/Core/Database/Migrations/2025MMDDHHmmss-Name.cs`

### Downstream projects

Consider moving Entity Framework migrations into a dedicated namespace and renaming them to follow Entity Framework conventions.

1. Move existing migration files to `application/your-self-contained-system/Core/Database/Migrations` and update the namespace accordingly.
2. Rename each file using the format `YYYYMMDDHHmmss-DescriptiveName.cs` to match the convention.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
