### PR TITLE
Add option to use Azure OpenAI for translations

### DIFF
--- a/developer-cli/DeveloperCli.csproj
+++ b/developer-cli/DeveloperCli.csproj
@@ -12,6 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
         <PackageReference Include="Azure.Identity" Version="1.13.2" />
         <PackageReference Include="Azure.ResourceManager" Version="1.13.0" />
         <PackageReference Include="Bogus" Version="35.6.1" />


### PR DESCRIPTION
### Summary & Motivation

Add support for Azure OpenAI as an alternative to standard OpenAI for translations in the Developer CLI.

- Add Azure OpenAI client integration for custom endpoints
- Enhance API key validation to support both standard OpenAI (sk-...) and Azure OpenAI keys
- Add interactive prompt for Azure OpenAI endpoint URL when Azure key is detected
- Store Azure OpenAI endpoint in secrets alongside the API key

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
