### PR TITLE
Show error toasts only for unhandled errors

### DIFF
--- a/application/account-management/WebApp/bootstrap.tsx
+++ b/application/account-management/WebApp/bootstrap.tsx
@@ -1,6 +1,7 @@
 import "@repo/ui/tailwind.css";
 import { router } from "@/shared/lib/router/router";
 import { ApplicationInsightsProvider } from "@repo/infrastructure/applicationInsights/ApplicationInsightsProvider";
+import { setupGlobalErrorHandlers } from "@repo/infrastructure/http/errorHandler";
 import { Translation } from "@repo/infrastructure/translations/Translation";
 import { GlobalToastRegion } from "@repo/ui/components/Toast";
 import { RouterProvider } from "@tanstack/react-router";
@@ -16,6 +17,8 @@ const rootElement = document.getElementById("root");
 if (!rootElement) {
   throw new Error("Root element not found.");
 }
+
+setupGlobalErrorHandlers();
 
 reactDom.createRoot(rootElement).render(
   <React.StrictMode>

--- a/application/back-office/WebApp/bootstrap.tsx
+++ b/application/back-office/WebApp/bootstrap.tsx
@@ -1,6 +1,7 @@
 import "@repo/ui/tailwind.css";
 import { router } from "@/shared/lib/router/router";
 import { ApplicationInsightsProvider } from "@repo/infrastructure/applicationInsights/ApplicationInsightsProvider";
+import { setupGlobalErrorHandlers } from "@repo/infrastructure/http/errorHandler";
 import { Translation } from "@repo/infrastructure/translations/Translation";
 import { GlobalToastRegion } from "@repo/ui/components/Toast";
 import { RouterProvider } from "@tanstack/react-router";
@@ -16,6 +17,8 @@ const rootElement = document.getElementById("root");
 if (!rootElement) {
   throw new Error("Root element not found.");
 }
+
+setupGlobalErrorHandlers();
 
 reactDom.createRoot(rootElement).render(
   <React.StrictMode>

--- a/application/shared-webapp/infrastructure/http/errorHandler.ts
+++ b/application/shared-webapp/infrastructure/http/errorHandler.ts
@@ -6,6 +6,7 @@
  * 2. Converts HTTP responses and errors into strongly-typed error objects
  * 3. Manages user-facing error notifications with appropriate styling
  * 4. Used by both httpClient.ts and queryClient.ts to ensure consistent error handling
+ * 5. Shows toast notifications to the user for unhandled errors
  */
 import { toastQueue } from "@repo/ui/components/Toast";
 
@@ -19,17 +20,23 @@ interface ProblemDetails {
   traceId?: string;
 }
 
-interface ServerError {
+export interface ServerError extends Error {
   kind: "server";
   status: number;
   problemDetails?: ProblemDetails;
 }
 
-interface ValidationError {
+export interface ValidationError extends Error {
   kind: "validation";
   errors: Record<string, string[]>;
   traceId?: string;
 }
+
+export interface TimeoutError extends Error {
+  kind: "timeout";
+}
+
+export type HttpError = ServerError | ValidationError | TimeoutError;
 
 interface ErrorMessage {
   title: string;
@@ -51,8 +58,8 @@ const getServerErrorMessage = (status: number): ErrorMessage => {
     };
   }
 
-  // Generic 5xx error
-  if (status >= 500) {
+  // Generic 5xx error or unknown errors
+  if (status >= 500 || status === 0) {
     return {
       title: "Server Error",
       detail: "The server encountered an error. Please try again later."
@@ -86,9 +93,6 @@ function getToastVariant(status: number): ToastVariant {
   return { variant: "warning", duration: 5000 }; // 5 seconds for warning
 }
 
-/**
- * Displays a toast notification for network timeout errors
- */
 function showTimeoutToast(): void {
   toastQueue.add({
     title: "Network Error",
@@ -97,10 +101,15 @@ function showTimeoutToast(): void {
   });
 }
 
-/**
- * Displays a toast notification for server errors with appropriate styling
- */
-function showErrorToast(error: ServerError): void {
+function showUnknownErrorToast(error: Error) {
+  toastQueue.add({
+    title: "Unknown Error",
+    description: `An unknown error occured (${error})`,
+    variant: "danger"
+  });
+}
+
+function showServerErrorToast(error: ServerError) {
   // Skip showing toast for 401 errors (handled by AuthenticationMiddleware)
   if (error.status === 401) {
     return;
@@ -129,10 +138,45 @@ function showErrorToast(error: ServerError): void {
 }
 
 /**
+ * Displays a toast notification for server errors with appropriate styling
+ */
+export function showErrorToast(error: HttpError): void {
+  if (error.kind === "timeout") {
+    showTimeoutToast();
+  } else if (error.kind === "server") {
+    showServerErrorToast(error);
+  } else if (error.kind !== "validation") {
+    showUnknownErrorToast(error);
+  }
+}
+
+function createServerError(status = 0, problemDetails?: ProblemDetails) {
+  const serverError = new Error("An unexpected error occurred") as ServerError;
+  serverError.kind = "server";
+  serverError.status = status;
+  serverError.problemDetails = problemDetails;
+  return serverError;
+}
+
+function createTimeoutError() {
+  const timeoutError = new Error("Request timeout") as TimeoutError;
+  timeoutError.kind = "timeout";
+  return timeoutError;
+}
+
+function createValidationError(errors: Record<string, string[]>, traceId?: string) {
+  const validationError = new Error("Validation error") as ValidationError;
+  validationError.kind = "validation";
+  validationError.errors = errors;
+  validationError.traceId = traceId;
+  return validationError;
+}
+
+/**
  * Processes HTTP error responses and converts them to typed error objects
  * Attempts to parse JSON response body and extract ProblemDetails information
  */
-async function handleHttpResponseError(response: Response): Promise<Error> {
+async function normalizeHttpResponseError(response: Response): Promise<HttpError> {
   try {
     // Attempt to parse response as JSON
     const data = await response.clone().json();
@@ -141,40 +185,27 @@ async function handleHttpResponseError(response: Response): Promise<Error> {
     if (typeof data === "object" && data !== null && "type" in data && "title" in data && "status" in data) {
       // Check if it's a validation error
       if (data.errors && Object.keys(data.errors).length > 0) {
-        const validationError = new Error("Validation error") as Error & ValidationError;
-        validationError.kind = "validation";
-        validationError.errors = data.errors;
-        validationError.traceId = data.traceId;
-        return validationError;
+        return createValidationError(data.errors, data.traceId);
       }
 
       // Regular server error with ProblemDetails
-      const serverError = new Error(data.title ?? "Server error") as Error & ServerError;
-      serverError.kind = "server";
-      serverError.status = response.status;
-      serverError.problemDetails = data;
-      showErrorToast(serverError);
-      return serverError;
+      return createServerError(response.status, data);
     }
   } catch {
     // JSON parsing failed, continue to default error handling
   }
 
-  const serverError = new Error("Server error") as Error & ServerError;
-  serverError.kind = "server";
-  serverError.status = response.status;
-  showErrorToast(serverError);
-  return serverError;
+  return createServerError(response.status);
 }
 
 /**
- * Central error handler that processes all error types and shows appropriate notifications
+ * Convert errors during HTTP communication into a normalized HttpError type.
  * Handles HTTP responses, network errors, and already processed errors
  */
-export async function handleError(errorOrResponse: unknown): Promise<Error> {
+export async function normalizeError(errorOrResponse: unknown): Promise<Error | HttpError> {
   // Process HTTP error responses (non-2xx status codes)
   if (errorOrResponse instanceof Response) {
-    return await handleHttpResponseError(errorOrResponse);
+    return await normalizeHttpResponseError(errorOrResponse);
   }
 
   // Handle network timeout errors and AbortController errors
@@ -182,8 +213,7 @@ export async function handleError(errorOrResponse: unknown): Promise<Error> {
     errorOrResponse instanceof DOMException &&
     (errorOrResponse.name === "TimeoutError" || errorOrResponse.name === "AbortError")
   ) {
-    showTimeoutToast();
-    return new Error("Request timeout");
+    return createTimeoutError();
   }
 
   // Check for Safari-specific timeout errors
@@ -192,20 +222,18 @@ export async function handleError(errorOrResponse: unknown): Promise<Error> {
     (errorOrResponse.message?.includes("The operation couldn't be completed") ||
       errorOrResponse.message?.includes("The network connection was lost"))
   ) {
-    showTimeoutToast();
-    return new Error("Request timeout");
+    return createTimeoutError();
   }
 
   // Check for "Failed to fetch" errors (works in Chrome/Firefox/Edge)
   if (errorOrResponse instanceof TypeError && errorOrResponse.message?.includes("Failed to fetch")) {
-    showTimeoutToast();
-    return new Error("Request timeout");
+    return createTimeoutError();
   }
 
   // Return errors that have already been processed (have a 'kind' property)
   if (typeof errorOrResponse === "object" && errorOrResponse !== null && "kind" in errorOrResponse) {
-    // These are our custom error types (ServerError or ValidationError)
-    return errorOrResponse as unknown as Error;
+    // These are our custom error types
+    return errorOrResponse as unknown as HttpError;
   }
 
   // If it's already an Error instance, return it directly
@@ -214,8 +242,29 @@ export async function handleError(errorOrResponse: unknown): Promise<Error> {
   }
 
   // Handle any other unknown errors
-  const serverError = new Error("An unexpected error occurred") as Error & ServerError;
-  serverError.kind = "server";
-  showErrorToast(serverError);
-  return serverError;
+  return createServerError();
+}
+
+export function setupGlobalErrorHandlers() {
+  // Handle uncaught promise rejections
+  window.addEventListener("unhandledrejection", (event) => {
+    event.preventDefault();
+    console.error("[Global error handler] Unhandled promise rejection:", event.reason);
+
+    if (event.reason) {
+      showErrorToast(event.reason);
+    }
+  });
+
+  // Handle uncaught exceptions
+  window.addEventListener("error", (event) => {
+    event.preventDefault();
+    console.error("[Global error handler] Uncaught exception:", event.error);
+
+    if (event.error) {
+      showErrorToast(event.error);
+    }
+
+    return true; // Needed specifically for the error event, to stop propagation
+  });
 }

--- a/application/shared-webapp/infrastructure/http/errorHandler.ts
+++ b/application/shared-webapp/infrastructure/http/errorHandler.ts
@@ -145,7 +145,7 @@ export function showErrorToast(error: HttpError): void {
     showTimeoutToast();
   } else if (error.kind === "server") {
     showServerErrorToast(error);
-  } else if (error.kind !== "validation") {
+  } else {
     showUnknownErrorToast(error);
   }
 }

--- a/application/shared-webapp/infrastructure/http/httpClient.ts
+++ b/application/shared-webapp/infrastructure/http/httpClient.ts
@@ -8,7 +8,7 @@
  *
  * Use this module when working with endpoints that don't have OpenAPI/strongly-typed definitions
  */
-import { handleError } from "./errorHandler";
+import { normalizeError } from "./errorHandler";
 
 // Default timeout for all fetch requests (in milliseconds)
 export const DEFAULT_TIMEOUT = 30000;
@@ -50,12 +50,11 @@ export async function enhancedFetch(input: RequestInfo | URL, init?: RequestInit
     const response = await window.fetch(input, enhancedInit);
 
     if (!response.ok) {
-      throw await handleError(response);
+      throw await normalizeError(response);
     }
 
     return response;
   } catch (error) {
-    // Process any errors through the central error handler
-    throw await handleError(error);
+    throw await normalizeError(error);
   }
 }

--- a/application/shared-webapp/infrastructure/http/queryClient.ts
+++ b/application/shared-webapp/infrastructure/http/queryClient.ts
@@ -65,7 +65,19 @@ export const queryClient = new QueryClient({
       retry: false
     },
     mutations: {
-      retry: false
+      retry: false,
+      // Mutations can override this error handler if custom error handling is needed.
+      onError: (error: unknown) => {
+        // Validation errors in mutations should be handled by UI
+        const httpError = error as HttpError;
+        if (httpError.kind === "validation") {
+          return;
+        }
+
+        // Re-throwing using "throw" does not bubble the error to the global error handler.
+        // We use an unhandled promise rejection instead:
+        Promise.reject(error);
+      }
     }
   },
   queryCache: new QueryCache({
@@ -76,14 +88,6 @@ export const queryClient = new QueryClient({
   mutationCache: new MutationCache({
     onSuccess: () => {
       queryClient.invalidateQueries();
-    },
-    onError: (error: unknown) => {
-      // Validation errors in mutations should be handled by UI
-      const httpError = error as HttpError;
-      if (httpError.kind === "validation") {
-        return;
-      }
-      throw error;
     }
   })
 });


### PR DESCRIPTION
### Summary & Motivation

Changes error handling to allow application code to catch and handle errors, overriding the error handling, which shows toast notifications to the user. Toasts are no longer shown in `handleError`, but instead from a global error handler that catches unhandled exceptions.

Validation errors (HTTP 400) are now only suppressed in mutations. Furthermore, mutations can override error handling by specifying a custom `onError` handler.

### Downstream projects

Global error handling needs to be enabled in each frontend project. Edit `bootstrap.tsx`, adding a call to `setupGlobalErrorHandlers` before the `reactDom.createRoot` line:

```diff
+import { setupGlobalErrorHandlers } from "@repo/infrastructure/http/errorHandler";
...
+setupGlobalErrorHandlers();
+
reactDom.createRoot(rootElement).render(
```

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
