### PR TITLE
Add watch CLI command to manage Aspire AppHost lifecycle

### DIFF
--- a/developer-cli/Commands/WatchCommand.cs
+++ b/developer-cli/Commands/WatchCommand.cs
@@ -1,0 +1,173 @@
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using PlatformPlatform.DeveloperCli.Installation;
+using PlatformPlatform.DeveloperCli.Utilities;
+using Spectre.Console;
+
+namespace PlatformPlatform.DeveloperCli.Commands;
+
+/// <summary>
+///     Command to manage Aspire AppHost lifecycle - start, stop, and monitor the application host.
+/// </summary>
+public class WatchCommand : Command
+{
+    private const int AspirePort = 9001;
+    private const int DashboardPort = 9097;
+    private const int ResourceServicePort = 9098;
+
+    public WatchCommand() : base("watch", "Manages Aspire AppHost operations")
+    {
+        AddOption(new Option<bool>(["--force"], "Force start a fresh Aspire AppHost instance, stopping any existing one"));
+        AddOption(new Option<bool>(["--stop"], "Stop any running Aspire AppHost instance without starting a new one"));
+        AddOption(new Option<bool>(["--attach", "-a"], "Keep the CLI process attached to the Aspire process"));
+        AddOption(new Option<bool>(["--detach", "-d"], "Run the Aspire process in detached mode (background)"));
+
+        Handler = CommandHandler.Create<bool, bool, bool, bool>(Execute);
+    }
+
+    private static void Execute(bool force, bool stop, bool attach, bool detach)
+    {
+        Prerequisite.Ensure(Prerequisite.Dotnet, Prerequisite.Node, Prerequisite.Docker);
+
+        var isRunning = IsAspireRunning();
+
+        if (stop)
+        {
+            if (!IsAspireRunning())
+            {
+                AnsiConsole.MarkupLine("[yellow]No Aspire AppHost instance is running.[/]");
+                Environment.Exit(1);
+            }
+
+            StopAspire();
+            return;
+        }
+
+        // Validate that either --attach or --detach is specified (but not both)
+        if (attach == detach)
+        {
+            AnsiConsole.MarkupLine("[red]You must specify either --attach (-a) or --detach (-d) mode.[/]");
+            Environment.Exit(1);
+        }
+
+        if (isRunning)
+        {
+            if (!force)
+            {
+                AnsiConsole.MarkupLine($"[yellow]Aspire AppHost is already running on port {AspirePort}. Use --force to force a fresh start or --stop to stop it.[/]");
+                Environment.Exit(1);
+            }
+
+            StopAspire();
+        }
+
+        StartAspireAppHost(attach);
+    }
+
+    private static bool IsAspireRunning()
+    {
+        // Check the main Aspire port
+        var portCheckCommand = Configuration.IsWindows
+            ? $"netstat -ano | findstr :{AspirePort} | findstr LISTENING"
+            : $"lsof -i :{AspirePort} -sTCP:LISTEN -t";
+
+        var result = ProcessHelper.StartProcess(portCheckCommand, redirectOutput: true, exitOnError: false);
+        if (!string.IsNullOrWhiteSpace(result))
+        {
+            return true;
+        }
+        
+        // Also check if there are any dotnet watch processes running AppHost
+        if (Configuration.IsWindows)
+        {
+            // Check if any dotnet.exe processes are running with AppHost in the command line
+            var watchProcesses = ProcessHelper.StartProcess("wmic process where \"name='dotnet.exe' and commandline like '%watch%AppHost%'\" get processid", redirectOutput: true, exitOnError: false);
+            return !string.IsNullOrWhiteSpace(watchProcesses) && watchProcesses.Contains("ProcessId");
+        }
+        else
+        {
+            var watchProcesses = ProcessHelper.StartProcess("pgrep -f dotnet.*watch.*AppHost", redirectOutput: true, exitOnError: false);
+            return !string.IsNullOrWhiteSpace(watchProcesses);
+        }
+    }
+
+    private static void StopAspire()
+    {
+        AnsiConsole.MarkupLine("[blue]Stopping Aspire AppHost and all related services...[/]");
+
+        var applicationFolder = Configuration.ApplicationFolder;
+
+        if (Configuration.IsWindows)
+        {
+            // Use taskkill with filters to kill processes
+            // This approach is simpler and more reliable than WMIC
+            
+            // Kill all dotnet.exe processes that have AppHost in their command line
+            ProcessHelper.StartProcess("taskkill /F /IM dotnet.exe /FI \"WINDOWTITLE eq *AppHost*\"", redirectOutput: true, exitOnError: false);
+            
+            // Kill all processes that contain our application folder in the command line
+            // Note: Windows doesn't have a direct equivalent to pkill -f, so we use WMIC for this specific case
+            ProcessHelper.StartProcess($"wmic process where \"commandline like '%{applicationFolder}%'\" delete", redirectOutput: true, exitOnError: false);
+            
+            // Kill specific Aspire and watch processes
+            ProcessHelper.StartProcess("taskkill /F /IM dotnet.exe /FI \"WINDOWTITLE eq *watch*\"", redirectOutput: true, exitOnError: false);
+            ProcessHelper.StartProcess("taskkill /F /IM dotnet.exe /FI \"WINDOWTITLE eq *Aspire*\"", redirectOutput: true, exitOnError: false);
+            ProcessHelper.StartProcess("taskkill /F /IM dotnet.exe /FI \"WINDOWTITLE eq *Dashboard*\"", redirectOutput: true, exitOnError: false);
+            ProcessHelper.StartProcess("taskkill /F /IM dcp.exe", redirectOutput: true, exitOnError: false);
+            ProcessHelper.StartProcess("taskkill /F /IM dcpproc.exe", redirectOutput: true, exitOnError: false);
+        }
+        else
+        {
+            // Kill all dotnet watch processes that are running AppHost
+            // This handles both absolute and relative paths
+            ProcessHelper.StartProcess("pkill -9 -f dotnet.*watch.*AppHost", redirectOutput: true, exitOnError: false);
+            
+            // Kill all processes that contain our application folder path
+            // This catches any process started from our directory
+            ProcessHelper.StartProcess($"pkill -9 -f {applicationFolder}", redirectOutput: true, exitOnError: false);
+            
+            // Kill Aspire-specific processes (Dashboard, DCP, etc.)
+            ProcessHelper.StartProcess("pkill -9 -if aspire", redirectOutput: true, exitOnError: false);
+            ProcessHelper.StartProcess("pkill -9 -f dcp", redirectOutput: true, exitOnError: false);
+            
+            // Kill processes by project names in case they're running from different locations
+            ProcessHelper.StartProcess("pkill -9 -f AppHost", redirectOutput: true, exitOnError: false);
+            ProcessHelper.StartProcess("pkill -9 -f AccountManagement", redirectOutput: true, exitOnError: false);
+            ProcessHelper.StartProcess("pkill -9 -f BackOffice", redirectOutput: true, exitOnError: false);
+            ProcessHelper.StartProcess("pkill -9 -f AppGateway", redirectOutput: true, exitOnError: false);
+        }
+
+        Thread.Sleep(TimeSpan.FromSeconds(2));
+
+        // Final verification - check if core Aspire ports are free
+        var stillRunning = false;
+        var checkCommand = Configuration.IsWindows
+            ? $"netstat -ano | findstr :{AspirePort} | findstr LISTENING"
+            : $"lsof -i :{AspirePort} -sTCP:LISTEN -t";
+        var result = ProcessHelper.StartProcess(checkCommand, redirectOutput: true, exitOnError: false);
+        if (!string.IsNullOrWhiteSpace(result))
+        {
+            stillRunning = true;
+        }
+
+        if (stillRunning)
+        {
+            AnsiConsole.MarkupLine("[yellow]Warning: Some processes may still be running. You may need to manually kill them.[/]");
+            AnsiConsole.MarkupLine("[yellow]Check running processes with: ps aux | grep dotnet[/]");
+        }
+        else
+        {
+            AnsiConsole.MarkupLine("[green]Aspire AppHost stopped successfully.[/]");
+        }
+    }
+
+    private static void StartAspireAppHost(bool attach)
+    {
+
+        AnsiConsole.MarkupLine($"[blue]Starting Aspire AppHost in {(attach ? "attached" : "detached")} mode...[/]");
+
+        var appHostProjectPath = Path.Combine(Configuration.ApplicationFolder, "AppHost", "AppHost.csproj");
+        var command = $"dotnet watch --non-interactive --project {appHostProjectPath}";
+        ProcessHelper.StartProcess(command, Configuration.ApplicationFolder, waitForExit: attach);
+    }
+}

