### PR TITLE
Fix production deployments failing due to missing -global suffix in staging registry reference

### DIFF
--- a/.github/workflows/_deploy-container.yml
+++ b/.github/workflows/_deploy-container.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Import Container Image from Staging to Production
         if: inputs.azure_environment == 'prod'
         run: |
-          STAGING_REGISTRY_ID="/subscriptions/${{ vars.STAGING_SUBSCRIPTION_ID }}/resourceGroups/${{ env.UNIQUE_PREFIX }}-stage/providers/Microsoft.ContainerRegistry/registries/${{ env.UNIQUE_PREFIX }}stage"
+          STAGING_REGISTRY_ID="/subscriptions/${{ vars.STAGING_SUBSCRIPTION_ID }}/resourceGroups/${{ env.UNIQUE_PREFIX }}-stage-global/providers/Microsoft.ContainerRegistry/registries/${{ env.UNIQUE_PREFIX }}stage"
 
           az acr import \
             --name ${{ env.UNIQUE_PREFIX }}${{ env.ENVIRONMENT }} \


### PR DESCRIPTION
### Summary & Motivation

Fix production container deployments failing to import images from the staging registry. The `STAGING_REGISTRY_ID` in `_deploy-container.yml` was missing the `-global` suffix in the resource group name, a bug introduced in #793 when the global resource group was renamed. This is currently preventing all deployments to production.

- Update resource group reference from `{prefix}-stage` to `{prefix}-stage-global` to match the actual location of the staging container registry

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary