### PR TITLE
Use full PropertyName in validation errors

### DIFF
--- a/application/account-management/Tests/Authentication/StartLoginTests.cs
+++ b/application/account-management/Tests/Authentication/StartLoginTests.cs
@@ -53,7 +53,7 @@ public sealed class StartLoginTests : EndpointBaseTest<AccountManagementDbContex
         // Assert
         var expectedErrors = new[]
         {
-            new ErrorDetail("Email", "'Email' must not be empty.")
+            new ErrorDetail("email", "'Email' must not be empty.")
         };
         await response.ShouldHaveErrorStatusCode(HttpStatusCode.BadRequest, expectedErrors);
 
@@ -75,7 +75,7 @@ public sealed class StartLoginTests : EndpointBaseTest<AccountManagementDbContex
         // Assert
         var expectedErrors = new[]
         {
-            new ErrorDetail("Email", "Email must be in a valid format and no longer than 100 characters.")
+            new ErrorDetail("email", "Email must be in a valid format and no longer than 100 characters.")
         };
         await response.ShouldHaveErrorStatusCode(HttpStatusCode.BadRequest, expectedErrors);
 

--- a/application/account-management/Tests/Signups/StartSignupTests.cs
+++ b/application/account-management/Tests/Signups/StartSignupTests.cs
@@ -58,7 +58,7 @@ public sealed class StartSignupTests : EndpointBaseTest<AccountManagementDbConte
         // Assert
         var expectedErrors = new[]
         {
-            new ErrorDetail("Email", "Email must be in a valid format and no longer than 100 characters.")
+            new ErrorDetail("email", "Email must be in a valid format and no longer than 100 characters.")
         };
         await response.ShouldHaveErrorStatusCode(HttpStatusCode.BadRequest, expectedErrors);
 

--- a/application/shared-kernel/SharedKernel/PipelineBehaviors/ValidationPipelineBehavior.cs
+++ b/application/shared-kernel/SharedKernel/PipelineBehaviors/ValidationPipelineBehavior.cs
@@ -27,7 +27,7 @@ public sealed class ValidationPipelineBehavior<TRequest, TResponse>(IEnumerable<
             var errorDetails = validationResults
                 .SelectMany(result => result.Errors)
                 .Where(failure => failure is not null)
-                .Select(failure => new ErrorDetail(failure.PropertyName.Split('.')[0], failure.ErrorMessage))
+                .Select(failure => new ErrorDetail(failure.PropertyName, failure.ErrorMessage))
                 .Distinct()
                 .ToArray();
 

--- a/application/shared-kernel/SharedKernel/Validation/SharedValidations.cs
+++ b/application/shared-kernel/SharedKernel/Validation/SharedValidations.cs
@@ -9,13 +9,12 @@ public static class SharedValidations
         // While emails can be longer, we will limit them to 100 characters which should be enough for most cases
         private const int EmailMaxLength = 100;
 
-        public Email(string emailName = nameof(Email))
+        public Email()
         {
             const string errorMessage = "Email must be in a valid format and no longer than 100 characters.";
 
             RuleFor(email => email)
                 .EmailAddress()
-                .WithName(emailName)
                 .WithMessage(errorMessage)
                 .MaximumLength(EmailMaxLength)
                 .WithMessage(errorMessage)


### PR DESCRIPTION
### Summary & Motivation

Removes splitting of the `PropertyName` when creating the `ErrrorDetail` during validation of APIs.
This way we can use React Aria validation on complex forms.
For example, for an API command like:
```C#
[PublicAPI]
public sealed record UpdateUserFriendsCommand : ICommand, IRequest<Result>
{
    [JsonIgnore]
    public UserId Id { get; init; } = null!;

    public required FriendRequest[] Friends { get; init; } = [];
}

[PublicAPI]
public sealed record FriendRequest(
    UserId UserId,
    string Nickname 
);

public sealed class UpdateUserFriendsValidator : AbstractValidator<UpdateUserFriendsCommand>
{
    public UpdateUserFriendsValidator()
    {
        RuleForEach(x => x.Friends).ChildRules(friend =>
            {
                friend.RuleFor(f => f.Nickname)
                    .MaximumLength(100)
                    .WithMessage("Nickname must be no longer than 100 characters.");
            }
        );
    }
}
```
When the API request has the first "friend" with a "nickname" longer than 100 characters, the error detail will be like so:
```C#
new ErrorDetail("friends[0].Nickname", "Nickname must be no longer than 100 characters."),
```
Making it possible for the front-end to use `validationBehavior="aria"` for complex forms, like so:
```js
<TextField
  name={`friends[${index}].Nickname`}
  ...
/>
```

Updates the shared Email validation to remove the unused `emailName` parameter that caused the `PropertyName` to be: `email.email`.
Lower-cases the key `email` to align with the other tests.

### Downstream projects

If you have added complex form commands like the example above to your self-contained system follow these instructions:
 - Update the `ErrorDetail` in the tests
 - Update the front-end forms to use the full `PropertyName`:
```js
<TextField
  name="<PropertyName>"
  ...
/>
```

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
