### PR TITLE
Replace static time access with injected TimeProvider for testability

### DIFF
--- a/.agent/rules/backend/backend.md
+++ b/.agent/rules/backend/backend.md
@@ -61,7 +61,8 @@ Guidelines for C# backend development, including code style, naming, exceptions,
 - Use `user?.IsActive == true` over `user != null && user.IsActive == true`
 - Avoid try-catch unless we cannot fix the root cause—global exception handling covers unknown exceptions
 - Use `SharedInfrastructureConfiguration.IsRunningInAzure` to determine if running in Azure
-- Use `TimeProvider.System.GetUtcNow()` instead of `DateTime.UtcNow()`
+- Inject `TimeProvider` into services and handlers, use `timeProvider.GetUtcNow()` instead of `DateTimeOffset.UtcNow`
+- Pass `DateTimeOffset` values (not `TimeProvider`) to domain methods and aggregates to maintain clean boundaries (e.g., `entity.HasExpired(timeProvider.GetUtcNow())`)
 - Naming rules:
   - Never use acronyms or abbreviations (e.g., use `SharedAccessSignature` not `Sas`, `Context` not `Ctx`)
   - Prefer long variable names for readability (e.g., `gravatarHttpClient` not `httpClient`)

--- a/.claude/rules/backend/backend.md
+++ b/.claude/rules/backend/backend.md
@@ -61,7 +61,8 @@ Guidelines for C# backend development, including code style, naming, exceptions,
 - Use `user?.IsActive == true` over `user != null && user.IsActive == true`
 - Avoid try-catch unless we cannot fix the root cause—global exception handling covers unknown exceptions
 - Use `SharedInfrastructureConfiguration.IsRunningInAzure` to determine if running in Azure
-- Use `TimeProvider.System.GetUtcNow()` instead of `DateTime.UtcNow()`
+- Inject `TimeProvider` into services and handlers, use `timeProvider.GetUtcNow()` instead of `DateTimeOffset.UtcNow`
+- Pass `DateTimeOffset` values (not `TimeProvider`) to domain methods and aggregates to maintain clean boundaries (e.g., `entity.HasExpired(timeProvider.GetUtcNow())`)
 - Naming rules:
   - Never use acronyms or abbreviations (e.g., use `SharedAccessSignature` not `Sas`, `Context` not `Ctx`)
   - Prefer long variable names for readability (e.g., `gravatarHttpClient` not `httpClient`)

--- a/.cursor/rules/backend/backend.mdc
+++ b/.cursor/rules/backend/backend.mdc
@@ -61,7 +61,8 @@ Guidelines for C# backend development, including code style, naming, exceptions,
 - Use `user?.IsActive == true` over `user != null && user.IsActive == true`
 - Avoid try-catch unless we cannot fix the root cause—global exception handling covers unknown exceptions
 - Use `SharedInfrastructureConfiguration.IsRunningInAzure` to determine if running in Azure
-- Use `TimeProvider.System.GetUtcNow()` instead of `DateTime.UtcNow()`
+- Inject `TimeProvider` into services and handlers, use `timeProvider.GetUtcNow()` instead of `DateTimeOffset.UtcNow`
+- Pass `DateTimeOffset` values (not `TimeProvider`) to domain methods and aggregates to maintain clean boundaries (e.g., `entity.HasExpired(timeProvider.GetUtcNow())`)
 - Naming rules:
   - Never use acronyms or abbreviations (e.g., use `SharedAccessSignature` not `Sas`, `Context` not `Ctx`)
   - Prefer long variable names for readability (e.g., `gravatarHttpClient` not `httpClient`)

--- a/.github/copilot/rules/backend/backend.md
+++ b/.github/copilot/rules/backend/backend.md
@@ -56,7 +56,8 @@ Guidelines for C# backend development, including code style, naming, exceptions,
 - Use `user?.IsActive == true` over `user != null && user.IsActive == true`
 - Avoid try-catch unless we cannot fix the root cause—global exception handling covers unknown exceptions
 - Use `SharedInfrastructureConfiguration.IsRunningInAzure` to determine if running in Azure
-- Use `TimeProvider.System.GetUtcNow()` instead of `DateTime.UtcNow()`
+- Inject `TimeProvider` into services and handlers, use `timeProvider.GetUtcNow()` instead of `DateTimeOffset.UtcNow`
+- Pass `DateTimeOffset` values (not `TimeProvider`) to domain methods and aggregates to maintain clean boundaries (e.g., `entity.HasExpired(timeProvider.GetUtcNow())`)
 - Naming rules:
   - Never use acronyms or abbreviations (e.g., use `SharedAccessSignature` not `Sas`, `Context` not `Ctx`)
   - Prefer long variable names for readability (e.g., `gravatarHttpClient` not `httpClient`)

--- a/.windsurf/rules/backend/backend.md
+++ b/.windsurf/rules/backend/backend.md
@@ -62,7 +62,8 @@ Guidelines for C# backend development, including code style, naming, exceptions,
 - Use `user?.IsActive == true` over `user != null && user.IsActive == true`
 - Avoid try-catch unless we cannot fix the root cause—global exception handling covers unknown exceptions
 - Use `SharedInfrastructureConfiguration.IsRunningInAzure` to determine if running in Azure
-- Use `TimeProvider.System.GetUtcNow()` instead of `DateTime.UtcNow()`
+- Inject `TimeProvider` into services and handlers, use `timeProvider.GetUtcNow()` instead of `DateTimeOffset.UtcNow`
+- Pass `DateTimeOffset` values (not `TimeProvider`) to domain methods and aggregates to maintain clean boundaries (e.g., `entity.HasExpired(timeProvider.GetUtcNow())`)
 - Naming rules:
   - Never use acronyms or abbreviations (e.g., use `SharedAccessSignature` not `Sas`, `Context` not `Ctx`)
   - Prefer long variable names for readability (e.g., `gravatarHttpClient` not `httpClient`)

--- a/application/AppGateway/Middleware/AuthenticationCookieMiddleware.cs
+++ b/application/AppGateway/Middleware/AuthenticationCookieMiddleware.cs
@@ -10,9 +10,9 @@ namespace PlatformPlatform.AppGateway.Middleware;
 public class AuthenticationCookieMiddleware(
     ITokenSigningClient tokenSigningClient,
     IHttpClientFactory httpClientFactory,
+    TimeProvider timeProvider,
     ILogger<AuthenticationCookieMiddleware> logger
-)
-    : IMiddleware
+) : IMiddleware
 {
     private const string? RefreshAuthenticationTokensEndpoint = "/internal-api/account-management/authentication/refresh-authentication-tokens";
 
@@ -51,9 +51,9 @@ public class AuthenticationCookieMiddleware(
 
         try
         {
-            if (accessToken is null || ExtractExpirationFromToken(accessToken) < TimeProvider.System.GetUtcNow())
+            if (accessToken is null || ExtractExpirationFromToken(accessToken) < timeProvider.GetUtcNow())
             {
-                if (ExtractExpirationFromToken(refreshToken) < TimeProvider.System.GetUtcNow())
+                if (ExtractExpirationFromToken(refreshToken) < timeProvider.GetUtcNow())
                 {
                     context.Response.Cookies.Delete(AuthenticationTokenHttpKeys.RefreshTokenCookieName);
                     context.Response.Cookies.Delete(AuthenticationTokenHttpKeys.AccessTokenCookieName);

--- a/application/account-management/Core/Database/AccountManagementDbContext.cs
+++ b/application/account-management/Core/Database/AccountManagementDbContext.cs
@@ -4,5 +4,5 @@ using PlatformPlatform.SharedKernel.ExecutionContext;
 
 namespace PlatformPlatform.AccountManagement.Database;
 
-public sealed class AccountManagementDbContext(DbContextOptions<AccountManagementDbContext> options, IExecutionContext executionContext)
-    : SharedKernelDbContext<AccountManagementDbContext>(options, executionContext);
+public sealed class AccountManagementDbContext(DbContextOptions<AccountManagementDbContext> options, IExecutionContext executionContext, TimeProvider timeProvider)
+    : SharedKernelDbContext<AccountManagementDbContext>(options, executionContext, timeProvider);

--- a/application/account-management/Core/Features/Authentication/Commands/CompleteLogin.cs
+++ b/application/account-management/Core/Features/Authentication/Commands/CompleteLogin.cs
@@ -27,6 +27,7 @@ public sealed class CompleteLoginHandler(
     AvatarUpdater avatarUpdater,
     GravatarClient gravatarClient,
     ITelemetryEventsCollector events,
+    TimeProvider timeProvider,
     ILogger<CompleteLoginHandler> logger
 ) : IRequestHandler<CompleteLoginCommand, Result>
 {
@@ -98,7 +99,7 @@ public sealed class CompleteLoginHandler(
     {
         user.ConfirmEmail();
         userRepository.Update(user);
-        var inviteAcceptedTimeInMinutes = (int)(TimeProvider.System.GetUtcNow() - user.CreatedAt).TotalMinutes;
+        var inviteAcceptedTimeInMinutes = (int)(timeProvider.GetUtcNow() - user.CreatedAt).TotalMinutes;
         events.CollectEvent(new UserInviteAccepted(user.Id, inviteAcceptedTimeInMinutes));
     }
 }

--- a/application/account-management/Core/Features/Authentication/Commands/SwitchTenant.cs
+++ b/application/account-management/Core/Features/Authentication/Commands/SwitchTenant.cs
@@ -23,6 +23,7 @@ public sealed class SwitchTenantHandler(
     IBlobStorageClient blobStorageClient,
     IExecutionContext executionContext,
     ITelemetryEventsCollector events,
+    TimeProvider timeProvider,
     ILogger<SwitchTenantHandler> logger
 ) : IRequestHandler<SwitchTenantCommand, Result>
 {
@@ -88,7 +89,7 @@ public sealed class SwitchTenantHandler(
         userRepository.Update(targetUser);
 
         // Calculate how long it took to accept the invitation
-        var inviteAcceptedTimeInMinutes = (int)(DateTimeOffset.UtcNow - targetUser.CreatedAt).TotalMinutes;
+        var inviteAcceptedTimeInMinutes = (int)(timeProvider.GetUtcNow() - targetUser.CreatedAt).TotalMinutes;
         events.CollectEvent(new UserInviteAccepted(targetUser.Id, inviteAcceptedTimeInMinutes));
     }
 }

--- a/application/account-management/Core/Features/EmailConfirmations/Commands/StartEmailConfirmation.cs
+++ b/application/account-management/Core/Features/EmailConfirmations/Commands/StartEmailConfirmation.cs
@@ -29,7 +29,8 @@ public sealed class StartEmailConfirmationValidator : AbstractValidator<StartEma
 public sealed class StartEmailConfirmationHandler(
     IEmailConfirmationRepository emailConfirmationRepository,
     IEmailClient emailClient,
-    IPasswordHasher<object> passwordHasher
+    IPasswordHasher<object> passwordHasher,
+    TimeProvider timeProvider
 ) : IRequestHandler<StartEmailConfirmationCommand, Result<StartEmailConfirmationResponse>>
 {
     public async Task<Result<StartEmailConfirmationResponse>> Handle(StartEmailConfirmationCommand command, CancellationToken cancellationToken)
@@ -37,7 +38,7 @@ public sealed class StartEmailConfirmationHandler(
         var existingConfirmations = emailConfirmationRepository.GetByEmail(command.Email).ToArray();
 
         var lockoutMinutes = command.Type == EmailConfirmationType.Signup ? -60 : -15;
-        if (existingConfirmations.Count(r => r.CreatedAt > TimeProvider.System.GetUtcNow().AddMinutes(lockoutMinutes)) >= 3)
+        if (existingConfirmations.Count(r => r.CreatedAt > timeProvider.GetUtcNow().AddMinutes(lockoutMinutes)) >= 3)
         {
             return Result<StartEmailConfirmationResponse>.TooManyRequests("Too many attempts to confirm this email address. Please try again later.");
         }

--- a/application/account-management/Core/Features/Users/Commands/DeclineInvitation.cs
+++ b/application/account-management/Core/Features/Users/Commands/DeclineInvitation.cs
@@ -13,7 +13,8 @@ public sealed record DeclineInvitationCommand(TenantId TenantId) : ICommand, IRe
 public sealed class DeclineInvitationHandler(
     IUserRepository userRepository,
     IExecutionContext executionContext,
-    ITelemetryEventsCollector events
+    ITelemetryEventsCollector events,
+    TimeProvider timeProvider
 ) : IRequestHandler<DeclineInvitationCommand, Result>
 {
     public async Task<Result> Handle(DeclineInvitationCommand command, CancellationToken cancellationToken)
@@ -34,7 +35,7 @@ public sealed class DeclineInvitationHandler(
         }
 
         // Calculate how long the invitation existed
-        var inviteExistedTimeInMinutes = (int)(TimeProvider.System.GetUtcNow() - user.CreatedAt).TotalMinutes;
+        var inviteExistedTimeInMinutes = (int)(timeProvider.GetUtcNow() - user.CreatedAt).TotalMinutes;
 
         // Delete the user to decline the invitation
         userRepository.Remove(user);

--- a/application/account-management/Core/Features/Users/Domain/UserRepository.cs
+++ b/application/account-management/Core/Features/Users/Domain/UserRepository.cs
@@ -40,7 +40,7 @@ public interface IUserRepository : ICrudRepository<User, UserId>, IBulkRemoveRep
     Task<User[]> GetUsersByEmailUnfilteredAsync(string email, CancellationToken cancellationToken);
 }
 
-internal sealed class UserRepository(AccountManagementDbContext accountManagementDbContext, IExecutionContext executionContext)
+internal sealed class UserRepository(AccountManagementDbContext accountManagementDbContext, IExecutionContext executionContext, TimeProvider timeProvider)
     : RepositoryBase<User, UserId>(accountManagementDbContext), IUserRepository
 {
     /// <summary>
@@ -89,7 +89,7 @@ internal sealed class UserRepository(AccountManagementDbContext accountManagemen
 
     public async Task<(int TotalUsers, int ActiveUsers, int PendingUsers)> GetUserSummaryAsync(CancellationToken cancellationToken)
     {
-        var thirtyDaysAgo = TimeProvider.System.GetUtcNow().AddDays(-30);
+        var thirtyDaysAgo = timeProvider.GetUtcNow().AddDays(-30);
 
         var summary = await DbSet
             .GroupBy(_ => 1) // Group all records into a single group to calculate multiple COUNT aggregates in one query

--- a/application/account-management/Tests/Authentication/CompleteLoginTests.cs
+++ b/application/account-management/Tests/Authentication/CompleteLoginTests.cs
@@ -159,7 +159,7 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
                 ("TenantId", DatabaseSeeder.Tenant1Owner.TenantId.ToString()),
                 ("UserId", DatabaseSeeder.Tenant1Owner.Id.ToString()),
                 ("Id", loginId.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("EmailConfirmationId", emailConfirmationId.ToString()),
                 ("Completed", false)
@@ -167,12 +167,12 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
         );
         Connection.Insert("EmailConfirmations", [
                 ("Id", emailConfirmationId.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", DatabaseSeeder.Tenant1Owner.Email),
                 ("Type", EmailConfirmationType.Signup),
                 ("OneTimePasswordHash", new PasswordHasher<object>().HashPassword(this, CorrectOneTimePassword)),
-                ("ValidUntil", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                ("ValidUntil", TimeProvider.GetUtcNow().AddMinutes(-10)),
                 ("RetryCount", 0),
                 ("ResendCount", 0),
                 ("Completed", false)
@@ -236,7 +236,7 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
 
         Connection.Insert("Tenants", [
                 ("Id", tenant2Id.Value),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", Faker.Company.CompanyName()),
                 ("State", nameof(TenantState.Active)),
@@ -247,7 +247,7 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
         Connection.Insert("Users", [
                 ("TenantId", tenant2Id.Value),
                 ("Id", user2Id.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Email", DatabaseSeeder.Tenant1Owner.Email),
                 ("EmailConfirmed", true),
@@ -309,7 +309,7 @@ public sealed class CompleteLoginTests : EndpointBaseTest<AccountManagementDbCon
 
         Connection.Insert("Tenants", [
                 ("Id", tenant2Id.Value),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", Faker.Company.CompanyName()),
                 ("State", nameof(TenantState.Active)),

--- a/application/account-management/Tests/Authentication/StartLoginTests.cs
+++ b/application/account-management/Tests/Authentication/StartLoginTests.cs
@@ -127,12 +127,12 @@ public sealed class StartLoginTests : EndpointBaseTest<AccountManagementDbContex
             var oneTimePasswordHash = new PasswordHasher<object>().HashPassword(this, OneTimePasswordHelper.GenerateOneTimePassword(6));
             Connection.Insert("EmailConfirmations", [
                     ("Id", EmailConfirmationId.NewId().ToString()),
-                    ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-i)),
+                    ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-i)),
                     ("ModifiedAt", null),
                     ("Email", email.ToLower()),
                     ("Type", nameof(EmailConfirmationType.Login)),
                     ("OneTimePasswordHash", oneTimePasswordHash),
-                    ("ValidUntil", TimeProvider.System.GetUtcNow().AddMinutes(-i - 1)), // All should be expired
+                    ("ValidUntil", TimeProvider.GetUtcNow().AddMinutes(-i - 1)), // All should be expired
                     ("RetryCount", 0),
                     ("ResendCount", 0),
                     ("Completed", false)

--- a/application/account-management/Tests/Authentication/SwitchTenantTests.cs
+++ b/application/account-management/Tests/Authentication/SwitchTenantTests.cs
@@ -25,7 +25,7 @@ public sealed class SwitchTenantTests : EndpointBaseTest<AccountManagementDbCont
 
         Connection.Insert("Tenants", [
                 ("Id", tenant2Id.Value),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", tenant2Name),
                 ("State", nameof(TenantState.Active)),
@@ -36,7 +36,7 @@ public sealed class SwitchTenantTests : EndpointBaseTest<AccountManagementDbCont
         Connection.Insert("Users", [
                 ("TenantId", tenant2Id.Value),
                 ("Id", user2Id.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Email", DatabaseSeeder.Tenant1Member.Email),
                 ("EmailConfirmed", true),
@@ -93,7 +93,7 @@ public sealed class SwitchTenantTests : EndpointBaseTest<AccountManagementDbCont
 
         Connection.Insert("Tenants", [
                 ("Id", tenant2Id.Value),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", Faker.Company.CompanyName()),
                 ("State", nameof(TenantState.Active)),
@@ -104,7 +104,7 @@ public sealed class SwitchTenantTests : EndpointBaseTest<AccountManagementDbCont
         Connection.Insert("Users", [
                 ("TenantId", tenant2Id.Value),
                 ("Id", UserId.NewId().ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Email", Faker.Internet.UniqueEmail()),
                 ("EmailConfirmed", true),
@@ -152,7 +152,7 @@ public sealed class SwitchTenantTests : EndpointBaseTest<AccountManagementDbCont
 
         Connection.Insert("Tenants", [
                 ("Id", tenant2Id.Value),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", tenant2Name),
                 ("State", nameof(TenantState.Active)),
@@ -163,7 +163,7 @@ public sealed class SwitchTenantTests : EndpointBaseTest<AccountManagementDbCont
         Connection.Insert("Users", [
                 ("TenantId", tenant2Id.Value),
                 ("Id", user2Id.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Email", DatabaseSeeder.Tenant1Member.Email),
                 ("EmailConfirmed", false), // User's email is not confirmed
@@ -219,7 +219,7 @@ public sealed class SwitchTenantTests : EndpointBaseTest<AccountManagementDbCont
 
         Connection.Insert("Tenants", [
                 ("Id", tenant2Id.Value),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", tenant2Name),
                 ("State", nameof(TenantState.Active)),
@@ -231,7 +231,7 @@ public sealed class SwitchTenantTests : EndpointBaseTest<AccountManagementDbCont
         Connection.Insert("Users", [
                 ("TenantId", tenant2Id.Value),
                 ("Id", user2Id.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Email", DatabaseSeeder.Tenant1Member.Email),
                 ("EmailConfirmed", false), // Unconfirmed - invitation pending
@@ -294,7 +294,7 @@ public sealed class SwitchTenantTests : EndpointBaseTest<AccountManagementDbCont
 
         Connection.Insert("Tenants", [
                 ("Id", tenant2Id.Value),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", Faker.Company.CompanyName()),
                 ("State", nameof(TenantState.Active)),
@@ -305,7 +305,7 @@ public sealed class SwitchTenantTests : EndpointBaseTest<AccountManagementDbCont
         Connection.Insert("Users", [
                 ("TenantId", tenant2Id.Value),
                 ("Id", user2Id.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Email", DatabaseSeeder.Tenant1Member.Email),
                 ("EmailConfirmed", true),

--- a/application/account-management/Tests/EndpointBaseTest.cs
+++ b/application/account-management/Tests/EndpointBaseTest.cs
@@ -29,6 +29,7 @@ public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : 
     protected readonly IEmailClient EmailClient;
     protected readonly Faker Faker = new();
     protected readonly ServiceCollection Services;
+    protected readonly TimeProvider TimeProvider;
     private readonly WebApplicationFactory<Program> _webApplicationFactory;
     protected TelemetryEventsCollectorSpy TelemetryEventsCollectorSpy;
 
@@ -42,6 +43,7 @@ public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : 
         );
 
         Services = new ServiceCollection();
+        TimeProvider = TimeProvider.System;
 
         Services.AddLogging();
         Services.AddTransient<DatabaseSeeder>();

--- a/application/account-management/Tests/Signups/CompleteSignupTests.cs
+++ b/application/account-management/Tests/Signups/CompleteSignupTests.cs
@@ -142,12 +142,12 @@ public sealed class CompleteSignupTests : EndpointBaseTest<AccountManagementDbCo
         var emailConfirmationId = EmailConfirmationId.NewId();
         Connection.Insert("EmailConfirmations", [
                 ("Id", emailConfirmationId.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", email),
                 ("Type", EmailConfirmationType.Signup),
                 ("OneTimePasswordHash", new PasswordHasher<object>().HashPassword(this, CorrectOneTimePassword)),
-                ("ValidUntil", TimeProvider.System.GetUtcNow().AddMinutes(-5)),
+                ("ValidUntil", TimeProvider.GetUtcNow().AddMinutes(-5)),
                 ("RetryCount", 0),
                 ("ResendCount", 0),
                 ("Completed", false)

--- a/application/account-management/Tests/Signups/StartSignupTests.cs
+++ b/application/account-management/Tests/Signups/StartSignupTests.cs
@@ -78,12 +78,12 @@ public sealed class StartSignupTests : EndpointBaseTest<AccountManagementDbConte
             var oneTimePasswordHash = new PasswordHasher<object>().HashPassword(this, OneTimePasswordHelper.GenerateOneTimePassword(6));
             Connection.Insert("EmailConfirmations", [
                     ("Id", EmailConfirmationId.NewId().ToString()),
-                    ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-i)),
+                    ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-i)),
                     ("ModifiedAt", null),
                     ("Email", email),
                     ("Type", nameof(EmailConfirmationType.Signup)),
                     ("OneTimePasswordHash", oneTimePasswordHash),
-                    ("ValidUntil", TimeProvider.System.GetUtcNow().AddMinutes(-i - 1)), // All should be expired
+                    ("ValidUntil", TimeProvider.GetUtcNow().AddMinutes(-i - 1)), // All should be expired
                     ("RetryCount", 0),
                     ("ResendCount", 0),
                     ("Completed", false)

--- a/application/account-management/Tests/Tenants/DeleteTenantTests.cs
+++ b/application/account-management/Tests/Tenants/DeleteTenantTests.cs
@@ -36,7 +36,7 @@ public sealed class DeleteTenantTests : EndpointBaseTest<AccountManagementDbCont
         Connection.Insert("Users", [
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", UserId.NewId().ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", Faker.Internet.UniqueEmail()),
                 ("FirstName", Faker.Person.FirstName),

--- a/application/account-management/Tests/Tenants/GetTenantsForUserTests.cs
+++ b/application/account-management/Tests/Tenants/GetTenantsForUserTests.cs
@@ -25,7 +25,7 @@ public sealed class GetTenantsForUserTests : EndpointBaseTest<AccountManagementD
 
         Connection.Insert("Tenants", [
                 ("Id", tenant2Id.Value),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", tenant2Name),
                 ("State", nameof(TenantState.Active)),
@@ -36,7 +36,7 @@ public sealed class GetTenantsForUserTests : EndpointBaseTest<AccountManagementD
         Connection.Insert("Users", [
                 ("TenantId", tenant2Id.Value),
                 ("Id", user2Id.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Email", DatabaseSeeder.Tenant1Member.Email),
                 ("EmailConfirmed", true),
@@ -98,7 +98,7 @@ public sealed class GetTenantsForUserTests : EndpointBaseTest<AccountManagementD
 
         Connection.Insert("Tenants", [
                 ("Id", otherTenantId.Value),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", "Other Tenant"),
                 ("State", nameof(TenantState.Active)),
@@ -109,7 +109,7 @@ public sealed class GetTenantsForUserTests : EndpointBaseTest<AccountManagementD
         Connection.Insert("Users", [
                 ("TenantId", otherTenantId.Value),
                 ("Id", otherUserId.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Email", email),
                 ("EmailConfirmed", true),
@@ -142,7 +142,7 @@ public sealed class GetTenantsForUserTests : EndpointBaseTest<AccountManagementD
 
         Connection.Insert("Tenants", [
                 ("Id", otherUserTenantId.Value),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", "Other User Tenant"),
                 ("State", nameof(TenantState.Active)),
@@ -153,7 +153,7 @@ public sealed class GetTenantsForUserTests : EndpointBaseTest<AccountManagementD
         Connection.Insert("Users", [
                 ("TenantId", otherUserTenantId.Value),
                 ("Id", otherUserId.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Email", otherUserEmail),
                 ("EmailConfirmed", true),
@@ -187,7 +187,7 @@ public sealed class GetTenantsForUserTests : EndpointBaseTest<AccountManagementD
 
         Connection.Insert("Tenants", [
                 ("Id", tenant2Id.Value),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", tenant2Name),
                 ("State", nameof(TenantState.Active)),
@@ -198,7 +198,7 @@ public sealed class GetTenantsForUserTests : EndpointBaseTest<AccountManagementD
         Connection.Insert("Users", [
                 ("TenantId", tenant2Id.Value),
                 ("Id", user2Id.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Email", DatabaseSeeder.Tenant1Member.Email),
                 ("EmailConfirmed", false), // User has not confirmed email in this tenant

--- a/application/account-management/Tests/Users/BulkDeleteUsersTests.cs
+++ b/application/account-management/Tests/Users/BulkDeleteUsersTests.cs
@@ -27,7 +27,7 @@ public sealed class BulkDeleteUsersTests : EndpointBaseTest<AccountManagementDbC
             Connection.Insert("Users", [
                     ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                     ("Id", userId.ToString()),
-                    ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                    ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-10)),
                     ("ModifiedAt", null),
                     ("Email", Faker.Internet.UniqueEmail()),
                     ("FirstName", Faker.Person.FirstName),

--- a/application/account-management/Tests/Users/DeclineInvitationTests.cs
+++ b/application/account-management/Tests/Users/DeclineInvitationTests.cs
@@ -24,7 +24,7 @@ public sealed class DeclineInvitationTests : EndpointBaseTest<AccountManagementD
 
         Connection.Insert("Tenants", [
                 ("Id", newTenantId.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", Faker.Company.CompanyName()),
                 ("State", nameof(TenantState.Trial)),
@@ -35,7 +35,7 @@ public sealed class DeclineInvitationTests : EndpointBaseTest<AccountManagementD
         Connection.Insert("Users", [
                 ("TenantId", newTenantId.ToString()),
                 ("Id", userId.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", DatabaseSeeder.Tenant1Member.Email),
                 ("EmailConfirmed", false),
@@ -94,7 +94,7 @@ public sealed class DeclineInvitationTests : EndpointBaseTest<AccountManagementD
 
         Connection.Insert("Tenants", [
                 ("Id", tenant2Id.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", Faker.Company.CompanyName()),
                 ("State", nameof(TenantState.Trial)),
@@ -104,7 +104,7 @@ public sealed class DeclineInvitationTests : EndpointBaseTest<AccountManagementD
 
         Connection.Insert("Tenants", [
                 ("Id", tenant3Id.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow()),
+                ("CreatedAt", TimeProvider.GetUtcNow()),
                 ("ModifiedAt", null),
                 ("Name", Faker.Company.CompanyName()),
                 ("State", nameof(TenantState.Trial)),
@@ -115,7 +115,7 @@ public sealed class DeclineInvitationTests : EndpointBaseTest<AccountManagementD
         Connection.Insert("Users", [
                 ("TenantId", tenant2Id.ToString()),
                 ("Id", userId2.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", DatabaseSeeder.Tenant1Member.Email),
                 ("EmailConfirmed", false),
@@ -131,7 +131,7 @@ public sealed class DeclineInvitationTests : EndpointBaseTest<AccountManagementD
         Connection.Insert("Users", [
                 ("TenantId", tenant3Id.ToString()),
                 ("Id", userId3.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-5)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-5)),
                 ("ModifiedAt", null),
                 ("Email", DatabaseSeeder.Tenant1Member.Email),
                 ("EmailConfirmed", false),

--- a/application/account-management/Tests/Users/DeleteUserTests.cs
+++ b/application/account-management/Tests/Users/DeleteUserTests.cs
@@ -35,7 +35,7 @@ public sealed class DeleteUserTests : EndpointBaseTest<AccountManagementDbContex
         Connection.Insert("Users", [
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", userId.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", Faker.Internet.UniqueEmail()),
                 ("FirstName", Faker.Person.FirstName),
@@ -77,7 +77,7 @@ public sealed class DeleteUserTests : EndpointBaseTest<AccountManagementDbContex
         Connection.Insert("Users", [
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", userId.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", Faker.Internet.UniqueEmail()),
                 ("FirstName", Faker.Person.FirstName),
@@ -97,7 +97,7 @@ public sealed class DeleteUserTests : EndpointBaseTest<AccountManagementDbContex
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", loginId.ToString()),
                 ("UserId", userId.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-5)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-5)),
                 ("ModifiedAt", null),
                 ("EmailConfirmationId", emailConfirmationId.ToString()),
                 ("Completed", true)

--- a/application/account-management/Tests/Users/GetUserByIdTests.cs
+++ b/application/account-management/Tests/Users/GetUserByIdTests.cs
@@ -20,7 +20,7 @@ public sealed class GetUserByIdTests : EndpointBaseTest<AccountManagementDbConte
         Connection.Insert("Users", [
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", _userId.ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", Faker.Internet.UniqueEmail()),
                 ("FirstName", Faker.Name.FirstName()),

--- a/application/account-management/Tests/Users/GetUsersTests.cs
+++ b/application/account-management/Tests/Users/GetUsersTests.cs
@@ -22,7 +22,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
         Connection.Insert("Users", [
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", UserId.NewId().ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", Email),
                 ("FirstName", FirstName),
@@ -37,7 +37,7 @@ public sealed class GetUsersTests : EndpointBaseTest<AccountManagementDbContext>
         Connection.Insert("Users", [
                 ("TenantId", DatabaseSeeder.Tenant1.Id.ToString()),
                 ("Id", UserId.NewId().ToString()),
-                ("CreatedAt", TimeProvider.System.GetUtcNow().AddMinutes(-10)),
+                ("CreatedAt", TimeProvider.GetUtcNow().AddMinutes(-10)),
                 ("ModifiedAt", null),
                 ("Email", "ada@lovelace.com"),
                 ("FirstName", "Ada"),

--- a/application/back-office/Core/Database/BackOfficeDbContext.cs
+++ b/application/back-office/Core/Database/BackOfficeDbContext.cs
@@ -4,5 +4,5 @@ using PlatformPlatform.SharedKernel.ExecutionContext;
 
 namespace PlatformPlatform.BackOffice.Database;
 
-public sealed class BackOfficeDbContext(DbContextOptions<BackOfficeDbContext> options, IExecutionContext executionContext)
-    : SharedKernelDbContext<BackOfficeDbContext>(options, executionContext);
+public sealed class BackOfficeDbContext(DbContextOptions<BackOfficeDbContext> options, IExecutionContext executionContext, TimeProvider timeProvider)
+    : SharedKernelDbContext<BackOfficeDbContext>(options, executionContext, timeProvider);

--- a/application/back-office/Tests/EndpointBaseTest.cs
+++ b/application/back-office/Tests/EndpointBaseTest.cs
@@ -29,6 +29,7 @@ public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : 
     protected readonly IEmailClient EmailClient;
     protected readonly Faker Faker = new();
     protected readonly ServiceCollection Services;
+    [UsedImplicitly] protected readonly TimeProvider TimeProvider;
     private readonly WebApplicationFactory<Program> _webApplicationFactory;
     protected TelemetryEventsCollectorSpy TelemetryEventsCollectorSpy;
 
@@ -42,6 +43,7 @@ public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : 
         );
 
         Services = new ServiceCollection();
+        TimeProvider = TimeProvider.System;
 
         Services.AddLogging();
         Services.AddTransient<DatabaseSeeder>();

--- a/application/shared-kernel/SharedKernel/Authentication/TokenGeneration/AccessTokenGenerator.cs
+++ b/application/shared-kernel/SharedKernel/Authentication/TokenGeneration/AccessTokenGenerator.cs
@@ -5,7 +5,7 @@ using PlatformPlatform.SharedKernel.Authentication.TokenSigning;
 
 namespace PlatformPlatform.SharedKernel.Authentication.TokenGeneration;
 
-public sealed class AccessTokenGenerator(ITokenSigningClient tokenSigningClient)
+public sealed class AccessTokenGenerator(ITokenSigningClient tokenSigningClient, TimeProvider timeProvider)
 {
     // Access tokens should only be valid for a very short time and cannot be revoked.
     // For example, if a user gets a new role, the changes will not take effect until the access token expires.
@@ -31,8 +31,10 @@ public sealed class AccessTokenGenerator(ITokenSigningClient tokenSigningClient)
             )
         };
 
+        var now = timeProvider.GetUtcNow();
         return tokenDescriptor.GenerateToken(
-            TimeProvider.System.GetUtcNow().AddMinutes(ValidForMinutes).UtcDateTime,
+            now,
+            now.AddMinutes(ValidForMinutes),
             tokenSigningClient.Issuer,
             tokenSigningClient.Audience,
             tokenSigningClient.GetSigningCredentials()

--- a/application/shared-kernel/SharedKernel/Authentication/TokenGeneration/RefreshTokenGenerator.cs
+++ b/application/shared-kernel/SharedKernel/Authentication/TokenGeneration/RefreshTokenGenerator.cs
@@ -5,7 +5,7 @@ using PlatformPlatform.SharedKernel.Authentication.TokenSigning;
 
 namespace PlatformPlatform.SharedKernel.Authentication.TokenGeneration;
 
-public sealed class RefreshTokenGenerator(ITokenSigningClient tokenSigningClient)
+public sealed class RefreshTokenGenerator(ITokenSigningClient tokenSigningClient, TimeProvider timeProvider)
 {
     // Refresh tokens are stored as a persistent cookie in the user's browser.
     // Similar to Facebook and GitHub, when a user logs in, the session will be valid for a very long time.
@@ -13,7 +13,7 @@ public sealed class RefreshTokenGenerator(ITokenSigningClient tokenSigningClient
 
     public string Generate(UserInfo userInfo)
     {
-        return GenerateRefreshToken(userInfo, RefreshTokenId.NewId(), 1, TimeProvider.System.GetUtcNow().AddHours(ValidForHours));
+        return GenerateRefreshToken(userInfo, RefreshTokenId.NewId(), 1, timeProvider.GetUtcNow().AddHours(ValidForHours));
     }
 
     public string Update(UserInfo userInfo, RefreshTokenId refreshTokenId, int currentRefreshTokenVersion, DateTimeOffset expires)
@@ -38,6 +38,7 @@ public sealed class RefreshTokenGenerator(ITokenSigningClient tokenSigningClient
         };
 
         return tokenDescriptor.GenerateToken(
+            timeProvider.GetUtcNow(),
             expires,
             tokenSigningClient.Issuer,
             tokenSigningClient.Audience,

--- a/application/shared-kernel/SharedKernel/Authentication/TokenGeneration/SecurityTokenDescriptorExtensions.cs
+++ b/application/shared-kernel/SharedKernel/Authentication/TokenGeneration/SecurityTokenDescriptorExtensions.cs
@@ -7,8 +7,10 @@ internal static class SecurityTokenDescriptorExtensions
 {
     extension(SecurityTokenDescriptor tokenDescriptor)
     {
-        internal string GenerateToken(DateTimeOffset expires, string issuer, string audience, SigningCredentials signingCredentials)
+        internal string GenerateToken(DateTimeOffset now, DateTimeOffset expires, string issuer, string audience, SigningCredentials signingCredentials)
         {
+            tokenDescriptor.NotBefore = now.UtcDateTime;
+            tokenDescriptor.IssuedAt = now.UtcDateTime;
             tokenDescriptor.Expires = expires.UtcDateTime;
             tokenDescriptor.Issuer = issuer;
             tokenDescriptor.Audience = audience;

--- a/application/shared-kernel/SharedKernel/Configuration/SharedDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/SharedDependencyConfiguration.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using PlatformPlatform.SharedKernel.Authentication;
 using PlatformPlatform.SharedKernel.Authentication.TokenGeneration;
@@ -66,6 +67,7 @@ public static class SharedDependencyConfiguration
                 .AddSingleton(GetTokenSigningService())
                 .AddCrossServiceDataProtection()
                 .AddSingleton(Settings.Current)
+                .AddTimeProvider()
                 .AddAuthentication()
                 .AddDefaultJsonSerializerOptions()
                 .AddPersistenceHelpers<T>()
@@ -87,6 +89,12 @@ public static class SharedDependencyConfiguration
                 dataProtection.SetApplicationName("PlatformPlatform");
             }
 
+            return services;
+        }
+
+        private IServiceCollection AddTimeProvider()
+        {
+            services.TryAddSingleton(TimeProvider.System); // Use Try to allow tests to override with a fake TimeProvider
             return services;
         }
 

--- a/application/shared-kernel/SharedKernel/Domain/AudibleEntity.cs
+++ b/application/shared-kernel/SharedKernel/Domain/AudibleEntity.cs
@@ -8,15 +8,12 @@ namespace PlatformPlatform.SharedKernel.Domain;
 /// </summary>
 public abstract class AudibleEntity<T>(T id) : Entity<T>(id), IAuditableEntity where T : IComparable<T>
 {
-    public DateTimeOffset CreatedAt { get; init; } = TimeProvider.System.GetUtcNow();
+    public DateTimeOffset CreatedAt { get; init; } = TimeProviderAccessor.Current.GetUtcNow();
 
     [ConcurrencyCheck]
     public DateTimeOffset? ModifiedAt { get; private set; }
 
-    /// <summary>
-    ///     This method is used by the UpdateAuditableEntitiesInterceptor in the Infrastructure layer.
-    ///     It's not intended to be used by the application, which is why it is implemented using an explicit interface.
-    /// </summary>
+    // Used by UpdateAuditableEntitiesInterceptor via explicit interface implementation
     void IAuditableEntity.UpdateModifiedAt(DateTimeOffset? modifiedAt)
     {
         ModifiedAt = modifiedAt;

--- a/application/shared-kernel/SharedKernel/EntityFramework/ITimeProviderSource.cs
+++ b/application/shared-kernel/SharedKernel/EntityFramework/ITimeProviderSource.cs
@@ -1,0 +1,9 @@
+namespace PlatformPlatform.SharedKernel.EntityFramework;
+
+/// <summary>
+///     Exposes TimeProvider for use in Entity Framework Core interceptors without knowing the concrete DbContext type.
+/// </summary>
+internal interface ITimeProviderSource
+{
+    TimeProvider TimeProvider { get; }
+}

--- a/application/shared-kernel/SharedKernel/EntityFramework/SharedKernelDbContext.cs
+++ b/application/shared-kernel/SharedKernel/EntityFramework/SharedKernelDbContext.cs
@@ -11,10 +11,12 @@ namespace PlatformPlatform.SharedKernel.EntityFramework;
 ///     The SharedKernelDbContext class represents the Entity Framework Core DbContext for managing data access to the
 ///     database, like creation, querying, and updating of <see cref="IAggregateRoot" /> entities.
 /// </summary>
-public abstract class SharedKernelDbContext<TContext>(DbContextOptions<TContext> options, IExecutionContext executionContext)
-    : DbContext(options) where TContext : DbContext
+public abstract class SharedKernelDbContext<TContext>(DbContextOptions<TContext> options, IExecutionContext executionContext, TimeProvider timeProvider)
+    : DbContext(options), ITimeProviderSource where TContext : DbContext
 {
     protected TenantId? TenantId => executionContext.TenantId;
+
+    public TimeProvider TimeProvider => timeProvider;
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {

--- a/application/shared-kernel/SharedKernel/TimeProviderAccessor.cs
+++ b/application/shared-kernel/SharedKernel/TimeProviderAccessor.cs
@@ -1,0 +1,17 @@
+namespace PlatformPlatform.SharedKernel;
+
+/// <summary>
+///     Provides access to the current TimeProvider using AsyncLocal for thread-safe, async-context-isolated access.
+///     This allows domain entities to get the current time during construction while remaining testable.
+///     Each async context (including parallel tests) has its own isolated TimeProvider instance.
+/// </summary>
+public static class TimeProviderAccessor
+{
+    private static readonly AsyncLocal<TimeProvider> CurrentTimeProvider = new();
+
+    public static TimeProvider Current
+    {
+        get => CurrentTimeProvider.Value ?? TimeProvider.System;
+        set => CurrentTimeProvider.Value = value;
+    }
+}

--- a/application/shared-kernel/Tests/EntityFramework/MapStronglyTypedStringTests.cs
+++ b/application/shared-kernel/Tests/EntityFramework/MapStronglyTypedStringTests.cs
@@ -17,7 +17,7 @@ public sealed class MapStronglyTypedStringTests : IDisposable
     public MapStronglyTypedStringTests()
     {
         var executionContext = new BackgroundWorkerExecutionContext();
-        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext);
+        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext, TimeProvider.System);
         _testDbContext = _sqliteInMemoryDbContextFactory.CreateContext();
         _connection = (SqliteConnection)_testDbContext.Database.GetDbConnection();
     }

--- a/application/shared-kernel/Tests/EntityFramework/SaveChangesInterceptorTests.cs
+++ b/application/shared-kernel/Tests/EntityFramework/SaveChangesInterceptorTests.cs
@@ -13,7 +13,7 @@ public sealed class SaveChangesInterceptorTests : IDisposable
     public SaveChangesInterceptorTests()
     {
         var executionContext = new BackgroundWorkerExecutionContext();
-        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext);
+        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext, TimeProvider.System);
         _testDbContext = _sqliteInMemoryDbContextFactory.CreateContext();
     }
 

--- a/application/shared-kernel/Tests/EntityFramework/UseStringForEnumsTests.cs
+++ b/application/shared-kernel/Tests/EntityFramework/UseStringForEnumsTests.cs
@@ -17,7 +17,7 @@ public sealed class UseStringForEnumsTests : IDisposable
     public UseStringForEnumsTests()
     {
         var executionContext = new BackgroundWorkerExecutionContext();
-        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext);
+        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext, TimeProvider.System);
         _testDbContext = _sqliteInMemoryDbContextFactory.CreateContext();
         _connection = (SqliteConnection)_testDbContext.Database.GetDbConnection();
     }

--- a/application/shared-kernel/Tests/Persistence/RepositoryTests.cs
+++ b/application/shared-kernel/Tests/Persistence/RepositoryTests.cs
@@ -16,7 +16,7 @@ public sealed class RepositoryTests : IDisposable
     public RepositoryTests()
     {
         var executionContext = new BackgroundWorkerExecutionContext();
-        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext);
+        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext, TimeProvider.System);
         _testDbContext = _sqliteInMemoryDbContextFactory.CreateContext();
         _testAggregateRepository = new TestAggregateRepository(_testDbContext);
     }

--- a/application/shared-kernel/Tests/Persistence/SqliteConnectionExtensions.cs
+++ b/application/shared-kernel/Tests/Persistence/SqliteConnectionExtensions.cs
@@ -61,10 +61,12 @@ public static class SqliteConnectionExtensions
                     not null when valueType == typeof(byte[]) => SqliteType.Blob,
                     not null when valueType == typeof(string) => SqliteType.Text,
                     not null when valueType == typeof(DateTime) => SqliteType.Text, // SQLite stores dates as text
+                    not null when valueType == typeof(DateTimeOffset) => SqliteType.Text, // SQLite stores dates as text
                     not null when valueType == typeof(Guid) => SqliteType.Text, // Store GUIDs as text
                     null => SqliteType.Text, // Handle null values by setting SqliteType to Text
                     _ => SqliteType.Text // Default to Text if the type is unknown
                 };
+
                 var parameter = new SqliteParameter($"@{column.Item1}", sqliteType) { Value = column.Item2 ?? DBNull.Value };
                 command.Parameters.Add(parameter);
             }
@@ -106,10 +108,12 @@ public static class SqliteConnectionExtensions
                     not null when valueType == typeof(byte[]) => SqliteType.Blob,
                     not null when valueType == typeof(string) => SqliteType.Text,
                     not null when valueType == typeof(DateTime) => SqliteType.Text, // SQLite stores dates as text
+                    not null when valueType == typeof(DateTimeOffset) => SqliteType.Text, // SQLite stores dates as text
                     not null when valueType == typeof(Guid) => SqliteType.Text, // Store GUIDs as text
                     null => SqliteType.Text, // Handle null values by setting SqliteType to Text
                     _ => SqliteType.Text // Default to Text if the type is unknown
                 };
+
                 var parameter = new SqliteParameter($"@{column.Item1}", sqliteType) { Value = column.Item2 ?? DBNull.Value };
                 command.Parameters.Add(parameter);
             }

--- a/application/shared-kernel/Tests/Persistence/UnitOfWorkTests.cs
+++ b/application/shared-kernel/Tests/Persistence/UnitOfWorkTests.cs
@@ -16,7 +16,7 @@ public sealed class UnitOfWorkTests : IDisposable
     public UnitOfWorkTests()
     {
         var executionContext = new BackgroundWorkerExecutionContext();
-        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext);
+        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<TestDbContext>(executionContext, TimeProvider.System);
         _testDbContext = _sqliteInMemoryDbContextFactory.CreateContext();
         _unitOfWork = new UnitOfWork(_testDbContext);
     }

--- a/application/shared-kernel/Tests/TestEntities/SqliteInMemoryDbContextFactory.cs
+++ b/application/shared-kernel/Tests/TestEntities/SqliteInMemoryDbContextFactory.cs
@@ -8,10 +8,12 @@ public sealed class SqliteInMemoryDbContextFactory<T> : IDisposable where T : Db
 {
     private readonly IExecutionContext _executionContext;
     private readonly SqliteConnection _sqliteConnection;
+    private readonly TimeProvider _timeProvider;
 
-    public SqliteInMemoryDbContextFactory(IExecutionContext executionContext)
+    public SqliteInMemoryDbContextFactory(IExecutionContext executionContext, TimeProvider timeProvider)
     {
         _executionContext = executionContext;
+        _timeProvider = timeProvider;
         _sqliteConnection = new SqliteConnection("DataSource=:memory:");
         _sqliteConnection.Open();
     }
@@ -25,7 +27,7 @@ public sealed class SqliteInMemoryDbContextFactory<T> : IDisposable where T : Db
     {
         var options = CreateOptions();
 
-        var context = (T)Activator.CreateInstance(typeof(T), options, _executionContext)!;
+        var context = (T)Activator.CreateInstance(typeof(T), options, _executionContext, _timeProvider)!;
         context.Database.EnsureCreated();
 
         return context;

--- a/application/shared-kernel/Tests/TestEntities/TestDbContext.cs
+++ b/application/shared-kernel/Tests/TestEntities/TestDbContext.cs
@@ -4,8 +4,8 @@ using PlatformPlatform.SharedKernel.ExecutionContext;
 
 namespace PlatformPlatform.SharedKernel.Tests.TestEntities;
 
-public sealed class TestDbContext(DbContextOptions<TestDbContext> options, IExecutionContext executionContext)
-    : SharedKernelDbContext<TestDbContext>(options, executionContext)
+public sealed class TestDbContext(DbContextOptions<TestDbContext> options, IExecutionContext executionContext, TimeProvider timeProvider)
+    : SharedKernelDbContext<TestDbContext>(options, executionContext, timeProvider)
 {
     public DbSet<TestAggregate> TestAggregates => Set<TestAggregate>();
 


### PR DESCRIPTION
### Summary & Motivation

Replaces all static `DateTimeOffset.UtcNow` and `TimeProvider.System.GetUtcNow()` calls with injected `TimeProvider` to enable time mocking in tests. This makes time-sensitive business logic (expiration, rate limiting, token generation) fully testable.

Key changes:
- **Services inject TimeProvider**: `AccessTokenGenerator`, `RefreshTokenGenerator`, `BlobStorageClient`, and handlers now inject TimeProvider for timestamp operations
- **Domain methods accept DateTimeOffset**: Methods like `EmailConfirmation.HasExpired()` now accept `DateTimeOffset now` parameter instead of calling static time directly, maintaining clean domain boundaries
- **TimeProviderAccessor for entity construction**: Introduces `TimeProviderAccessor` using `AsyncLocal<TimeProvider>` to provide `CreatedAt` timestamps during entity construction, ensuring computed properties like `EmailConfirmation.ValidUntil` calculate correctly immediately after creation
- **UpdateAuditableEntitiesInterceptor**: Now uses TimeProvider from DbContext for setting `ModifiedAt`, with validation that `CreatedAt` is already set
- **Test infrastructure**: Tests use `TimeProvider.System` by default; `TimeProviderAccessor.Current` can be overridden for tests requiring time control
- **DbContext updates**: All `SharedKernelDbContext` implementations now accept `TimeProvider` as dependency and implement `ITimeProviderSource` interface
- **SecurityTokenDescriptorExtensions**: Token generation now accepts both `now` and `expires` timestamps to properly set `NotBefore` and `IssuedAt` claims

Minor fixes:
- Added `DateTimeOffset` type handling in `SqliteConnectionExtensions.Insert()` for test data
- Updated backend AI rules documentation to reflect TimeProvider usage patterns

### Downstream projects

Search for `TimeProvider.System` in your codebase and apply these changes:

1. Update your DbContext implementations to accept and pass `TimeProvider`:

```diff
-public sealed class YourDbContext(DbContextOptions<YourDbContext> options, IExecutionContext executionContext)
-    : SharedKernelDbContext<YourDbContext>(options, executionContext);
+public sealed class YourDbContext(DbContextOptions<YourDbContext> options, IExecutionContext executionContext, TimeProvider timeProvider)
+    : SharedKernelDbContext<YourDbContext>(options, executionContext, timeProvider);
```

2. Inject `TimeProvider` into all handlers, services, and repositories that use timestamps, and replace `TimeProvider.System.GetUtcNow()` with `timeProvider.GetUtcNow()`:

```diff
-public sealed class YourHandler(IRepository repository)
+public sealed class YourHandler(IRepository repository, TimeProvider timeProvider)
     : IRequestHandler<YourCommand, Result>
 {
     public async Task<Result> Handle(YourCommand command, CancellationToken cancellationToken)
     {
-        var expiresAt = TimeProvider.System.GetUtcNow().AddMinutes(30);
+        var expiresAt = timeProvider.GetUtcNow().AddMinutes(30);
         // ...
     }
 }
```

3. Update `your-self-contained-system/Tests/EndpointBaseTest.cs` to add TimeProvider field:

```diff
 public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : DbContext
 {
     protected readonly ServiceCollection Services;
+    [UsedImplicitly] protected readonly TimeProvider TimeProvider;
     
     protected EndpointBaseTest()
     {
         Services = new ServiceCollection();
+        TimeProvider = TimeProvider.System;
         // ...
     }
 }
```

4. Replace all `TimeProvider.System.GetUtcNow()` calls with `TimeProvider.GetUtcNow()` in test files to use the instance field.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary