### PR TITLE
Add named query filters and soft delete infrastructure to shared kernel

### DIFF
--- a/application/shared-kernel/SharedKernel/Domain/ISoftDeletable.cs
+++ b/application/shared-kernel/SharedKernel/Domain/ISoftDeletable.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace PlatformPlatform.SharedKernel.Domain;
+
+/// <summary>
+///     Interface for entities that support soft delete functionality.
+///     Entities implementing this interface will be filtered from queries by default
+///     and can be restored or permanently deleted.
+/// </summary>
+public interface ISoftDeletable
+{
+    /// <summary>
+    ///     The timestamp when the entity was soft-deleted, or null if not deleted.
+    /// </summary>
+    DateTimeOffset? DeletedAt { get; }
+
+    /// <summary>
+    ///     When true, the soft delete interceptor will not convert the delete to a soft delete,
+    ///     allowing the entity to be permanently removed from the database.
+    /// </summary>
+    [NotMapped]
+    bool ForceHardDelete { get; }
+
+    /// <summary>
+    ///     Marks the entity as deleted by setting the DeletedAt timestamp.
+    /// </summary>
+    void MarkAsDeleted(DateTimeOffset deletedAt);
+
+    /// <summary>
+    ///     Restores a soft-deleted entity by clearing the DeletedAt timestamp.
+    /// </summary>
+    void Restore();
+
+    /// <summary>
+    ///     Marks the entity for permanent deletion, bypassing the soft delete interceptor.
+    /// </summary>
+    void MarkForHardDelete();
+}

--- a/application/shared-kernel/SharedKernel/Domain/ISoftDeletableRepository.cs
+++ b/application/shared-kernel/SharedKernel/Domain/ISoftDeletableRepository.cs
@@ -1,0 +1,39 @@
+namespace PlatformPlatform.SharedKernel.Domain;
+
+/// <summary>
+///     Interface for repositories that manage soft-deletable aggregates.
+///     Extends standard repository operations with methods for querying deleted entities,
+///     restoring them, and permanently removing them from the database.
+/// </summary>
+public interface ISoftDeletableRepository<T, in TId> where T : IAggregateRoot, ISoftDeletable
+{
+    /// <summary>
+    ///     Retrieves a soft-deleted entity by its ID, ignoring the soft delete filter.
+    /// </summary>
+    Task<T?> GetDeletedByIdAsync(TId id, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Retrieves all soft-deleted entities, ignoring the soft delete filter.
+    /// </summary>
+    Task<T[]> GetAllDeletedAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Restores a soft-deleted entity by clearing its DeletedAt timestamp.
+    /// </summary>
+    void Restore(T aggregate);
+
+    /// <summary>
+    ///     Permanently removes an entity from the database, bypassing soft delete.
+    /// </summary>
+    void PermanentlyRemove(T aggregate);
+
+    /// <summary>
+    ///     Restores multiple soft-deleted entities.
+    /// </summary>
+    void RestoreRange(T[] aggregates);
+
+    /// <summary>
+    ///     Permanently removes multiple entities from the database.
+    /// </summary>
+    void PermanentlyRemoveRange(T[] aggregates);
+}

--- a/application/shared-kernel/SharedKernel/EntityFramework/QueryFilterNames.cs
+++ b/application/shared-kernel/SharedKernel/EntityFramework/QueryFilterNames.cs
@@ -1,0 +1,20 @@
+namespace PlatformPlatform.SharedKernel.EntityFramework;
+
+/// <summary>
+///     Contains the names of EF Core named query filters used throughout the application.
+///     Named filters allow selective disabling at query time using IgnoreQueryFilters(["FilterName"]).
+/// </summary>
+public static class QueryFilterNames
+{
+    /// <summary>
+    ///     Filter that restricts queries to entities belonging to the current tenant.
+    ///     Applied to all entities implementing <see cref="Domain.ITenantScopedEntity" />.
+    /// </summary>
+    public const string Tenant = "Tenant";
+
+    /// <summary>
+    ///     Filter that excludes soft-deleted entities from queries.
+    ///     Applied to all entities implementing <see cref="Domain.ISoftDeletable" />.
+    /// </summary>
+    public const string SoftDelete = "SoftDelete";
+}

--- a/application/shared-kernel/SharedKernel/EntityFramework/SoftDeleteInterceptor.cs
+++ b/application/shared-kernel/SharedKernel/EntityFramework/SoftDeleteInterceptor.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using PlatformPlatform.SharedKernel.Domain;
+
+namespace PlatformPlatform.SharedKernel.EntityFramework;
+
+/// <summary>
+///     The SoftDeleteInterceptor intercepts delete operations and converts them to soft deletes
+///     for entities implementing <see cref="ISoftDeletable" />. When an entity is marked for deletion,
+///     instead of physically removing it from the database, the DeletedAt timestamp is set.
+/// </summary>
+public sealed class SoftDeleteInterceptor : SaveChangesInterceptor
+{
+    public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
+    {
+        ProcessSoftDeletes(eventData);
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+    {
+        ProcessSoftDeletes(eventData);
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    private static void ProcessSoftDeletes(DbContextEventData eventData)
+    {
+        var dbContext = eventData.Context ?? throw new UnreachableException("The 'eventData.Context' property is unexpectedly null.");
+
+        var timeProvider = dbContext is ITimeProviderSource timeProviderSource
+            ? timeProviderSource.TimeProvider
+            : TimeProvider.System;
+
+        var deletedEntities = dbContext.ChangeTracker.Entries<ISoftDeletable>()
+            .Where(e => e.State is EntityState.Deleted && !e.Entity.ForceHardDelete);
+
+        foreach (var entityEntry in deletedEntities)
+        {
+            entityEntry.State = EntityState.Modified;
+            entityEntry.Entity.MarkAsDeleted(timeProvider.GetUtcNow());
+        }
+    }
+}

--- a/application/shared-kernel/SharedKernel/Persistence/RepositoryBase.cs
+++ b/application/shared-kernel/SharedKernel/Persistence/RepositoryBase.cs
@@ -62,7 +62,7 @@ public abstract class RepositoryBase<T, TId>(DbContext context)
         await DbSet.AddRangeAsync(aggregates, cancellationToken);
     }
 
-    public void UpdateRange(T[] aggregates)
+    protected void UpdateRange(T[] aggregates)
     {
         DbSet.UpdateRange(aggregates);
     }

--- a/application/shared-kernel/SharedKernel/Persistence/SoftDeletableRepositoryBase.cs
+++ b/application/shared-kernel/SharedKernel/Persistence/SoftDeletableRepositoryBase.cs
@@ -1,0 +1,86 @@
+using Microsoft.EntityFrameworkCore;
+using PlatformPlatform.SharedKernel.Domain;
+using PlatformPlatform.SharedKernel.EntityFramework;
+
+namespace PlatformPlatform.SharedKernel.Persistence;
+
+/// <summary>
+///     Base class for repositories managing soft-deletable aggregates.
+///     Extends <see cref="RepositoryBase{T,TId}" /> with operations for querying deleted entities,
+///     restoring them, and permanently removing them from the database.
+/// </summary>
+[UsedImplicitly(ImplicitUseTargetFlags.WithInheritors)]
+public abstract class SoftDeletableRepositoryBase<T, TId>(DbContext context)
+    : RepositoryBase<T, TId>(context), ISoftDeletableRepository<T, TId>
+    where T : AggregateRoot<TId>, ISoftDeletable where TId : IComparable<TId>
+{
+    /// <summary>
+    ///     Retrieves a soft-deleted entity by its ID, ignoring the soft delete filter.
+    ///     The tenant filter is still applied for tenant-scoped entities.
+    /// </summary>
+    public async Task<T?> GetDeletedByIdAsync(TId id, CancellationToken cancellationToken)
+    {
+        return await DbSet
+            .IgnoreQueryFilters([QueryFilterNames.SoftDelete])
+            .Where(e => e.DeletedAt != null)
+            .SingleOrDefaultAsync(e => e.Id.Equals(id), cancellationToken);
+    }
+
+    /// <summary>
+    ///     Retrieves all soft-deleted entities, ignoring the soft delete filter.
+    ///     The tenant filter is still applied for tenant-scoped entities.
+    /// </summary>
+    public async Task<T[]> GetAllDeletedAsync(CancellationToken cancellationToken)
+    {
+        return await DbSet
+            .IgnoreQueryFilters([QueryFilterNames.SoftDelete])
+            .Where(e => e.DeletedAt != null)
+            .ToArrayAsync(cancellationToken);
+    }
+
+    /// <summary>
+    ///     Restores a soft-deleted entity by clearing its DeletedAt timestamp.
+    /// </summary>
+    public void Restore(T aggregate)
+    {
+        ArgumentNullException.ThrowIfNull(aggregate);
+        aggregate.Restore();
+        Update(aggregate);
+    }
+
+    /// <summary>
+    ///     Permanently removes an entity from the database, bypassing soft delete.
+    /// </summary>
+    public void PermanentlyRemove(T aggregate)
+    {
+        ArgumentNullException.ThrowIfNull(aggregate);
+        aggregate.MarkForHardDelete();
+        Remove(aggregate);
+    }
+
+    /// <summary>
+    ///     Restores multiple soft-deleted entities.
+    /// </summary>
+    public void RestoreRange(T[] aggregates)
+    {
+        foreach (var aggregate in aggregates)
+        {
+            aggregate.Restore();
+        }
+
+        UpdateRange(aggregates);
+    }
+
+    /// <summary>
+    ///     Permanently removes multiple entities from the database.
+    /// </summary>
+    public void PermanentlyRemoveRange(T[] aggregates)
+    {
+        foreach (var aggregate in aggregates)
+        {
+            aggregate.MarkForHardDelete();
+        }
+
+        RemoveRange(aggregates);
+    }
+}

--- a/application/shared-kernel/Tests/EntityFramework/SoftDeleteTests.cs
+++ b/application/shared-kernel/Tests/EntityFramework/SoftDeleteTests.cs
@@ -1,0 +1,261 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using PlatformPlatform.SharedKernel.ExecutionContext;
+using PlatformPlatform.SharedKernel.Tests.TestEntities;
+using Xunit;
+
+namespace PlatformPlatform.SharedKernel.Tests.EntityFramework;
+
+public sealed class SoftDeleteTests : IDisposable
+{
+    private readonly SqliteInMemoryDbContextFactory<SoftDeletableTestDbContext> _sqliteInMemoryDbContextFactory;
+
+    public SoftDeleteTests()
+    {
+        var executionContext = new BackgroundWorkerExecutionContext();
+        _sqliteInMemoryDbContextFactory = new SqliteInMemoryDbContextFactory<SoftDeletableTestDbContext>(executionContext, TimeProvider.System);
+    }
+
+    public void Dispose()
+    {
+        _sqliteInMemoryDbContextFactory.Dispose();
+    }
+
+    [Fact]
+    public async Task Remove_WhenCalledOnSoftDeletableEntity_ShouldSetDeletedAtInsteadOfDeleting()
+    {
+        // Arrange
+        var testDbContext1 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository1 = new SoftDeletableTestAggregateRepository(testDbContext1);
+        var aggregate = SoftDeletableTestAggregate.Create("TestAggregate");
+        await repository1.AddAsync(aggregate, CancellationToken.None);
+        await testDbContext1.SaveChangesAsync();
+        var aggregateId = aggregate.Id;
+        repository1.Remove(aggregate);
+        await testDbContext1.SaveChangesAsync();
+        var testDbContext2 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository2 = new SoftDeletableTestAggregateRepository(testDbContext2);
+
+        // Act
+        var retrievedAggregate = await testDbContext2.SoftDeletableTestAggregates.SingleOrDefaultAsync(e => e.Id == aggregateId);
+        var deletedAggregate = (await repository2.GetDeletedByIdAsync(aggregateId, CancellationToken.None))!;
+
+        // Assert
+        retrievedAggregate.Should().BeNull();
+        deletedAggregate.DeletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetAllDeletedAsync_ShouldReturnOnlySoftDeletedEntities()
+    {
+        // Arrange
+        var testDbContext = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository = new SoftDeletableTestAggregateRepository(testDbContext);
+        var activeAggregate = SoftDeletableTestAggregate.Create("ActiveAggregate");
+        var deletedAggregate1 = SoftDeletableTestAggregate.Create("DeletedAggregate1");
+        var deletedAggregate2 = SoftDeletableTestAggregate.Create("DeletedAggregate2");
+        await repository.AddAsync(activeAggregate, CancellationToken.None);
+        await repository.AddAsync(deletedAggregate1, CancellationToken.None);
+        await repository.AddAsync(deletedAggregate2, CancellationToken.None);
+        await testDbContext.SaveChangesAsync();
+        repository.Remove(deletedAggregate1);
+        repository.Remove(deletedAggregate2);
+        await testDbContext.SaveChangesAsync();
+        var testDbContext2 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository2 = new SoftDeletableTestAggregateRepository(testDbContext2);
+
+        // Act
+        var allDeleted = await repository2.GetAllDeletedAsync(CancellationToken.None);
+
+        // Assert
+        allDeleted.Should().HaveCount(2);
+        allDeleted.Should().Contain(a => a.Name == "DeletedAggregate1");
+        allDeleted.Should().Contain(a => a.Name == "DeletedAggregate2");
+        allDeleted.Should().NotContain(a => a.Name == "ActiveAggregate");
+    }
+
+    [Fact]
+    public async Task Restore_WhenCalledOnSoftDeletedEntity_ShouldClearDeletedAt()
+    {
+        // Arrange
+        var testDbContext1 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository1 = new SoftDeletableTestAggregateRepository(testDbContext1);
+        var aggregate = SoftDeletableTestAggregate.Create("TestAggregate");
+        await repository1.AddAsync(aggregate, CancellationToken.None);
+        await testDbContext1.SaveChangesAsync();
+        var aggregateId = aggregate.Id;
+        repository1.Remove(aggregate);
+        await testDbContext1.SaveChangesAsync();
+        var testDbContext2 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository2 = new SoftDeletableTestAggregateRepository(testDbContext2);
+        var deletedAggregate = (await repository2.GetDeletedByIdAsync(aggregateId, CancellationToken.None))!;
+
+        // Act
+        repository2.Restore(deletedAggregate);
+        await testDbContext2.SaveChangesAsync();
+
+        // Assert
+        var testDbContext3 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var restoredAggregate = (await testDbContext3.SoftDeletableTestAggregates.SingleOrDefaultAsync(e => e.Id == aggregateId))!;
+        restoredAggregate.DeletedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PermanentlyRemove_WhenCalled_ShouldDeleteEntityFromDatabase()
+    {
+        // Arrange
+        var testDbContext1 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository1 = new SoftDeletableTestAggregateRepository(testDbContext1);
+        var aggregate = SoftDeletableTestAggregate.Create("TestAggregate");
+        await repository1.AddAsync(aggregate, CancellationToken.None);
+        await testDbContext1.SaveChangesAsync();
+        var aggregateId = aggregate.Id;
+        repository1.Remove(aggregate);
+        await testDbContext1.SaveChangesAsync();
+        var testDbContext2 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository2 = new SoftDeletableTestAggregateRepository(testDbContext2);
+        var deletedAggregate = (await repository2.GetDeletedByIdAsync(aggregateId, CancellationToken.None))!;
+
+        // Act
+        repository2.PermanentlyRemove(deletedAggregate);
+        await testDbContext2.SaveChangesAsync();
+
+        // Assert
+        var testDbContext3 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository3 = new SoftDeletableTestAggregateRepository(testDbContext3);
+        var normalQuery = await testDbContext3.SoftDeletableTestAggregates.SingleOrDefaultAsync(e => e.Id == aggregateId);
+        normalQuery.Should().BeNull();
+        var deletedQuery = await repository3.GetDeletedByIdAsync(aggregateId, CancellationToken.None);
+        deletedQuery.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RestoreRange_WhenCalledOnMultipleEntities_ShouldRestoreAll()
+    {
+        // Arrange
+        var testDbContext1 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository1 = new SoftDeletableTestAggregateRepository(testDbContext1);
+        var aggregate1 = SoftDeletableTestAggregate.Create("TestAggregate1");
+        var aggregate2 = SoftDeletableTestAggregate.Create("TestAggregate2");
+        await repository1.AddAsync(aggregate1, CancellationToken.None);
+        await repository1.AddAsync(aggregate2, CancellationToken.None);
+        await testDbContext1.SaveChangesAsync();
+        var id1 = aggregate1.Id;
+        var id2 = aggregate2.Id;
+        repository1.Remove(aggregate1);
+        repository1.Remove(aggregate2);
+        await testDbContext1.SaveChangesAsync();
+        var testDbContext2 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository2 = new SoftDeletableTestAggregateRepository(testDbContext2);
+        var deletedAggregates = await repository2.GetAllDeletedAsync(CancellationToken.None);
+
+        // Act
+        repository2.RestoreRange(deletedAggregates);
+        await testDbContext2.SaveChangesAsync();
+
+        // Assert
+        var testDbContext3 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository3 = new SoftDeletableTestAggregateRepository(testDbContext3);
+        var stillDeleted = await repository3.GetAllDeletedAsync(CancellationToken.None);
+        stillDeleted.Should().BeEmpty();
+        var restored1 = await testDbContext3.SoftDeletableTestAggregates.SingleOrDefaultAsync(e => e.Id == id1);
+        var restored2 = await testDbContext3.SoftDeletableTestAggregates.SingleOrDefaultAsync(e => e.Id == id2);
+        restored1.Should().NotBeNull();
+        restored2.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task PermanentlyRemoveRange_WhenCalledOnMultipleEntities_ShouldDeleteAll()
+    {
+        // Arrange
+        var testDbContext1 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository1 = new SoftDeletableTestAggregateRepository(testDbContext1);
+        var aggregate1 = SoftDeletableTestAggregate.Create("TestAggregate1");
+        var aggregate2 = SoftDeletableTestAggregate.Create("TestAggregate2");
+        await repository1.AddAsync(aggregate1, CancellationToken.None);
+        await repository1.AddAsync(aggregate2, CancellationToken.None);
+        await testDbContext1.SaveChangesAsync();
+        var id1 = aggregate1.Id;
+        var id2 = aggregate2.Id;
+        repository1.Remove(aggregate1);
+        repository1.Remove(aggregate2);
+        await testDbContext1.SaveChangesAsync();
+        var testDbContext2 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository2 = new SoftDeletableTestAggregateRepository(testDbContext2);
+        var deletedAggregates = await repository2.GetAllDeletedAsync(CancellationToken.None);
+
+        // Act
+        repository2.PermanentlyRemoveRange(deletedAggregates);
+        await testDbContext2.SaveChangesAsync();
+
+        // Assert
+        var testDbContext3 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository3 = new SoftDeletableTestAggregateRepository(testDbContext3);
+        var stillDeleted = await repository3.GetAllDeletedAsync(CancellationToken.None);
+        stillDeleted.Should().BeEmpty();
+        var normalQuery1 = await testDbContext3.SoftDeletableTestAggregates.SingleOrDefaultAsync(e => e.Id == id1);
+        var normalQuery2 = await testDbContext3.SoftDeletableTestAggregates.SingleOrDefaultAsync(e => e.Id == id2);
+        normalQuery1.Should().BeNull();
+        normalQuery2.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SoftDeleteInterceptor_WhenEntityIsModified_ShouldUpdateModifiedAt()
+    {
+        // Arrange
+        var testDbContext = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository = new SoftDeletableTestAggregateRepository(testDbContext);
+        var aggregate = SoftDeletableTestAggregate.Create("TestAggregate");
+        await repository.AddAsync(aggregate, CancellationToken.None);
+        await testDbContext.SaveChangesAsync();
+        var initialModifiedAt = aggregate.ModifiedAt;
+
+        // Act
+        aggregate.Name = "UpdatedName";
+        repository.Update(aggregate);
+        await testDbContext.SaveChangesAsync();
+
+        // Assert
+        aggregate.ModifiedAt.Should().NotBe(initialModifiedAt);
+    }
+
+    [Fact]
+    public async Task GetDeletedByIdAsync_WhenEntityIsNotDeleted_ShouldReturnNull()
+    {
+        // Arrange
+        var testDbContext = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository = new SoftDeletableTestAggregateRepository(testDbContext);
+        var aggregate = SoftDeletableTestAggregate.Create("TestAggregate");
+        await repository.AddAsync(aggregate, CancellationToken.None);
+        await testDbContext.SaveChangesAsync();
+        var testDbContext2 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository2 = new SoftDeletableTestAggregateRepository(testDbContext2);
+
+        // Act
+        var result = await repository2.GetDeletedByIdAsync(aggregate.Id, CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenEntityIsSoftDeleted_ShouldReturnNull()
+    {
+        // Arrange
+        var testDbContext1 = _sqliteInMemoryDbContextFactory.CreateContext();
+        var repository1 = new SoftDeletableTestAggregateRepository(testDbContext1);
+        var aggregate = SoftDeletableTestAggregate.Create("TestAggregate");
+        await repository1.AddAsync(aggregate, CancellationToken.None);
+        await testDbContext1.SaveChangesAsync();
+        var aggregateId = aggregate.Id;
+        repository1.Remove(aggregate);
+        await testDbContext1.SaveChangesAsync();
+        var testDbContext2 = _sqliteInMemoryDbContextFactory.CreateContext();
+
+        // Act
+        var result = await testDbContext2.SoftDeletableTestAggregates.SingleOrDefaultAsync(e => e.Id == aggregateId);
+
+        // Assert
+        result.Should().BeNull();
+    }
+}

--- a/application/shared-kernel/Tests/TestEntities/ISoftDeletableTestAggregateRepository.cs
+++ b/application/shared-kernel/Tests/TestEntities/ISoftDeletableTestAggregateRepository.cs
@@ -1,0 +1,5 @@
+using PlatformPlatform.SharedKernel.Domain;
+
+namespace PlatformPlatform.SharedKernel.Tests.TestEntities;
+
+public interface ISoftDeletableTestAggregateRepository : ICrudRepository<SoftDeletableTestAggregate, long>, ISoftDeletableRepository<SoftDeletableTestAggregate, long>;

--- a/application/shared-kernel/Tests/TestEntities/SoftDeletableTestAggregate.cs
+++ b/application/shared-kernel/Tests/TestEntities/SoftDeletableTestAggregate.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using PlatformPlatform.SharedKernel.Domain;
+using PlatformPlatform.SharedKernel.StronglyTypedIds;
+
+namespace PlatformPlatform.SharedKernel.Tests.TestEntities;
+
+public sealed class SoftDeletableTestAggregate(string name) : AggregateRoot<long>(IdGenerator.NewId()), ISoftDeletable
+{
+    // ReSharper disable once EntityFramework.ModelValidation.UnlimitedStringLength
+    public string Name { get; set; } = name;
+
+    public DateTimeOffset? DeletedAt { get; private set; }
+
+    [NotMapped]
+    public bool ForceHardDelete { get; private set; }
+
+    public void MarkAsDeleted(DateTimeOffset deletedAt)
+    {
+        DeletedAt = deletedAt;
+    }
+
+    public void Restore()
+    {
+        DeletedAt = null;
+    }
+
+    public void MarkForHardDelete()
+    {
+        ForceHardDelete = true;
+    }
+
+    public static SoftDeletableTestAggregate Create(string name)
+    {
+        return new SoftDeletableTestAggregate(name);
+    }
+}

--- a/application/shared-kernel/Tests/TestEntities/SoftDeletableTestAggregateRepository.cs
+++ b/application/shared-kernel/Tests/TestEntities/SoftDeletableTestAggregateRepository.cs
@@ -1,0 +1,6 @@
+using PlatformPlatform.SharedKernel.Persistence;
+
+namespace PlatformPlatform.SharedKernel.Tests.TestEntities;
+
+public sealed class SoftDeletableTestAggregateRepository(SoftDeletableTestDbContext testDbContext)
+    : SoftDeletableRepositoryBase<SoftDeletableTestAggregate, long>(testDbContext), ISoftDeletableTestAggregateRepository;

--- a/application/shared-kernel/Tests/TestEntities/SoftDeletableTestDbContext.cs
+++ b/application/shared-kernel/Tests/TestEntities/SoftDeletableTestDbContext.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using PlatformPlatform.SharedKernel.EntityFramework;
+using PlatformPlatform.SharedKernel.ExecutionContext;
+
+namespace PlatformPlatform.SharedKernel.Tests.TestEntities;
+
+public sealed class SoftDeletableTestDbContext(DbContextOptions<SoftDeletableTestDbContext> options, IExecutionContext executionContext, TimeProvider timeProvider)
+    : SharedKernelDbContext<SoftDeletableTestDbContext>(options, executionContext, timeProvider)
+{
+    public DbSet<SoftDeletableTestAggregate> SoftDeletableTestAggregates => Set<SoftDeletableTestAggregate>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.UseStringForEnums();
+    }
+}


### PR DESCRIPTION
### Summary & Motivation

Introduce EF Core 10 named query filters and opt-in soft delete support for aggregates in the shared kernel. Named query filters allow multiple independently manageable filters per entity that can be selectively disabled at query time using `IgnoreQueryFilters(["FilterName"])`.

- Convert the existing tenant query filter to a named filter ("Tenant") using EF Core 10's `HasQueryFilter(name, lambda)` syntax
- Add "SoftDelete" named query filter for entities implementing `ISoftDeletable`
- Create `SoftDeleteInterceptor` that automatically converts delete operations to soft deletes by setting `DeletedAt` instead of removing the entity
- Add `ISoftDeletableRepository<T, TId>` and `SoftDeletableRepositoryBase<T, TId>` with operations for querying deleted entities, restoring them, and permanently removing them

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary