### PR TITLE
Restore logic to invalidate all queries globally after a successful mutation

### DIFF
--- a/application/shared-webapp/infrastructure/http/queryClient.ts
+++ b/application/shared-webapp/infrastructure/http/queryClient.ts
@@ -39,7 +39,6 @@ function createHttpMiddleware() {
       const signal = abortController.signal;
       return new Request(request, { signal });
     },
-
     onResponse: async ({ response }: { request: Request; response: Response }) => {
       if (!response.ok) {
         // Process error directly through handleError to ensure validation errors are properly handled
@@ -49,7 +48,6 @@ function createHttpMiddleware() {
 
       return response;
     },
-
     onRequestError: async ({ error }: { error: unknown; request: Request }) => {
       // Process error directly through handleError to ensure validation errors are properly handled
       const processedError = await handleError(error);
@@ -77,6 +75,9 @@ export const queryClient = new QueryClient({
     }
   }),
   mutationCache: new MutationCache({
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+    },
     onError: (error: unknown) => {
       handleError(error);
     }


### PR DESCRIPTION
### Summary & Motivation

Fix a bug introduced in the previous change where query cache invalidation did not occur automatically after a successful mutation. This resulted in stale UI state after mutations (`POST`, `PUT`, `DELETE`).

- Add an `onSuccess` handler to the MutationCache configuration to automatically invalidate all queries on mutation success

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
