### PR TITLE
 Fix Input component icon positioning by only wrapping in relative container when needed

### DIFF
--- a/application/shared-webapp/ui/components/Input.tsx
+++ b/application/shared-webapp/ui/components/Input.tsx
@@ -49,33 +49,39 @@ export function Input({
   startIcon,
   ...props
 }: Readonly<InputProps>) {
-  return (
-    <div className={isEmbedded ? "relative flex-1" : "relative"}>
-      {startIcon && (
+  const inputElement = (
+    <AriaInput
+      {...props}
+      disabled={isDisabled}
+      readOnly={isReadOnly}
+      type={type}
+      className={composeRenderProps(
+        className,
+        (className, { isFocusVisible, isDisabled, ...renderProps }) =>
+          `${inputStyles({
+            ...renderProps,
+            isFile: type === "file",
+            isFocusVisible: isEmbedded ? false : isFocusVisible,
+            isEmbedded,
+            isDisabled,
+            isReadOnly,
+            hasStartIcon: !!startIcon,
+            className
+          })} ${isDisabled || isReadOnly ? "border-input" : ""}`
+      )}
+    />
+  );
+
+  if (startIcon) {
+    return (
+      <div className="relative">
         <div className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-3 flex items-center">
           {startIcon}
         </div>
-      )}
-      <AriaInput
-        {...props}
-        disabled={isDisabled}
-        readOnly={isReadOnly}
-        type={type}
-        className={composeRenderProps(
-          className,
-          (className, { isFocusVisible, isDisabled, ...renderProps }) =>
-            `${inputStyles({
-              ...renderProps,
-              isFile: type === "file",
-              isFocusVisible: isEmbedded ? false : isFocusVisible,
-              isEmbedded,
-              isDisabled,
-              isReadOnly,
-              hasStartIcon: !!startIcon,
-              className
-            })} ${isDisabled || isReadOnly ? "border-input" : ""}`
-        )}
-      />
-    </div>
-  );
+        {inputElement}
+      </div>
+    );
+  }
+
+  return inputElement;
 }


### PR DESCRIPTION
 ### Summary & Motivation

Fix layout issues with the Input component when displaying icons. The component was wrapping all inputs in a div with conditional flex-1 class, which broke form layouts in certain scenarios like the questionnaire forms.

- Modified the Input component to only wrap itself in a relative container when a startIcon is present.
- Removed the conditional `isEmbedded ? "relative flex-1" : "relative"` wrapper that was applied to all inputs.
- This preserves the original layout behavior for inputs without icons while maintaining proper icon positioning.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
