### PR TITLE
Fix client IP address detection to show real user IP instead of AppGateway internal IP

### DIFF
--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -5,7 +5,6 @@ using PlatformPlatform.AppGateway.Middleware;
 using PlatformPlatform.AppGateway.Transformations;
 using PlatformPlatform.SharedKernel.Configuration;
 using Scalar.AspNetCore;
-using Yarp.ReverseProxy.Transforms;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,12 +13,7 @@ var reverseProxyBuilder = builder.Services
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"))
     .AddConfigFilter<ClusterDestinationConfigFilter>()
     .AddConfigFilter<ApiExplorerRouteFilter>()
-    .AddTransforms(context =>
-        {
-            context.AddXForwarded();
-            context.RequestTransforms.Add(context.Services.GetRequiredService<BlockInternalApiTransform>());
-        }
-    );
+    .AddTransforms(context => context.RequestTransforms.Add(context.Services.GetRequiredService<BlockInternalApiTransform>()));
 
 if (SharedInfrastructureConfiguration.IsRunningInAzure)
 {


### PR DESCRIPTION
### Summary & Motivation

Fix the Sessions dialog showing the AppGateway's internal IP address (e.g., `10.0.0.54`) instead of the user's real public IP address. This regression was introduced in commit `c67bdac` which added YARP's `AddXForwarded` transform.

- Remove YARP's `AddXForwarded()` transform from AppGateway, which was replacing the original `X-Forwarded-For` header set by Azure Container Apps ingress
- Update `HttpExecutionContext.ClientIpAddress` to read the `X-Forwarded-For` header directly and extract the first IP address (the original client), with a fallback to `RemoteIpAddress` for local development

The previous approach relied on `UseForwardedHeaders` middleware processing the header correctly across multiple proxy hops, but YARP's `AddXForwarded` transform was overwriting the header with the wrong IP before it reached the backend API.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary