### PR TITLE
Delete old migration PR comments

### DIFF
--- a/.github/workflows/_migrate-database.yml
+++ b/.github/workflows/_migrate-database.yml
@@ -190,7 +190,28 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.rest.issues.createComment({
+            // Delete previous migration info comments
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+
+            const MIGRATION_HEADER = '## Approve Database Migration';
+
+            for (const comment of comments.data) {
+              if (comment.body && comment.body.startsWith(MIGRATION_HEADER)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id
+                });
+              }
+            }
+
+            // Add the new migration info comment
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
### Summary & Motivation

The workflow now deletes all previous migration information comments from the pull request before posting a new migration info comment.
This prevents repeated migration comments from accumulating on the same PR when multiple pushes occur.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
