### PR TITLE
Check SSL certificate expiration and renew automatically in Aspire AppHost

### DIFF
--- a/application/AppHost/SslCertificateManager.cs
+++ b/application/AppHost/SslCertificateManager.cs
@@ -22,7 +22,12 @@ public static class SslCertificateManager
         var certificateLocation = GetCertificateLocation("localhost");
         try
         {
-            X509CertificateLoader.LoadPkcs12FromFile(certificateLocation, certificatePassword);
+            var certificate2 = X509CertificateLoader.LoadPkcs12FromFile(certificateLocation, certificatePassword);
+            if (certificate2.NotAfter < DateTime.UtcNow)
+            {
+                Console.WriteLine($"Certificate {certificateLocation} is expired. Creating a new certificate.");
+                CreateNewSelfSignedDeveloperCertificate(certificateLocation, certificatePassword);
+            }
         }
         catch (CryptographicException)
         {


### PR DESCRIPTION
### Summary & Motivation

Add certificate expiration check in the Aspire AppHost to prevent startup failures due to expired SSL certificates. Previously, if the localhost certificate expired, the application would fail to start without a clear error message or automatic recovery.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary