### PR TITLE
Check out shell scripts with Unix line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Enforce consistent line endings for all text files
 * text=auto
+
+# Shell scripts must use LF line endings (even on Windows)
+*.sh text eol=lf


### PR DESCRIPTION
### Summary & Motivation

Updates .gitattributes to check out `.sh` files with Unix line endings (`\n`) on all platforms, including Windows.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
