### PR TITLE
Resolve principalId inside diagnostic module to avoid cross-scope reference error

### DIFF
--- a/cloud-infrastructure/cluster/main-cluster.bicep
+++ b/cloud-infrastructure/cluster/main-cluster.bicep
@@ -120,7 +120,6 @@ module microsoftSqlDerverDiagnosticConfiguration '../modules/microsoft-sql-serve
   params: {
     diagnosticStorageAccountName: diagnosticStorageAccountName
     microsoftSqlServerName: resourceGroupName
-    principalId: microsoftSqlServer.outputs.principalId
     dianosticStorageAccountBlobEndpoint: diagnosticStorageAccount.outputs.blobEndpoint
     dianosticStorageAccountSubscriptionId: subscription().subscriptionId
   }

--- a/cloud-infrastructure/modules/microsoft-sql-server-diagnostic.bicep
+++ b/cloud-infrastructure/modules/microsoft-sql-server-diagnostic.bicep
@@ -1,19 +1,20 @@
 param diagnosticStorageAccountName string
 param microsoftSqlServerName string
-param principalId string
 param dianosticStorageAccountSubscriptionId string
 param dianosticStorageAccountBlobEndpoint string
 
-module diagnosticStorageBlobDataContributorRoleAssignment 'role-assignments-storage-blob-data-contributor.bicep' = if (principalId != '') {
+resource existingMicrosoftSqlServer 'Microsoft.Sql/servers@2023-05-01-preview' existing = {
+  name: microsoftSqlServerName
+}
+
+var contributorPrincipalId = existingMicrosoftSqlServer.identity.principalId
+
+module diagnosticStorageBlobDataContributorRoleAssignment './role-assignments-storage-blob-data-contributor.bicep' = {
   name: '${microsoftSqlServerName}-microsoft-sql-server-blob-contributer'
   params: {
     storageAccountName: diagnosticStorageAccountName
-    principalId: principalId
+    principalId: contributorPrincipalId
   }
-}
-
-resource existingMicrosoftSqlServer 'Microsoft.Sql/servers@2023-05-01-preview' existing = {
-  name: microsoftSqlServerName
 }
 
 resource microsoftSqlServerOutboundFirewallRules 'Microsoft.Sql/servers/outboundFirewallRules@2023-05-01-preview' = {


### PR DESCRIPTION
### Summary & Motivation

Resolve `principalId` inside the diagnostics module to eliminate the cross-scope `reference()` error during deployment.
This fixes [this cloud infrastructure error](https://github.com/platformplatform/PlatformPlatform/actions/runs/16051114349/job/45293755354).

- Remove the `principalId` parameter from the diagnostics module interface.  
- Retrieve the `principalId` internally within the module, ensuring all references stay within the same scope.  
- Update calling templates to reflect the revised module signature.

### Checklist

- [x] I have added tests, or done manual regression tests  
- [x] I have updated the documentation, if necessary