### PR TITLE
Use consistent time provider

### DIFF
--- a/application/account-management/Tests/Authentication/CompleteLoginTests.cs
+++ b/application/account-management/Tests/Authentication/CompleteLoginTests.cs
@@ -156,7 +156,7 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
                 ("TenantId", DatabaseSeeder.Tenant1Owner.TenantId.ToString()),
                 ("UserId", DatabaseSeeder.Tenant1Owner.Id.ToString()),
                 ("Id", loginId.ToString()),
-                ("CreatedAt", DateTime.UtcNow.AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("EmailConfirmationId", emailConfirmationId.ToString()),
                 ("Completed", false)
@@ -164,12 +164,12 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
         );
         Connection.Insert("EmailConfirmations", [
                 ("Id", emailConfirmationId.ToString()),
-                ("CreatedAt", DateTime.UtcNow.AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", DatabaseSeeder.Tenant1Owner.Email),
                 ("Type", EmailConfirmationType.Signup),
                 ("OneTimePasswordHash", new PasswordHasher<object>().HashPassword(this, CorrectOneTimePassword)),
-                ("ValidUntil", DateTime.UtcNow.AddMinutes(-10)),
+                ("ValidUntil", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
                 ("RetryCount", 0),
                 ("ResendCount", 0),
                 ("Completed", false)

--- a/application/account-management/Tests/Signups/CompleteSignupTests.cs
+++ b/application/account-management/Tests/Signups/CompleteSignupTests.cs
@@ -142,12 +142,12 @@ public sealed class CompleteSignupTests : EndpointBaseTest<AccountManagementDbCo
         var emailConfirmationId = EmailConfirmationId.NewId();
         Connection.Insert("EmailConfirmations", [
                 ("Id", emailConfirmationId.ToString()),
-                ("CreatedAt", DateTime.UtcNow.AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", email),
                 ("Type", EmailConfirmationType.Signup),
                 ("OneTimePasswordHash", new PasswordHasher<object>().HashPassword(this, CorrectOneTimePassword)),
-                ("ValidUntil", DateTime.UtcNow.AddMinutes(-5)),
+                ("ValidUntil", TimeProvider.System.GetUtcNow().AddMinutes(-5)),
                 ("RetryCount", 0),
                 ("ResendCount", 0),
                 ("Completed", false)

--- a/application/account-management/Tests/Signups/StartSignupTests.cs
+++ b/application/account-management/Tests/Signups/StartSignupTests.cs
@@ -103,12 +103,12 @@ public sealed class StartSignupTests : EndpointBaseTest<AccountManagementDbConte
             var oneTimePasswordHash = new PasswordHasher<object>().HashPassword(this, OneTimePasswordHelper.GenerateOneTimePassword(6));
             Connection.Insert("EmailConfirmations", [
                     ("Id", EmailConfirmationId.NewId().ToString()),
-                    ("CreatedAt", DateTime.UtcNow.AddHours(-i)),
+                    ("CreatedAt", TimeProvider.System.GetUtcNow().AddHours(-i)),
                     ("ModifiedAt", null),
                     ("Email", email),
                     ("Type", EmailConfirmationType.Signup.ToString()),
                     ("OneTimePasswordHash", oneTimePasswordHash),
-                    ("ValidUntil", DateTime.UtcNow.AddHours(-i).AddMinutes(5)),
+                    ("ValidUntil", TimeProvider.System.GetUtcNow().AddHours(-i).AddMinutes(5)),
                     ("RetryCount", 0),
                     ("ResendCount", 0),
                     ("Completed", false)

--- a/application/account-management/Tests/Tenants/DeleteTenantTests.cs
+++ b/application/account-management/Tests/Tenants/DeleteTenantTests.cs
@@ -36,7 +36,7 @@ public sealed class DeleteTenantTests : EndpointBaseTest<AccountManagementDbCont
         Connection.Insert("Users", [
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", UserId.NewId().ToString()),
-                ("CreatedAt", DateTime.UtcNow.AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", Faker.Internet.Email()),
                 ("FirstName", Faker.Person.FirstName),

--- a/application/account-management/Tests/Users/BulkDeleteUsersTests.cs
+++ b/application/account-management/Tests/Users/BulkDeleteUsersTests.cs
@@ -27,7 +27,7 @@ public sealed class BulkDeleteUsersTests : EndpointBaseTest<AccountManagementDbC
             Connection.Insert("Users", [
                     ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                     ("Id", userId.ToString()),
-                    ("CreatedAt", DateTime.UtcNow.AddMinutes(-10)),
+                    ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
                     ("ModifiedAt", null),
                     ("Email", Faker.Internet.Email()),
                     ("FirstName", Faker.Person.FirstName),

--- a/application/account-management/Tests/Users/DeleteUserTests.cs
+++ b/application/account-management/Tests/Users/DeleteUserTests.cs
@@ -35,7 +35,7 @@ public sealed class DeleteUserTests : EndpointBaseTest<AccountManagementDbContex
         Connection.Insert("Users", [
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", userId.ToString()),
-                ("CreatedAt", DateTime.UtcNow.AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", Faker.Internet.Email()),
                 ("FirstName", Faker.Person.FirstName),
@@ -77,7 +77,7 @@ public sealed class DeleteUserTests : EndpointBaseTest<AccountManagementDbContex
         Connection.Insert("Users", [
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", userId.ToString()),
-                ("CreatedAt", DateTime.UtcNow.AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", Faker.Internet.Email()),
                 ("FirstName", Faker.Person.FirstName),
@@ -97,7 +97,7 @@ public sealed class DeleteUserTests : EndpointBaseTest<AccountManagementDbContex
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", loginId.ToString()),
                 ("UserId", userId.ToString()),
-                ("CreatedAt", DateTime.UtcNow.AddMinutes(-5)),
+                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-5)),
                 ("ModifiedAt", null),
                 ("EmailConfirmationId", emailConfirmationId.ToString()),
                 ("Completed", true)

--- a/application/account-management/Tests/Users/GetUsersTests.cs
+++ b/application/account-management/Tests/Users/GetUsersTests.cs
@@ -22,7 +22,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
         Connection.Insert("Users", [
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", UserId.NewId().ToString()),
-                ("CreatedAt", DateTime.UtcNow.AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", Email),
                 ("FirstName", FirstName),
@@ -37,7 +37,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
         Connection.Insert("Users", [
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", UserId.NewId().ToString()),
-                ("CreatedAt", DateTime.UtcNow.AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", Faker.Internet.Email()),
                 ("FirstName", Faker.Name.FirstName()),

--- a/developer-cli/Commands/BuildCommand.cs
+++ b/developer-cli/Commands/BuildCommand.cs
@@ -29,7 +29,7 @@ public class BuildCommand : Command
 
         try
         {
-            var totalStopwatch = Stopwatch.StartNew();
+            var startTime = Stopwatch.GetTimestamp();
             var backendTime = TimeSpan.Zero;
             var frontendTime = TimeSpan.Zero;
 
@@ -38,17 +38,17 @@ public class BuildCommand : Command
                 AnsiConsole.MarkupLine("[blue]Running backend build...[/]");
                 var solutionFile = SolutionHelper.GetSolution(solutionName);
                 ProcessHelper.StartProcess($"dotnet build {solutionFile.Name}", solutionFile.Directory?.FullName);
-                backendTime = totalStopwatch.Elapsed;
+                backendTime = Stopwatch.GetElapsedTime(startTime);
             }
 
             if (buildFrontend)
             {
                 AnsiConsole.MarkupLine("[blue]Running frontend build...[/]");
                 ProcessHelper.StartProcess("npm run build", Configuration.ApplicationFolder);
-                frontendTime = totalStopwatch.Elapsed - backendTime;
+                frontendTime = Stopwatch.GetElapsedTime(startTime) - backendTime;
             }
 
-            AnsiConsole.MarkupLine($"[green]Build completed successfully in {totalStopwatch.Elapsed.Format()}[/]");
+            AnsiConsole.MarkupLine($"[green]Build completed successfully in {Stopwatch.GetElapsedTime(startTime).Format()}[/]");
             if (buildBackend && buildFrontend)
             {
                 AnsiConsole.MarkupLine(

--- a/developer-cli/Commands/CheckCommand.cs
+++ b/developer-cli/Commands/CheckCommand.cs
@@ -29,23 +29,23 @@ public class CheckCommand : Command
 
         try
         {
-            var totalStopwatch = Stopwatch.StartNew();
+            var startTime = Stopwatch.GetTimestamp();
             var backendTime = TimeSpan.Zero;
             var frontendTime = TimeSpan.Zero;
 
             if (checkBackend)
             {
                 RunBackendChecks(solutionName, skipFormat, skipInspect);
-                backendTime = totalStopwatch.Elapsed;
+                backendTime = Stopwatch.GetElapsedTime(startTime);
             }
 
             if (checkFrontend)
             {
                 RunFrontendChecks();
-                frontendTime = totalStopwatch.Elapsed - backendTime;
+                frontendTime = Stopwatch.GetElapsedTime(startTime) - backendTime;
             }
 
-            AnsiConsole.MarkupLine($"[green]All checks completed successfully in {totalStopwatch.Elapsed.Format()}[/]");
+            AnsiConsole.MarkupLine($"[green]All checks completed successfully in {Stopwatch.GetElapsedTime(startTime).Format()}[/]");
             if (checkBackend && checkFrontend)
             {
                 AnsiConsole.MarkupLine(

--- a/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
+++ b/developer-cli/Commands/ConfigureContinuousDeploymentsCommand.cs
@@ -75,7 +75,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
 
         ConfirmChangesPrompt();
 
-        var startNew = Stopwatch.StartNew();
+        var startTime = Stopwatch.GetTimestamp();
 
         PrintHeader("Configuring Azure and GitHub");
 
@@ -99,7 +99,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
 
         ApplyAdditionalConfigurations();
 
-        PrintHeader($"Configuration of GitHub and Azure completed in {startNew.Elapsed:g} 🎉");
+        PrintHeader($"Configuration of GitHub and Azure completed in {Stopwatch.GetElapsedTime(startTime):g} 🎉");
 
         ShowSuccessMessage();
     }
@@ -469,43 +469,43 @@ public class ConfigureContinuousDeploymentsCommand : Command
              [bold]Please review planned changes before continuing.[/]
 
              1. The following will be created or updated in Azure:
-             
+
                 [bold]Active Directory App Registrations/Service Principals:[/]
                 * [blue]{Config.StagingSubscription.AppRegistration.Name}[/] with access to the [blue]{Config.StagingSubscription.Name}[/] subscription.
                 * [blue]{Config.ProductionSubscription.AppRegistration.Name}[/] with access to the [blue]{Config.ProductionSubscription.Name}[/] subscription.
-             
+
                 [yellow]** The Service Principals will get 'Contributor' and 'User Access Administrator' role on the Azure Subscriptions.[/]
-             
+
                 [bold]Active Directory Security Groups:[/]
                 * [blue]{Config.StagingSubscription.SqlAdminsGroup.Name}[/]
                 * [blue]{Config.ProductionSubscription.SqlAdminsGroup.Name}[/]
-             
+
                 [yellow]** The SQL Admins Security Groups are used to grant Managed Identities and CI/CD permissions to SQL Databases.[/]
 
              2. The following GitHub environments will be created if not exists:
                 * [blue]staging[/]
                 * [blue]production[/]
-             
+
                 [yellow]** Environments are used to require approval when infrastructure is deployed. In private GitHub repositories, this requires a paid plan.[/]
 
              3. The following GitHub repository variables will be created:
-             
+
                 [bold]Shared Variables:[/]
                 * TENANT_ID: [blue]{Config.TenantId}[/]
                 * UNIQUE_PREFIX: [blue]{Config.UniquePrefix}[/]
-             
+
                 [bold]Staging Shared Variables:[/]
                 * STAGING_SUBSCRIPTION_ID: [blue]{Config.StagingSubscription.Id}[/]
                 * STAGING_SHARED_LOCATION: [blue]{Config.StagingLocation.SharedLocation}[/]
                 * STAGING_SERVICE_PRINCIPAL_ID: [blue]{stagingServicePrincipal}[/]
                 * STAGING_SQL_ADMIN_OBJECT_ID: [blue]{stagingSqlAdminObject}[/]
                 * STAGING_DOMAIN_NAME: [blue]-[/] ([yellow]Manually changed this and triggered deployment to set up the domain[/])
-             
+
                 [bold]Staging Cluster Variables:[/]
                 * STAGING_CLUSTER_ENABLED: [blue]true[/]
                 * STAGING_CLUSTER_LOCATION: [blue]{Config.StagingLocation.ClusterLocation}[/]
                 * STAGING_CLUSTER_LOCATION_ACRONYM: [blue]{Config.StagingLocation.ClusterLocationAcronym}[/]
-             
+
                 [bold]Production Shared Variables:[/]
                 * PRODUCTION_SUBSCRIPTION_ID: [blue]{Config.ProductionSubscription.Id}[/]
                 * PRODUCTION_SHARED_LOCATION: [blue]{Config.ProductionLocation.SharedLocation}[/]
@@ -513,12 +513,12 @@ public class ConfigureContinuousDeploymentsCommand : Command
                 * PRODUCTION_SERVICE_PRINCIPAL_OBJECT_ID: [blue]{Config.ProductionSubscription.AppRegistration.ServicePrincipalObjectId}[/]
                 * PRODUCTION_SQL_ADMIN_OBJECT_ID: [blue]{productionSqlAdminObject}[/]
                 * PRODUCTION_DOMAIN_NAME: [blue]-[/] ([yellow]Manually changed this and triggered deployment to set up the domain[/])
-             
+
                 [bold]Production Cluster 1 Variables:[/]
                 * PRODUCTION_CLUSTER1_ENABLED: [blue]false[/] ([yellow]Change this to 'true' when ready to deploy to production[/])
                 * PRODUCTION_CLUSTER1_LOCATION: [blue]{Config.ProductionLocation.ClusterLocation}[/]
                 * PRODUCTION_CLUSTER1_LOCATION_ACRONYM: [blue]{Config.ProductionLocation.ClusterLocationAcronym}[/]
-             
+
                 [yellow]** All variables can be changed on the GitHub Settings page. For example, if you want to deploy production or staging to different locations.[/]
 
              4. Disable the reusable GitHub workflows [blue]Deploy Container[/] and [blue]Plan and Deploy Infrastructure[/].
@@ -889,9 +889,9 @@ public class ConfigureContinuousDeploymentsCommand : Command
              - To add a step for manual approval during infrastructure deployment to the staging and production environments, set up required reviewers on GitHub environments. Visit [blue]{Config.GithubInfo!.Url}/settings/environments[/] and enable [blue]Required reviewers[/] for the [bold]staging[/] and [bold]production[/] environments. Requires a paid GitHub plan for private repositories.
 
              - Configure the Domain Name for the staging and production environments. This involves two steps:
-             
+
                  a. Go to [blue]{Config.GithubInfo!.Url}/settings/variables/actions[/] to set the [blue]DOMAIN_NAME_STAGING[/] and [blue]DOMAIN_NAME_PRODUCTION[/] variables. E.g. [blue]staging.your-saas-company.com[/] and [blue]your-saas-company.com[/].
-             
+
                  b. Run the [blue]Cloud Infrastructure - Deployment[/] workflow again. Note that it might fail with an error message to set up a DNS TXT and CNAME record. Once done, re-run the failed jobs.
 
              - Set up SonarCloud for code quality and security analysis. This service is free for public repositories. Visit [blue]https://sonarcloud.io[/] to connect your GitHub account. Add the [blue]SONAR_TOKEN[/] secret, and the [blue]SONAR_ORGANIZATION[/] and [blue]SONAR_PROJECT_KEY[/] variables to the GitHub repository. The workflows are already configured for SonarCloud analysis.
@@ -927,7 +927,7 @@ public class ConfigureContinuousDeploymentsCommand : Command
                 RedirectStandardOutput = redirectOutput,
                 RedirectStandardError = redirectOutput,
                 UseShellExecute = false,
-                CreateNoWindow = true,
+                CreateNoWindow = true
             },
             exitOnError: false
         );

--- a/developer-cli/Commands/FormatCommand.cs
+++ b/developer-cli/Commands/FormatCommand.cs
@@ -33,7 +33,7 @@ public class FormatCommand : Command
                 AnsiConsole.MarkupLine("[yellow]Warning: You have unstaged changes in your working directory.[/]");
             }
 
-            var totalStopwatch = Stopwatch.StartNew();
+            var startTime = Stopwatch.GetTimestamp();
             var backendTime = TimeSpan.Zero;
             var frontendTime = TimeSpan.Zero;
 
@@ -41,14 +41,14 @@ public class FormatCommand : Command
             {
                 Prerequisite.Ensure(Prerequisite.Dotnet);
                 RunBackendFormat(solutionName);
-                backendTime = totalStopwatch.Elapsed;
+                backendTime = Stopwatch.GetElapsedTime(startTime);
             }
 
             if (formatFrontend)
             {
                 Prerequisite.Ensure(Prerequisite.Node);
                 RunFrontendFormat();
-                frontendTime = totalStopwatch.Elapsed - backendTime;
+                frontendTime = Stopwatch.GetElapsedTime(startTime) - backendTime;
             }
 
             var uncommittedFilesAfterFormat = GitHelper.GetChangedFiles();
@@ -63,7 +63,7 @@ public class FormatCommand : Command
                 AnsiConsole.MarkupLine($"[blue]{string.Join(Environment.NewLine, modifiedFiles)}[/]");
             }
 
-            AnsiConsole.MarkupLine($"[green]Code format completed in {totalStopwatch.Elapsed.Format()}[/]");
+            AnsiConsole.MarkupLine($"[green]Code format completed in {Stopwatch.GetElapsedTime(startTime).Format()}[/]");
             if (formatBackend && formatFrontend)
             {
                 AnsiConsole.MarkupLine(

--- a/developer-cli/Commands/InspectCommand.cs
+++ b/developer-cli/Commands/InspectCommand.cs
@@ -26,7 +26,7 @@ public class InspectCommand : Command
 
         try
         {
-            var totalStopwatch = Stopwatch.StartNew();
+            var startTime = Stopwatch.GetTimestamp();
             var backendTime = TimeSpan.Zero;
             var frontendTime = TimeSpan.Zero;
 
@@ -34,17 +34,17 @@ public class InspectCommand : Command
             {
                 Prerequisite.Ensure(Prerequisite.Dotnet);
                 RunBackendInspections(solutionName, noBuild);
-                backendTime = totalStopwatch.Elapsed;
+                backendTime = Stopwatch.GetElapsedTime(startTime);
             }
 
             if (inspectFrontend)
             {
                 Prerequisite.Ensure(Prerequisite.Node);
                 RunFrontendInspections();
-                frontendTime = totalStopwatch.Elapsed - backendTime;
+                frontendTime = Stopwatch.GetElapsedTime(startTime) - backendTime;
             }
 
-            AnsiConsole.MarkupLine($"[green]Code inspections completed in {totalStopwatch.Elapsed.Format()}[/]");
+            AnsiConsole.MarkupLine($"[green]Code inspections completed in {Stopwatch.GetElapsedTime(startTime).Format()}[/]");
             if (inspectBackend && inspectFrontend)
             {
                 AnsiConsole.MarkupLine(


### PR DESCRIPTION
### Summary & motivation

Time-based tests were failing on Windows machines.

- Use `TimeProvider` in tests to get consistent results and ensure the tests pass reliably
- Replace all usages of `Stopwatch.StartNew()` with `Stopwatch.GetTimestamp()` to reduce allocations and follow the recommended approach

### Downstream projects

Update tests to use `TimeProvider.System.GetUtcNow()` instead of `DateTime.UtcNow()`.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
