### PR TITLE
Fix duplicate page navigation tracking in Application Insights

### DIFF
--- a/application/account-management/WebApp/routes/__root.tsx
+++ b/application/account-management/WebApp/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { queryClient } from "@/shared/lib/api/client";
+import { PageTracker } from "@repo/infrastructure/applicationInsights/PageTracker";
 import { AuthenticationProvider } from "@repo/infrastructure/auth/AuthenticationProvider";
 import { ErrorPage } from "@repo/infrastructure/errorComponents/ErrorPage";
 import { NotFound } from "@repo/infrastructure/errorComponents/NotFoundPage";
@@ -23,6 +24,7 @@ function Root() {
       <ThemeModeProvider>
         <ReactAriaRouterProvider>
           <AuthenticationProvider navigate={(options) => navigate(options)}>
+            <PageTracker />
             <Outlet />
           </AuthenticationProvider>
         </ReactAriaRouterProvider>

--- a/application/back-office/WebApp/routes/__root.tsx
+++ b/application/back-office/WebApp/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { queryClient } from "@/shared/lib/api/client";
+import { PageTracker } from "@repo/infrastructure/applicationInsights/PageTracker";
 import { AuthenticationProvider } from "@repo/infrastructure/auth/AuthenticationProvider";
 import { ErrorPage } from "@repo/infrastructure/errorComponents/ErrorPage";
 import { NotFound } from "@repo/infrastructure/errorComponents/NotFoundPage";
@@ -23,6 +24,7 @@ function Root() {
       <ThemeModeProvider>
         <ReactAriaRouterProvider>
           <AuthenticationProvider navigate={(options) => navigate(options)}>
+            <PageTracker />
             <Outlet />
           </AuthenticationProvider>
         </ReactAriaRouterProvider>

--- a/application/shared-kernel/SharedKernel/Endpoints/TrackEndpoints.cs
+++ b/application/shared-kernel/SharedKernel/Endpoints/TrackEndpoints.cs
@@ -41,7 +41,7 @@ public class TrackEndpoints : IEndpoints
                     var telemetry = new PageViewTelemetry
                     {
                         Name = trackRequest.Data.BaseData.Name,
-                        Url = new Uri(trackRequest.Data.BaseData.Url),
+                        Url = Uri.TryCreate(trackRequest.Data.BaseData.Url, UriKind.Absolute, out var pageViewUri) ? pageViewUri : null,
                         Duration = trackRequest.Data.BaseData.Duration,
                         Timestamp = trackRequest.Time,
                         Id = trackRequest.Data.BaseData.Id
@@ -59,7 +59,7 @@ public class TrackEndpoints : IEndpoints
                     var telemetry = new PageViewPerformanceTelemetry
                     {
                         Name = trackRequest.Data.BaseData.Name,
-                        Url = new Uri(trackRequest.Data.BaseData.Url),
+                        Url = Uri.TryCreate(trackRequest.Data.BaseData.Url, UriKind.Absolute, out var perfUri) ? perfUri : null,
                         Duration = trackRequest.Data.BaseData.Duration,
                         Timestamp = trackRequest.Time,
                         Id = trackRequest.Data.BaseData.Id,

--- a/application/shared-webapp/infrastructure/applicationInsights/ApplicationInsightsProvider.tsx
+++ b/application/shared-webapp/infrastructure/applicationInsights/ApplicationInsightsProvider.tsx
@@ -62,3 +62,6 @@ const applicationInsights = new ApplicationInsights({
 applicationInsights.loadAppInsights();
 // Track the initial page view
 applicationInsights.trackPageView();
+
+// Export for error tracking
+export { applicationInsights };

--- a/application/shared-webapp/infrastructure/applicationInsights/ApplicationInsightsProvider.tsx
+++ b/application/shared-webapp/infrastructure/applicationInsights/ApplicationInsightsProvider.tsx
@@ -34,8 +34,8 @@ const applicationInsights = new ApplicationInsights({
     disableInstrumentationKeyValidation: true,
     // Set the endpoint URL to our custom endpoint
     endpointUrl: "/api/track",
-    // Enable auto route tracking for React Router
-    enableAutoRouteTracking: true,
+    // Disable auto route tracking (not compatible with TanStack Router)
+    enableAutoRouteTracking: false,
     // Instrument error tracking
     autoExceptionInstrumented: true,
     autoUnhandledPromiseInstrumented: true,
@@ -60,8 +60,6 @@ const applicationInsights = new ApplicationInsights({
 
 // Load the Application Insights script
 applicationInsights.loadAppInsights();
-// Track the initial page view
-applicationInsights.trackPageView();
 
 // Export for error tracking
 export { applicationInsights };

--- a/application/shared-webapp/infrastructure/applicationInsights/PageTracker.tsx
+++ b/application/shared-webapp/infrastructure/applicationInsights/PageTracker.tsx
@@ -1,0 +1,35 @@
+import { useRouter } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
+import { applicationInsights } from "./ApplicationInsightsProvider";
+
+export function PageTracker() {
+  const router = useRouter();
+  const lastPathname = useRef<string>("");
+
+  useEffect(() => {
+    // Track initial page view
+    const pathname = router.state.location.pathname;
+    if (pathname !== lastPathname.current) {
+      applicationInsights.trackPageView({
+        name: pathname,
+        uri: window.location.href
+      });
+      lastPathname.current = pathname;
+    }
+
+    // Subscribe to navigation events
+    const unsubscribe = router.subscribe("onLoad", ({ toLocation }) => {
+      if (toLocation.pathname !== lastPathname.current) {
+        applicationInsights.trackPageView({
+          name: toLocation.pathname,
+          uri: toLocation.href
+        });
+        lastPathname.current = toLocation.pathname;
+      }
+    });
+
+    return unsubscribe;
+  }, [router]);
+
+  return null;
+}


### PR DESCRIPTION
### Summary & Motivation

Fix duplicate page view tracking that occurred when navigating between pages in the single-page application. Application Insights' enableAutoRouteTracking feature was causing duplicate tracking with TanStack Router because both systems independently detected navigation events.

- Disable enableAutoRouteTracking in Application Insights configuration
- Create custom PageTracker component that integrates properly with TanStack Router
- Track initial page load and subsequent navigations without duplicates
- Maintain existing JavaScript error tracking functionality

The enableAutoRouteTracking feature is designed for React Router and listens to browser history changes (popstate, pushState/replaceState, hashchange). Since TanStack Router also manipulates browser history, both were detecting the same navigation event and sending duplicate page views. The custom PageTracker component uses TanStack Router's onLoad event and tracks pathname changes to ensure each navigation is tracked exactly once.

### Downstream projects

1. Add the PageTracker component to `your-self-contained-system/__root.tsx`:

 ```diff
 import { queryClient } from "@/shared/lib/api/client";
 +import { PageTracker } from "@repo/infrastructure/applicationInsights/PageTracker";
 import { AuthenticationProvider } from "@repo/infrastructure/auth/AuthenticationProvider";

 function Root() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeModeProvider>
         <ReactAriaRouterProvider>
           <AuthenticationProvider navigate={(options) => navigate(options)}>
 +           <PageTracker />
             <Outlet />
           </AuthenticationProvider>
         </ReactAriaRouterProvider>
       </ThemeModeProvider>
     </QueryClientProvider>
   );
 }
 ```

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