--- a/developer-cli/Commands/WatchCommand.cs
+++ b/developer-cli/Commands/WatchCommand.cs
@@ -148,10 +148,15 @@ public class WatchCommand : Command
             ProcessHelper.StartProcess("pkill -9 -f dcp", redirectOutput: true, exitOnError: false);
 
             // Kill processes by project names in case they're running from different locations
-            ProcessHelper.StartProcess("pkill -9 -f AppHost", redirectOutput: true, exitOnError: false);
-            ProcessHelper.StartProcess("pkill -9 -f AccountManagement", redirectOutput: true, exitOnError: false);
-            ProcessHelper.StartProcess("pkill -9 -f BackOffice", redirectOutput: true, exitOnError: false);
-            ProcessHelper.StartProcess("pkill -9 -f AppGateway", redirectOutput: true, exitOnError: false);
+            // Find all subdirectories in the application folder and kill matching processes
+            var applicationProjects = Directory.GetDirectories(Configuration.ApplicationFolder)
+                .Select(Path.GetFileName)
+                .Where(name => !string.IsNullOrEmpty(name));
+
+            foreach (var projectName in applicationProjects)
+            {
+                ProcessHelper.StartProcess($"pkill -9 -f {projectName}", redirectOutput: true, exitOnError: false);
+            }
         }
 
         // Wait a moment for processes to terminate

--- a/developer-cli/Utilities/ProcessHelper.cs
+++ b/developer-cli/Utilities/ProcessHelper.cs
@@ -69,10 +69,17 @@ public static class ProcessHelper
         bool redirectOutput = false,
         bool waitForExit = true,
         bool exitOnError = true,
-        bool throwOnError = false
+        bool throwOnError = false,
+        params (string Name, string Value)[] environmentVariables
     )
     {
         var processStartInfo = CreateProcessStartInfo(command, solutionFolder, redirectOutput);
+        
+        foreach (var environmentVariable in environmentVariables)
+        {
+            processStartInfo.Environment[environmentVariable.Name] = environmentVariable.Value;
+        }
+        
         return StartProcess(processStartInfo, waitForExit: waitForExit, exitOnError: exitOnError, throwOnError: throwOnError);
     }
 


### PR DESCRIPTION
### Summary & Motivation

Add a new `watch` command to the developer CLI that manages the Aspire AppHost lifecycle. The command provides a convenient way to start, stop, and monitor the Aspire application host with support for both attached and detached modes.

- Create `watch` command with options for `--force`, `--stop`, `--attach/-a`, and `--detach/-d modes`
- Automatically detect and kill all .NET processes in the project when stopping
- Add `--public-url` parameter to set PUBLIC_URL environment variable for external device testing using e.g. ngrok and Tailscale
- Implement automatic ngrok tunnel startup when using ngrok URLs with the watch command
- Add port conflict detection in AppHost with user-friendly warnings when ports are already in use

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
