### PR TITLE
Force resolution of lingui peer dependency

### DIFF
--- a/application/package.json
+++ b/application/package.json
@@ -64,6 +64,9 @@
     "turbo": "2.3.3",
     "typescript": "5.7.2"
   },
+  "overrides": {
+    "@lingui/babel-plugin-lingui-macro": "5.0.0"
+  },
   "postcss": {
     "plugins": {
       "tailwindcss": {}


### PR DESCRIPTION
### Summary & Motivation

Fix the warnings received when running `npm install`.
This also happens in the [Github Actions](https://github.com/platformplatform/PlatformPlatform/actions/runs/14225765294/job/39864801540#step:6:1).

“Force” the resolution of the peer dependency by adding an overrides section to the `package.json`.
This tells npm that whenever `@lingui/macro` asks for version 4.11.2 of the babel plugin, use version 5.0.0 instead (which is already installed).

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
