### PR TITLE
Trigger database migrations only when staging cluster is enabled

### DIFF
--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -219,6 +219,7 @@ jobs:
 
   database-migrations-stage:
     name: Database Staging
+    if: ${{ vars.STAGING_CLUSTER_ENABLED == 'true' }}
     needs: build-and-test
     uses: ./.github/workflows/_migrate-database.yml
     secrets: inherit

--- a/.github/workflows/back-office.yml
+++ b/.github/workflows/back-office.yml
@@ -219,6 +219,7 @@ jobs:
 
   database-migrations-stage:
     name: Database Staging
+    if: ${{ vars.STAGING_CLUSTER_ENABLED == 'true' }}
     needs: build-and-test
     uses: ./.github/workflows/_migrate-database.yml
     secrets: inherit


### PR DESCRIPTION
### Summary & Motivation

Only trigger the database migrations Github Actions job when staging cluster is enabled.

### Downstream projects

Add the following line to your workflow YAML files:
```yaml
database-migrations-stage:
    name: Database Staging
    if: ${{ vars.STAGING_CLUSTER_ENABLED == 'true' }} # add this line
    ...
```

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
