### PR TITLE
Fix Biome formatter configuration and add symbolic link for editor integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,7 @@
   "githubIssues.issueBranchTitle": "${issueNumber}-${sanitizedLowercaseIssueTitle}",
   "githubPullRequests.assignCreated": "${user}",
   "dotnet.defaultSolution": "application/PlatformPlatform.slnx",
-  "biome.lspBin": "./application/node_modules/.bin/workspace-biome",
+  "biome.lspBin": "./application/node_modules/.bin/biome",
   "biome.searchInPath": false,
   "biome.enabled": true,
 }

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,1 @@
+application/biome.json


### PR DESCRIPTION
### Summary & Motivation

Fix the issue with Biome code formatting when working with tools like VS Code, Cursor, and Windsurf from the root of the mono repository. Since Biome settings is located under `application/biome.json`, Biome used default settings, including tabs instead of spaces.

- Add symbolic link to `biome.json` in the repository root that points to `application/biome.json`, ensuring code editors can locate the configuration when the root directory is opened.
- Correct the `biome.lspBin` path in VS Code settings from `./application/node_modules/.bin/workspace-biome` to `./application/node_modules/.bin/biome`, addressing an invalid path that prevented the Biome language server from functioning properly.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary