### PR TITLE
Centralize toast notification configuration and add success toasts for all mutations

### DIFF
--- a/application/account-management/WebApp/routes/admin/account/index.tsx
+++ b/application/account-management/WebApp/routes/admin/account/index.tsx
@@ -31,8 +31,7 @@ export function AccountSettings() {
       toastQueue.add({
         title: t`Success`,
         description: t`Account updated successfully`,
-        variant: "success",
-        duration: 3000
+        variant: "success"
       });
     }
   }, [updateCurrentTenantMutation.isSuccess]);

--- a/application/account-management/WebApp/routes/admin/account/index.tsx
+++ b/application/account-management/WebApp/routes/admin/account/index.tsx
@@ -9,10 +9,11 @@ import { Breadcrumb } from "@repo/ui/components/Breadcrumbs";
 import { Button } from "@repo/ui/components/Button";
 import { Form } from "@repo/ui/components/Form";
 import { TextField } from "@repo/ui/components/TextField";
+import { toastQueue } from "@repo/ui/components/Toast";
 import { mutationSubmitter } from "@repo/ui/forms/mutationSubmitter";
 import { createFileRoute } from "@tanstack/react-router";
 import { Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Separator } from "react-aria-components";
 import DeleteAccountConfirmation from "./-components/DeleteAccountConfirmation";
 
@@ -24,6 +25,17 @@ export function AccountSettings() {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { data: tenant, isLoading } = api.useQuery("get", "/api/account-management/tenants/current");
   const updateCurrentTenantMutation = api.useMutation("put", "/api/account-management/tenants/current");
+
+  useEffect(() => {
+    if (updateCurrentTenantMutation.isSuccess) {
+      toastQueue.add({
+        title: t`Success`,
+        description: t`Account updated successfully`,
+        variant: "success",
+        duration: 3000
+      });
+    }
+  }, [updateCurrentTenantMutation.isSuccess]);
 
   if (isLoading) {
     return null;

--- a/application/account-management/WebApp/routes/admin/users/-components/ChangeUserRoleDialog.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/ChangeUserRoleDialog.tsx
@@ -32,8 +32,7 @@ export function ChangeUserRoleDialog({ user, isOpen, onOpenChange }: Readonly<Ch
           toastQueue.add({
             title: t`Success`,
             description: t`User role updated successfully for ${userDisplayName}`,
-            variant: "success",
-            duration: 3000
+            variant: "success"
           });
 
           onOpenChange(false);

--- a/application/account-management/WebApp/routes/admin/users/-components/ChangeUserRoleDialog.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/ChangeUserRoleDialog.tsx
@@ -5,6 +5,7 @@ import { Trans } from "@lingui/react/macro";
 import { AlertDialog } from "@repo/ui/components/AlertDialog";
 import { Modal } from "@repo/ui/components/Modal";
 import { Select, SelectItem } from "@repo/ui/components/Select";
+import { toastQueue } from "@repo/ui/components/Toast";
 import { useCallback } from "react";
 
 type UserDetails = components["schemas"]["UserDetails"];
@@ -24,9 +25,19 @@ export function ChangeUserRoleDialog({ user, isOpen, onOpenChange }: Readonly<Ch
         return null;
       }
 
-      await changeUserRoleMutation.mutateAsync({ params: { path: { id: user.id } }, body: { userRole: newUserRole } });
+      changeUserRoleMutation
+        .mutateAsync({ params: { path: { id: user.id } }, body: { userRole: newUserRole } })
+        .then(() => {
+          const userDisplayName = `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email;
+          toastQueue.add({
+            title: t`Success`,
+            description: t`User role updated successfully for ${userDisplayName}`,
+            variant: "success",
+            duration: 3000
+          });
 
-      onOpenChange(false);
+          onOpenChange(false);
+        });
     },
     [user, changeUserRoleMutation, onOpenChange]
   );

--- a/application/account-management/WebApp/routes/admin/users/-components/DeleteUserDialog.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/DeleteUserDialog.tsx
@@ -29,8 +29,7 @@ export function DeleteUserDialog({ users, isOpen, onOpenChange, onUsersDeleted }
         toastQueue.add({
           title: t`Success`,
           description: `User deleted successfully: ${userDisplayName}`,
-          variant: "success",
-          duration: 3000
+          variant: "success"
         });
 
         onUsersDeleted?.();
@@ -42,8 +41,7 @@ export function DeleteUserDialog({ users, isOpen, onOpenChange, onUsersDeleted }
         toastQueue.add({
           title: t`Success`,
           description: `${users.length} users deleted successfully`,
-          variant: "success",
-          duration: 3000
+          variant: "success"
         });
 
         onUsersDeleted?.();

--- a/application/account-management/WebApp/routes/admin/users/-components/DeleteUserDialog.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/DeleteUserDialog.tsx
@@ -3,6 +3,7 @@ import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { AlertDialog } from "@repo/ui/components/AlertDialog";
 import { Modal } from "@repo/ui/components/Modal";
+import { toastQueue } from "@repo/ui/components/Toast";
 import { useCallback } from "react";
 
 type UserDetails = components["schemas"]["UserDetails"];
@@ -11,25 +12,54 @@ interface DeleteUserDialogProps {
   users: UserDetails[];
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
+  onUsersDeleted?: () => void;
 }
 
-export function DeleteUserDialog({ users, isOpen, onOpenChange }: Readonly<DeleteUserDialogProps>) {
+export function DeleteUserDialog({ users, isOpen, onOpenChange, onUsersDeleted }: Readonly<DeleteUserDialogProps>) {
   const isSingleUser = users.length === 1;
   const user = users[0];
 
-  const bulkDeleteUsersMutation = api.useMutation("post", "/api/account-management/users/bulk-delete");
   const deleteUserMutation = api.useMutation("delete", "/api/account-management/users/{id}");
+  const bulkDeleteUsersMutation = api.useMutation("post", "/api/account-management/users/bulk-delete");
+  const userDisplayName = isSingleUser ? `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email : "";
 
   const handleDelete = useCallback(async () => {
     if (isSingleUser) {
-      await deleteUserMutation.mutateAsync({ params: { path: { id: user.id } } });
+      deleteUserMutation.mutateAsync({ params: { path: { id: user.id } } }).then(() => {
+        toastQueue.add({
+          title: t`Success`,
+          description: `User deleted successfully: ${userDisplayName}`,
+          variant: "success",
+          duration: 3000
+        });
+
+        onUsersDeleted?.();
+        onOpenChange(false);
+      });
     } else {
       const userIds = users.map((user) => user.id);
-      await bulkDeleteUsersMutation.mutateAsync({ body: { userIds: userIds } });
-    }
+      await bulkDeleteUsersMutation.mutateAsync({ body: { userIds: userIds } }).then(() => {
+        toastQueue.add({
+          title: t`Success`,
+          description: `${users.length} users deleted successfully`,
+          variant: "success",
+          duration: 3000
+        });
 
-    onOpenChange(false);
-  }, [users, isSingleUser, user, deleteUserMutation, bulkDeleteUsersMutation, onOpenChange]);
+        onUsersDeleted?.();
+        onOpenChange(false);
+      });
+    }
+  }, [
+    isSingleUser,
+    userDisplayName,
+    bulkDeleteUsersMutation,
+    deleteUserMutation,
+    user,
+    users,
+    onUsersDeleted,
+    onOpenChange
+  ]);
 
   return (
     <Modal isOpen={isOpen} onOpenChange={onOpenChange} blur={false} isDismissable={true}>
@@ -42,8 +72,7 @@ export function DeleteUserDialog({ users, isOpen, onOpenChange }: Readonly<Delet
       >
         {isSingleUser ? (
           <Trans>
-            Are you sure you want to delete{" "}
-            <b>{`${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email}?</b>
+            Are you sure you want to delete <b>{userDisplayName}</b>?
           </Trans>
         ) : (
           <Trans>

--- a/application/account-management/WebApp/routes/admin/users/-components/InviteUserDialog.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/InviteUserDialog.tsx
@@ -25,8 +25,7 @@ export default function InviteUserDialog({ isOpen, onOpenChange }: Readonly<Invi
       toastQueue.add({
         title: t`Success`,
         description: t`User invited successfully`,
-        variant: "success",
-        duration: 3000
+        variant: "success"
       });
       onOpenChange(false);
     }

--- a/application/account-management/WebApp/routes/admin/users/-components/InviteUserDialog.tsx
+++ b/application/account-management/WebApp/routes/admin/users/-components/InviteUserDialog.tsx
@@ -7,6 +7,7 @@ import { Form } from "@repo/ui/components/Form";
 import { Heading } from "@repo/ui/components/Heading";
 import { Modal } from "@repo/ui/components/Modal";
 import { TextField } from "@repo/ui/components/TextField";
+import { toastQueue } from "@repo/ui/components/Toast";
 import { mutationSubmitter } from "@repo/ui/forms/mutationSubmitter";
 import { XIcon } from "lucide-react";
 import { useEffect } from "react";
@@ -21,6 +22,12 @@ export default function InviteUserDialog({ isOpen, onOpenChange }: Readonly<Invi
 
   useEffect(() => {
     if (inviteUserMutation.isSuccess) {
+      toastQueue.add({
+        title: t`Success`,
+        description: t`User invited successfully`,
+        variant: "success",
+        duration: 3000
+      });
       onOpenChange(false);
     }
   }, [inviteUserMutation.isSuccess, onOpenChange]);

--- a/application/account-management/WebApp/shared/components/userModals/UserProfileModal.tsx
+++ b/application/account-management/WebApp/shared/components/userModals/UserProfileModal.tsx
@@ -99,8 +99,7 @@ function UserProfileDialog({ onOpenChange, onIsLoadingChange }: Readonly<Profile
       toastQueue.add({
         title: t`Success`,
         description: t`Profile updated successfully`,
-        variant: "success",
-        duration: 3000
+        variant: "success"
       });
       closeDialog();
     }

--- a/application/account-management/WebApp/shared/components/userModals/UserProfileModal.tsx
+++ b/application/account-management/WebApp/shared/components/userModals/UserProfileModal.tsx
@@ -7,6 +7,7 @@ import { Dialog } from "@repo/ui/components/Dialog";
 import { Menu, MenuItem, MenuSeparator, MenuTrigger } from "@repo/ui/components/Menu";
 import { Modal } from "@repo/ui/components/Modal";
 import { TextField } from "@repo/ui/components/TextField";
+import { toastQueue } from "@repo/ui/components/Toast";
 import { mutationSubmitter } from "@repo/ui/forms/mutationSubmitter";
 import { useMutation } from "@tanstack/react-query";
 import { CameraIcon, MailIcon, Trash2Icon, XIcon } from "lucide-react";
@@ -90,10 +91,20 @@ function UserProfileDialog({ onOpenChange, onIsLoadingChange }: Readonly<Profile
       if (updatedUser) {
         updateUserInfo(updatedUser);
       }
-
-      closeDialog();
     }
   });
+
+  useEffect(() => {
+    if (saveMutation.isSuccess) {
+      toastQueue.add({
+        title: t`Success`,
+        description: t`Profile updated successfully`,
+        variant: "success",
+        duration: 3000
+      });
+      closeDialog();
+    }
+  }, [saveMutation.isSuccess, closeDialog]);
 
   // Handle file selection
   const onFileSelect = (files: FileList | null) => {

--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -66,9 +66,8 @@ msgstr "Enhver status"
 msgid "Are you sure you want to delete <0>{0} users</0>?"
 msgstr "Er du sikker på, at du vil slette <0>{0} brugere</0>?"
 
-#. placeholder {0}: `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email
-msgid "Are you sure you want to delete <0>{0}?</0>"
-msgstr "Er du sikker på, at du vil slette <0>{0}?</0>"
+msgid "Are you sure you want to delete <0>{userDisplayName}</0>?"
+msgstr "Er du sikker på, at du vil slette <0>{userDisplayName}</0>?"
 
 msgid "By continuing, you accept our policies"
 msgstr "Ved at fortsætte accepterer du vores vilkår"
@@ -343,7 +342,7 @@ msgid "Signup verification code"
 msgstr "Tilmeldingsbekræftelseskode"
 
 msgid "Success"
-msgstr ""
+msgstr "Succes"
 
 msgid "Support"
 msgstr "Support"

--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -342,6 +342,9 @@ msgstr "Tilmeld dig på få sekunder for at begynde at bygge på PlatformPlatfor
 msgid "Signup verification code"
 msgstr "Tilmeldingsbekræftelseskode"
 
+msgid "Success"
+msgstr ""
+
 msgid "Support"
 msgstr "Support"
 
@@ -392,6 +395,9 @@ msgstr "Brugerprofilmenu"
 
 msgid "User role"
 msgstr "Brugerrolle"
+
+msgid "User role updated successfully for {userDisplayName}"
+msgstr "Brugerrolle opdateret succesfuldt for {userDisplayName}"
 
 msgid "User status"
 msgstr "Brugerstatus"

--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -25,6 +25,9 @@ msgstr "Kontonavn"
 msgid "Account settings"
 msgstr "Kontoindstillinger"
 
+msgid "Account updated successfully"
+msgstr "Konto opdateret succesfuldt"
+
 msgid "Actions"
 msgstr "Handlinger"
 
@@ -292,6 +295,9 @@ msgstr "Fortrolighedspolitikker"
 msgid "Profile picture"
 msgstr "Profilbillede"
 
+msgid "Profile updated successfully"
+msgstr "Profil opdateret succesfuldt"
+
 msgid "Region"
 msgstr "Region"
 
@@ -385,6 +391,12 @@ msgstr "Opdater dit profilbillede og personlige oplysninger her."
 
 msgid "Upload profile picture"
 msgstr "Upload profilbillede"
+
+msgid "User invited successfully"
+msgstr "Bruger inviteret succesfuldt"
+
+msgid "User invited successfully"
+msgstr "Bruger inviteret succesfuldt"
 
 msgid "User profile"
 msgstr "Brugerprofil"

--- a/application/account-management/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account-management/WebApp/shared/translations/locale/da-DK.po
@@ -395,9 +395,6 @@ msgstr "Upload profilbillede"
 msgid "User invited successfully"
 msgstr "Bruger inviteret succesfuldt"
 
-msgid "User invited successfully"
-msgstr "Bruger inviteret succesfuldt"
-
 msgid "User profile"
 msgstr "Brugerprofil"
 

--- a/application/account-management/WebApp/shared/translations/locale/en-US.po
+++ b/application/account-management/WebApp/shared/translations/locale/en-US.po
@@ -342,6 +342,9 @@ msgstr "Sign up in seconds to start building on PlatformPlatform – just like t
 msgid "Signup verification code"
 msgstr "Signup verification code"
 
+msgid "Success"
+msgstr "Success"
+
 msgid "Support"
 msgstr "Support"
 
@@ -392,6 +395,9 @@ msgstr "User profile menu"
 
 msgid "User role"
 msgstr "User role"
+
+msgid "User role updated successfully for {userDisplayName}"
+msgstr "User role updated successfully for {userDisplayName}"
 
 msgid "User status"
 msgstr "User status"

--- a/application/account-management/WebApp/shared/translations/locale/en-US.po
+++ b/application/account-management/WebApp/shared/translations/locale/en-US.po
@@ -66,9 +66,8 @@ msgstr "Any status"
 msgid "Are you sure you want to delete <0>{0} users</0>?"
 msgstr "Are you sure you want to delete <0>{0} users</0>?"
 
-#. placeholder {0}: `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email
-msgid "Are you sure you want to delete <0>{0}?</0>"
-msgstr "Are you sure you want to delete <0>{0}?</0>"
+msgid "Are you sure you want to delete <0>{userDisplayName}</0>?"
+msgstr "Are you sure you want to delete <0>{userDisplayName}</0>?"
 
 msgid "By continuing, you accept our policies"
 msgstr "By continuing, you accept our policies"

--- a/application/account-management/WebApp/shared/translations/locale/en-US.po
+++ b/application/account-management/WebApp/shared/translations/locale/en-US.po
@@ -25,6 +25,9 @@ msgstr "Account name"
 msgid "Account settings"
 msgstr "Account settings"
 
+msgid "Account updated successfully"
+msgstr "Account updated successfully"
+
 msgid "Actions"
 msgstr "Actions"
 
@@ -292,6 +295,9 @@ msgstr "Privacy policies"
 msgid "Profile picture"
 msgstr "Profile picture"
 
+msgid "Profile updated successfully"
+msgstr "Profile updated successfully"
+
 msgid "Region"
 msgstr "Region"
 
@@ -385,6 +391,12 @@ msgstr "Update your profile picture and personal details here."
 
 msgid "Upload profile picture"
 msgstr "Upload profile picture"
+
+msgid "User invited successfully"
+msgstr "User invited successfully"
+
+msgid "User invited successfully"
+msgstr "User invited successfully"
 
 msgid "User profile"
 msgstr "User profile"

--- a/application/account-management/WebApp/shared/translations/locale/en-US.po
+++ b/application/account-management/WebApp/shared/translations/locale/en-US.po
@@ -395,9 +395,6 @@ msgstr "Upload profile picture"
 msgid "User invited successfully"
 msgstr "User invited successfully"
 
-msgid "User invited successfully"
-msgstr "User invited successfully"
-
 msgid "User profile"
 msgstr "User profile"
 

--- a/application/account-management/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/account-management/WebApp/shared/translations/locale/nl-NL.po
@@ -25,6 +25,9 @@ msgstr "Accountnaam"
 msgid "Account settings"
 msgstr "Accountinstellingen"
 
+msgid "Account updated successfully"
+msgstr "Account succesvol bijgewerkt"
+
 msgid "Actions"
 msgstr "Acties"
 
@@ -292,6 +295,9 @@ msgstr "Privacybeleid"
 msgid "Profile picture"
 msgstr "Profielfoto"
 
+msgid "Profile updated successfully"
+msgstr "Profiel succesvol bijgewerkt"
+
 msgid "Region"
 msgstr "Regio"
 
@@ -385,6 +391,12 @@ msgstr "Werk hier je profielfoto en persoonlijke gegevens bij."
 
 msgid "Upload profile picture"
 msgstr "Profielfoto uploaden"
+
+msgid "User invited successfully"
+msgstr "Gebruiker succesvol uitgenodigd"
+
+msgid "User invited successfully"
+msgstr "Gebruiker succesvol uitgenodigd"
 
 msgid "User profile"
 msgstr "Gebruikersprofiel"

--- a/application/account-management/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/account-management/WebApp/shared/translations/locale/nl-NL.po
@@ -66,9 +66,8 @@ msgstr "Elke status"
 msgid "Are you sure you want to delete <0>{0} users</0>?"
 msgstr "Weet je zeker dat je <0>{0} gebruikers</0> wilt verwijderen?"
 
-#. placeholder {0}: `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email
-msgid "Are you sure you want to delete <0>{0}?</0>"
-msgstr "Weet je zeker dat je <0>{0}?</0> wilt verwijderen?"
+msgid "Are you sure you want to delete <0>{userDisplayName}</0>?"
+msgstr "Weet je zeker dat je <0>{userDisplayName}</0> wilt verwijderen?"
 
 msgid "By continuing, you accept our policies"
 msgstr "Door verder te gaan, accepteer je onze voorwaarden"
@@ -343,7 +342,7 @@ msgid "Signup verification code"
 msgstr "Verificatiecode voor aanmelding"
 
 msgid "Success"
-msgstr ""
+msgstr "Succes"
 
 msgid "Support"
 msgstr "Ondersteuning"

--- a/application/account-management/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/account-management/WebApp/shared/translations/locale/nl-NL.po
@@ -395,9 +395,6 @@ msgstr "Profielfoto uploaden"
 msgid "User invited successfully"
 msgstr "Gebruiker succesvol uitgenodigd"
 
-msgid "User invited successfully"
-msgstr "Gebruiker succesvol uitgenodigd"
-
 msgid "User profile"
 msgstr "Gebruikersprofiel"
 

--- a/application/account-management/WebApp/shared/translations/locale/nl-NL.po
+++ b/application/account-management/WebApp/shared/translations/locale/nl-NL.po
@@ -342,6 +342,9 @@ msgstr "Meld je in enkele seconden aan om te beginnen met bouwen op PlatformPlat
 msgid "Signup verification code"
 msgstr "Verificatiecode voor aanmelding"
 
+msgid "Success"
+msgstr ""
+
 msgid "Support"
 msgstr "Ondersteuning"
 
@@ -392,6 +395,9 @@ msgstr "Gebruikersprofielmenu"
 
 msgid "User role"
 msgstr "Gebruikersrol"
+
+msgid "User role updated successfully for {userDisplayName}"
+msgstr "Gebruikersrol succesvol bijgewerkt voor {userDisplayName}"
 
 msgid "User status"
 msgstr "Gebruikersstatus"

--- a/application/shared-webapp/infrastructure/http/errorHandler.ts
+++ b/application/shared-webapp/infrastructure/http/errorHandler.ts
@@ -77,31 +77,28 @@ const getServerErrorMessage = (status: number): ErrorMessage => {
   };
 };
 
-// Defines toast notification styling and duration options
-type ToastVariant = { variant: "info" | "warning" | "danger"; duration?: number };
-
-// Determines toast styling and duration based on HTTP status code
-function getToastVariant(status: number): ToastVariant {
-  // Success codes are information
+// Determines toast styling based on HTTP status code
+function getToastVariant(status: number): "info" | "warning" | "error" {
+  // Success codes are success
   if (status >= 200 && status < 300) {
-    return { variant: "info", duration: 3000 }; // 3 seconds for information
+    return "info";
   }
 
   // Critical errors that block user flow
   const criticalErrors = [401, 403, 407, 423, 426, 451, ...Array.from({ length: 100 }, (_, i) => i + 500)];
   if (criticalErrors.includes(status)) {
-    return { variant: "danger" }; // No auto-dismiss for critical
+    return "error";
   }
 
   // All other 4xx errors are warning
-  return { variant: "warning", duration: 5000 }; // 5 seconds for warning
+  return "warning";
 }
 
 function showTimeoutToast(): void {
   toastQueue.add({
     title: "Network Error",
     description: "The server is taking too long to respond. Please try again.",
-    variant: "danger"
+    variant: "error"
   });
 }
 
@@ -109,7 +106,7 @@ function showUnknownErrorToast(error: Error) {
   toastQueue.add({
     title: "Unknown Error",
     description: `An unknown error occured (${error})`,
-    variant: "danger"
+    variant: "error"
   });
 }
 
@@ -131,13 +128,13 @@ function showServerErrorToast(error: ServerError) {
     message = getServerErrorMessage(error.status);
   }
 
-  const toastVariant = getToastVariant(error.status);
+  const variant = getToastVariant(error.status);
 
   toastQueue.add({
-    variant: toastVariant.variant,
+    variant,
     title: message.title,
-    description: message.detail ?? "",
-    duration: toastVariant.duration
+    description: message.detail ?? ""
+    // Duration will be set based on variant in the Toast component
   });
 }
 

--- a/application/shared-webapp/infrastructure/http/errorHandler.ts
+++ b/application/shared-webapp/infrastructure/http/errorHandler.ts
@@ -78,12 +78,7 @@ const getServerErrorMessage = (status: number): ErrorMessage => {
 };
 
 // Determines toast styling based on HTTP status code
-function getToastVariant(status: number): "info" | "warning" | "error" {
-  // Success codes are success
-  if (status >= 200 && status < 300) {
-    return "info";
-  }
-
+function getToastVariant(status: number): "warning" | "error" {
   // Critical errors that block user flow
   const criticalErrors = [401, 403, 407, 423, 426, 451, ...Array.from({ length: 100 }, (_, i) => i + 500)];
   if (criticalErrors.includes(status)) {

--- a/application/shared-webapp/ui/components/Toast.tsx
+++ b/application/shared-webapp/ui/components/Toast.tsx
@@ -77,7 +77,7 @@ function ToastRegion<T extends ToastContents>({ state, ...props }: Readonly<Toas
     <div
       {...regionProps}
       ref={ref}
-      className="fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse gap-1 p-4 sm:top-auto sm:right-0 sm:bottom-0 sm:flex-col md:max-w-[420px]"
+      className="pointer-events-none fixed top-4 right-4 z-[100] flex max-h-screen w-full max-w-[420px] flex-col gap-1"
     >
       {state.visibleToasts.map((toast) => (
         <Toast key={toast.key} toast={toast} state={state} />

--- a/application/shared-webapp/ui/components/Toast.tsx
+++ b/application/shared-webapp/ui/components/Toast.tsx
@@ -14,7 +14,15 @@ import { createPortal } from "react-dom";
 import { tv } from "tailwind-variants";
 import { focusRing } from "./focusRing";
 
-type ToastVariant = "neutral" | "info" | "success" | "warning" | "danger";
+type ToastVariant = "info" | "success" | "warning" | "error";
+
+// Default duration for toasts in milliseconds
+export const DEFAULT_TOAST_DURATIONS = {
+  info: 4000,
+  success: 4000,
+  warning: 6000,
+  error: 10000
+} as const;
 
 type ToastOptions = {
   variant?: ToastVariant;
@@ -90,15 +98,14 @@ const toastStyle = tv({
   base: "group data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[state=closed]:animate-out data-[state=open]:animate-in data-[swipe=end]:animate-out data-[swipe=move]:transition-none",
   variants: {
     variant: {
-      neutral: "bg-popover text-foreground",
       info: "bg-info text-info-foreground",
       success: "bg-success text-success-foreground",
       warning: "bg-warning text-warning-foreground",
-      danger: "bg-danger text-danger-foreground"
+      error: "bg-danger text-danger-foreground"
     }
   },
   defaultVariants: {
-    variant: "neutral"
+    variant: "info"
   }
 });
 
@@ -125,20 +132,32 @@ function Toast<T extends ToastContents>({ state, ...props }: Readonly<ToastProps
   const remainingTimeRef = useRef<number | null>(null);
   const startTimeRef = useRef<number | null>(null);
 
+  // Determine the duration for this toast
+  const getToastDuration = () => {
+    if (content && typeof content === "object" && !isValidElement(content)) {
+      const toastOptions = content as ToastOptions;
+      // If explicit duration is provided, use it
+      if (toastOptions.duration !== undefined) {
+        return toastOptions.duration;
+      }
+      // Otherwise use the default based on variant
+      if (toastOptions.variant && toastOptions.variant in DEFAULT_TOAST_DURATIONS) {
+        return DEFAULT_TOAST_DURATIONS[toastOptions.variant];
+      }
+    }
+    return undefined;
+  };
+
+  const toastDuration = getToastDuration();
+
   // Handle auto-dismiss functionality with pause on hover/focus
   useEffect(() => {
-    // Only set up auto-dismiss if content is a ToastOptions object with a duration
-    if (
-      content &&
-      typeof content === "object" &&
-      !isValidElement(content) &&
-      "duration" in content &&
-      typeof content.duration === "number"
-    ) {
+    // Only set up auto-dismiss if we have a duration
+    if (toastDuration !== undefined) {
       // If we're not paused, start/resume the timer
       if (!isPaused) {
         // If we have remaining time from a pause, use that, otherwise use the full duration
-        const duration = remainingTimeRef.current !== null ? remainingTimeRef.current : content.duration;
+        const duration = remainingTimeRef.current !== null ? remainingTimeRef.current : toastDuration;
         startTimeRef.current = Date.now();
 
         timerRef.current = setTimeout(() => {
@@ -151,7 +170,7 @@ function Toast<T extends ToastContents>({ state, ...props }: Readonly<ToastProps
 
         // Calculate how much time is left
         const elapsedTime = Date.now() - startTimeRef.current;
-        remainingTimeRef.current = Math.max(0, content.duration - elapsedTime);
+        remainingTimeRef.current = Math.max(0, toastDuration - elapsedTime);
       }
 
       // Clean up timer if toast is dismissed manually
@@ -161,7 +180,7 @@ function Toast<T extends ToastContents>({ state, ...props }: Readonly<ToastProps
         }
       };
     }
-  }, [content, props.toast.key, isPaused]);
+  }, [toastDuration, props.toast.key, isPaused]);
 
   // Event handlers for mouse and keyboard interactions
   const handleMouseEnter = () => setIsPaused(true);
@@ -178,7 +197,7 @@ function Toast<T extends ToastContents>({ state, ...props }: Readonly<ToastProps
   // If the content is a ReactNode, render it directly
   if (isReactNode(content)) {
     return (
-      <toastContext.Provider value={{ variant: "neutral" }}>
+      <toastContext.Provider value={{ variant: "info" }}>
         <div
           {...toastProps}
           ref={ref}
@@ -238,18 +257,17 @@ const toastActionStyles = tv({
   ],
   variants: {
     variant: {
-      neutral: "pressed:bg-accent/90 hover:bg-accent hover:text-accent-foreground",
       info: "text-info-foreground hover:border-transparent",
       success: "text-success-foreground hover:border-transparent",
       warning: "text-warning-foreground hover:border-transparent",
-      danger: "text-danger-foreground hover:border-transparent"
+      error: "text-danger-foreground hover:border-transparent"
     },
     isDisabled: {
       true: "pointer-events-none opacity-50"
     }
   },
   defaultVariants: {
-    variant: "neutral"
+    variant: "info"
   }
 });
 

--- a/application/shared-webapp/ui/hooks/useToast.ts
+++ b/application/shared-webapp/ui/hooks/useToast.ts
@@ -1,6 +1,6 @@
-import { toastQueue } from "../components/Toast";
+import { DEFAULT_TOAST_DURATIONS, toastQueue } from "../components/Toast";
 
-type ToastVariant = "default" | "destructive" | "success" | "warning";
+type ToastVariant = "info" | "success" | "warning" | "error";
 
 export type ToastOptions = {
   title?: string;
@@ -16,38 +16,21 @@ export type ToastOptions = {
  */
 export function useToast() {
   const toast = (options: ToastOptions) => {
-    const { variant = "default", duration = 5000, ...rest } = options;
+    const { variant = "info", duration, ...rest } = options;
 
-    // Map the variant to the appropriate Toast variant
-    const mappedVariant = mapVariant(variant);
+    // Determine the duration - use provided duration or default based on variant
+    const toastDuration = duration ?? DEFAULT_TOAST_DURATIONS[variant];
 
     // Add the toast to the queue
     toastQueue.add(
       {
         ...rest,
-        variant: mappedVariant
+        variant,
+        duration: toastDuration
       },
-      { timeout: duration }
+      { timeout: toastDuration }
     );
   };
 
   return { toast };
-}
-
-/**
- * Maps the variant from the public API to the internal Toast component variant
- */
-function mapVariant(variant: ToastVariant): "neutral" | "info" | "success" | "warning" | "danger" {
-  switch (variant) {
-    case "default":
-      return "neutral";
-    case "destructive":
-      return "danger";
-    case "success":
-      return "success";
-    case "warning":
-      return "warning";
-    default:
-      return "neutral";
-  }
 }


### PR DESCRIPTION
### Summary & Motivation

Centralize toast notification timeout configuration and add success toasts for all mutation operations to provide consistent user feedback across the application. Toast notifications now appear in the upper right corner with centralized duration settings based on notification type (info: 4s, success: 4s, warning: 6s, error: 10s).

- Introduce centralized `DEFAULT_TOAST_DURATIONS` configuration for consistent toast display times.
- Add success toast notifications for all mutations: changing user roles, deleting users, inviting users, updating profiles, and modifying account information.
- Move toast container to upper right corner for better visibility and stack new toasts below existing ones.
- Standardize toast variants to info, success, warning, and error (removing neutral and danger).
- Implement toast deduplication to prevent showing duplicate error messages.

### Downstream projects

1. Update any custom toast usage in `your-self-contained-system` to use the new variant names:
```diff
- variant: "neutral"
+ variant: "info"

- variant: "danger"
+ variant: "error"
```

2. Add success toast notifications for all mutations in your-self-contained-system to maintainn consistency with the updated pattern. For example:

```typescript
mutation
  .mutateAsync(data)
  .then(() => {
    toastQueue.add({
      title: t`Success`,
      description: t`[Action] completed successfully`,
      variant: "success"
    });
  });
```

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
