### PR TITLE
Fix antiforgery token errors by restoring autoConfigureDataProtection in Azure Container Apps

### DIFF
--- a/cloud-infrastructure/modules/container-app.bicep
+++ b/cloud-infrastructure/modules/container-app.bicep
@@ -60,7 +60,7 @@ var image = useQuickStartImage
 // Create a revisionSuffix that contains the version and random suffix. E.g. "2025-11-19-756-a3f2"
 var fullRevisionSuffix = '${replace(containerImageTag, '.', '-')}-${revisionSuffix}'
 
-resource containerApp 'Microsoft.App/containerApps@2025-07-01' = {
+resource containerApp 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: name
   location: location
   tags: tags
@@ -149,6 +149,11 @@ resource containerApp 'Microsoft.App/containerApps@2025-07-01' = {
           identity: userAssignedIdentity.id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
       ingress: ingress
         ? {
             external: external


### PR DESCRIPTION
### Summary & Motivation

Upgrade the Azure Container Apps API version from `2025-07-01` (stable) to `2025-10-02-preview` to restore the `autoConfigureDataProtection` runtime setting for .NET containers.

When upgrading to the stable `2025-07-01` API version in PR #793, the `autoConfigureDataProtection` feature was inadvertently lost because it remains a preview-only feature not included in stable releases. This change reverts to a preview API version that supports this feature, which enables automatic configuration of ASP.NET Data Protection keys across all container apps in an environment - essential for antiforgery token validation when multiple container apps (AppGateway, account-management, back-office, etc.) need to share encrypted tokens.

The learning here is that stable API versions may not include all preview features that the infrastructure depends on. When upgrading API versions, verify that preview features are still available or consciously choose to remain on a preview version until the required features become stable.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary