### PR TITLE
Improve SQLite extension methods and remove obsolete code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ _ReSharper*/
 
 # Rider
 .idea
+.run
 result.xml
 result.json
 

--- a/application/AppGateway/Middleware/AuthenticationCookieMiddleware.cs
+++ b/application/AppGateway/Middleware/AuthenticationCookieMiddleware.cs
@@ -69,9 +69,7 @@ public class AuthenticationCookieMiddleware(
                 ReplaceAuthenticationHeaderWithCookie(context, refreshToken, accessToken);
             }
 
-            context.Request.Headers.Authorization = context.Request.Path.Value == RefreshAuthenticationTokensEndpoint
-                ? $"Bearer {refreshToken}" // When calling the refresh endpoint, use the refresh token as Bearer
-                : $"Bearer {accessToken}";
+            context.Request.Headers.Authorization = $"Bearer {accessToken}";
         }
         catch (SecurityTokenException ex)
         {

--- a/application/account-management/Tests/Authentication/CompleteLoginTests.cs
+++ b/application/account-management/Tests/Authentication/CompleteLoginTests.cs
@@ -31,7 +31,7 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
 
         // Assert
         await response.ShouldBeSuccessfulPostRequest(hasLocation: false);
-        var updatedLoginCount = Connection.ExecuteScalar(
+        var updatedLoginCount = Connection.ExecuteScalar<long>(
             "SELECT COUNT(*) FROM Logins WHERE Id = @id AND Completed = 1", new { id = loginId.ToString() }
         );
         updatedLoginCount.Should().Be(1);
@@ -79,9 +79,9 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
         await response.ShouldHaveErrorStatusCode(HttpStatusCode.BadRequest, "The code is wrong or no longer valid.");
 
         // Verify retry count increment and event collection
-        var loginCompleted = Connection.ExecuteScalar("SELECT Completed FROM Logins WHERE Id = @id", new { id = loginId.ToString() });
+        var loginCompleted = Connection.ExecuteScalar<long>("SELECT Completed FROM Logins WHERE Id = @id", new { id = loginId.ToString() });
         loginCompleted.Should().Be(0);
-        var updatedRetryCount = Connection.ExecuteScalar("SELECT RetryCount FROM EmailConfirmations WHERE Id = @id", new { id = emailConfirmationId.ToString() });
+        var updatedRetryCount = Connection.ExecuteScalar<long>("SELECT RetryCount FROM EmailConfirmations WHERE Id = @id", new { id = emailConfirmationId.ToString() });
         updatedRetryCount.Should().Be(1);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(2);
@@ -126,11 +126,11 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
         await response.ShouldHaveErrorStatusCode(HttpStatusCode.Forbidden, "Too many attempts, please request a new code.");
 
         // Verify retry count increment and event collection
-        var loginCompleted = Connection.ExecuteScalar(
+        var loginCompleted = Connection.ExecuteScalar<long>(
             "SELECT Completed FROM Logins WHERE Id = @id", new { id = loginId.ToString() }
         );
         loginCompleted.Should().Be(0);
-        var updatedRetryCount = Connection.ExecuteScalar(
+        var updatedRetryCount = Connection.ExecuteScalar<long>(
             "SELECT RetryCount FROM EmailConfirmations WHERE Id = @id", new { id = emailConfirmationId.ToString() }
         );
         updatedRetryCount.Should().Be(4);
@@ -205,7 +205,7 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
         await AnonymousHttpClient.PostAsJsonAsync($"/api/account-management/authentication/login/{loginId}/complete", command);
 
         // Assert
-        Connection.ExecuteScalar(
+        Connection.ExecuteScalar<long>(
             "SELECT COUNT(*) FROM Users WHERE TenantId = @tenantId AND Email = @email AND EmailConfirmed = 1",
             new { tenantId = DatabaseSeeder.Tenant1.Id.ToString(), email = email.ToLower() }
         ).Should().Be(1);

--- a/application/account-management/Tests/Signups/CompleteSignupTests.cs
+++ b/application/account-management/Tests/Signups/CompleteSignupTests.cs
@@ -40,7 +40,7 @@ public sealed class CompleteSignupTests : EndpointBaseTest<AccountManagementDbCo
 
         // Assert
         await response.ShouldBeSuccessfulPostRequest(hasLocation: false);
-        Connection.ExecuteScalar("SELECT COUNT(*) FROM Users WHERE Email = @email", new { email = email.ToLower() }).Should().Be(1);
+        Connection.ExecuteScalar<long>("SELECT COUNT(*) FROM Users WHERE Email = @email", new { email = email.ToLower() }).Should().Be(1);
 
         TelemetryEventsCollectorSpy.CollectedEvents.Count.Should().Be(4);
         TelemetryEventsCollectorSpy.CollectedEvents[0].GetType().Name.Should().Be("SignupStarted");

--- a/application/account-management/Tests/Users/InviteUserTests.cs
+++ b/application/account-management/Tests/Users/InviteUserTests.cs
@@ -26,7 +26,7 @@ public sealed class InviteUserTests : EndpointBaseTest<AccountManagementDbContex
 
         // Assert
         await response.ShouldBeSuccessfulPostRequest(hasLocation: false);
-        Connection.ExecuteScalar(
+        Connection.ExecuteScalar<long>(
             "SELECT COUNT(*) FROM Users WHERE TenantId = @tenantId AND Email = @email AND EmailConfirmed = 0",
             new { tenantId, email = email.ToLower() }
         ).Should().Be(1);

--- a/application/shared-kernel/Tests/Persistence/SqliteConnectionExtensions.cs
+++ b/application/shared-kernel/Tests/Persistence/SqliteConnectionExtensions.cs
@@ -4,7 +4,13 @@ namespace PlatformPlatform.SharedKernel.Tests.Persistence;
 
 public static class SqliteConnectionExtensions
 {
+    [Obsolete("Use ExecuteScalar<long> instead")]
     public static long ExecuteScalar(this SqliteConnection connection, string sql, params object?[] parameters)
+    {
+        return connection.ExecuteScalar<long>(sql, parameters);
+    }
+
+    public static T ExecuteScalar<T>(this SqliteConnection connection, string sql, params object?[] parameters)
     {
         using var command = new SqliteCommand(sql, connection);
 
@@ -16,17 +22,20 @@ public static class SqliteConnectionExtensions
             }
         }
 
-        return (long)command.ExecuteScalar()!;
+        var result = command.ExecuteScalar();
+        return result is DBNull ? default! : (T)result!;
     }
 
     public static bool RowExists(this SqliteConnection connection, string tableName, string id)
     {
-        return connection.ExecuteScalar($"SELECT COUNT(*) FROM {tableName} WHERE Id = @id", new { id }) == 1;
+        object?[] parameters = [new { id }];
+        return connection.ExecuteScalar<long>($"SELECT COUNT(*) FROM {tableName} WHERE Id = @id", parameters) == 1;
     }
 
     public static bool RowExists(this SqliteConnection connection, string tableName, long id)
     {
-        return connection.ExecuteScalar($"SELECT COUNT(*) FROM {tableName} WHERE Id = @id", new { id }) == 1;
+        object?[] parameters = [new { id }];
+        return connection.ExecuteScalar<long>($"SELECT COUNT(*) FROM {tableName} WHERE Id = @id", parameters) == 1;
     }
 
     public static void Insert(this SqliteConnection connection, string tableName, (string, object?)[] columns)
@@ -35,6 +44,51 @@ public static class SqliteConnectionExtensions
         var columnsValues = string.Join(", ", columns.Select(c => "@" + c.Item1));
         var insertCommandText = $"INSERT INTO {tableName} ({columnsNames}) VALUES ({columnsValues})";
         using var command = new SqliteCommand(insertCommandText, connection);
+        foreach (var column in columns)
+        {
+            var valueType = column.Item2?.GetType();
+
+            var sqliteType = valueType switch
+            {
+                not null when valueType == typeof(int) => SqliteType.Integer,
+                not null when valueType == typeof(long) => SqliteType.Integer,
+                not null when valueType == typeof(bool) => SqliteType.Integer,
+                not null when valueType == typeof(double) => SqliteType.Real,
+                not null when valueType == typeof(float) => SqliteType.Real,
+                not null when valueType == typeof(decimal) => SqliteType.Real,
+                not null when valueType == typeof(byte[]) => SqliteType.Blob,
+                not null when valueType == typeof(string) => SqliteType.Text,
+                not null when valueType == typeof(DateTime) => SqliteType.Text, // SQLite stores dates as text
+                not null when valueType == typeof(Guid) => SqliteType.Text, // Store GUIDs as text
+                null => SqliteType.Text, // Handle null values by setting SqliteType to Text
+                _ => SqliteType.Text // Default to Text if the type is unknown
+            };
+            var parameter = new SqliteParameter($"@{column.Item1}", sqliteType) { Value = column.Item2 ?? DBNull.Value };
+            command.Parameters.Add(parameter);
+        }
+
+        command.ExecuteNonQuery();
+    }
+
+    public static void Update(this SqliteConnection connection, string tableName, string idColumnName, object idValue, (string, object?)[] columns)
+    {
+        var setClause = string.Join(", ", columns.Select(c => $"{c.Item1} = @{c.Item1}"));
+        var updateCommandText = $"UPDATE {tableName} SET {setClause} WHERE {idColumnName} = @{idColumnName}";
+
+        using var command = new SqliteCommand(updateCommandText, connection);
+
+        // Add ID parameter
+        var idValueType = idValue.GetType();
+        var idSqliteType = idValueType switch
+        {
+            not null when idValueType == typeof(int) => SqliteType.Integer,
+            not null when idValueType == typeof(long) => SqliteType.Integer,
+            _ => SqliteType.Text
+        };
+        var idParameter = new SqliteParameter($"@{idColumnName}", idSqliteType) { Value = idValue };
+        command.Parameters.Add(idParameter);
+
+        // Add column parameters
         foreach (var column in columns)
         {
             var valueType = column.Item2?.GetType();

--- a/application/shared-kernel/Tests/Persistence/SqliteConnectionExtensions.cs
+++ b/application/shared-kernel/Tests/Persistence/SqliteConnectionExtensions.cs
@@ -60,4 +60,11 @@ public static class SqliteConnectionExtensions
 
         command.ExecuteNonQuery();
     }
+
+    public static void Delete(this SqliteConnection connection, string tableName, string id)
+    {
+        using var command = new SqliteCommand($"DELETE FROM {tableName} WHERE Id = @id", connection);
+        command.Parameters.AddWithValue("@id", id);
+        command.ExecuteNonQuery();
+    }
 }

--- a/developer-cli/Utilities/GitHelper.cs
+++ b/developer-cli/Utilities/GitHelper.cs
@@ -131,9 +131,12 @@ public static class GitHelper
     public static Dictionary<string, string> GetChangedFiles()
     {
         var status = ProcessHelper.StartProcess("git status --porcelain", Configuration.SourceCodeFolder, true);
-        return status.Split('\n', StringSplitOptions.RemoveEmptyEntries)
-            .Select(line => line.Substring(3)) // Skip the status flags (first 3 characters)
-            .ToDictionary(file => file.Replace(Configuration.SourceCodeFolder, ""), GetFileHash);
+        var changedFiles = status
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Where(f => !f.EndsWith('/') && !f.EndsWith('\\'))
+            .Select(line => line[3..].Trim());
+
+        return changedFiles.ToDictionary(file => file.Replace(Configuration.SourceCodeFolder, ""), GetFileHash);
 
         string GetFileHash(string file)
         {


### PR DESCRIPTION
### Summary & Motivation

Update SQLite extension methods to improve type safety and add new functionality for tests:

- Add `Update` method for modifying existing rows with proper type handling
- Add `Delete` method for removing rows from SQLite tables
- Add `ExecuteScalar<T>` generic method to allow strong typing of SQL query results
- Mark the old `ExecuteScalar` method as obsolete to encourage migration to the generic version

Additional improvements:
- Fix bug in `GitHelper.GetChangedFiles()` to properly handle empty directories
- Add `.run` directory used by JetBrains Rider to `.gitignore`
- Remove obsolete check for refresh token in `AuthenticationCookieMiddleware`


### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
