### PR TITLE
Rework issue templates as AI-actionable prompts and fix broken links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,12 +1,11 @@
 name: Report a bug
 description: File a bug report
-title: "[Bug]: "
-labels: ["bug"]
+labels: ["Bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report!
+        Write your bug report as a clear prompt that an AI agent can act on. Focus on observable behavior, steps to reproduce, and expected outcome.
   - type: input
     id: contact
     attributes:
@@ -16,19 +15,21 @@ body:
     validations:
       required: false
   - type: textarea
-    id: detailed-description
+    id: description
     attributes:
-      label: Detailed description?
-      description: Also tell us more about the bug, and what you were expecting.
+      label: Bug description
+      description: Describe the bug as if you are instructing an AI to investigate and fix it.
       value: |
-        **Describe the bug**
-        A clear and concise description of the bug.
+        **What happens?**
+        When I [do X], [Y happens] instead of [expected Z].
 
-        **Expected behavior**
-        A clear and concise description of what you expected to happen.
+        **Steps to reproduce**
+        1. ...
+        2. ...
+        3. ...
 
-        **Additional context**
-        Add any other context about the problem here.
+        **Error messages or logs**
+        ...
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,12 +1,11 @@
 name: Add a feature request
 description: Suggest an idea for this project
-title: "[Feature]: "
-labels: ["enhancement"]
+labels: ["Enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this feature request!
+        Write your feature request as a clear prompt that an AI agent can act on. Focus on the problem, desired outcome, and any constraints.
   - type: input
     id: contact
     attributes:
@@ -16,22 +15,19 @@ body:
     validations:
       required: false
   - type: textarea
-    id: detailed-description
+    id: description
     attributes:
-      label: Detailed description?
-      description: Tell us more about the feature request and what you would like to see.
+      label: Feature description
+      description: Describe the feature as if you are instructing an AI to implement it.
       value: |
-        **Is your feature request related to a problem? Please describe.**
-        A clear and concise description of what the problem is.
+        **Problem**
+        What problem does this solve or what need does it address?
 
-        **Describe the solution you'd like**
-        A clear and concise description of what you want to happen.
+        **Desired behavior**
+        What should happen when this feature is implemented?
 
-        **Describe alternatives you've considered**
-        A clear and concise description of any alternative solutions or features you've considered.
-
-        **Additional context**
-        Add any other context or screenshots about the feature request here.
+        **Constraints or considerations**
+        Any technical constraints, design preferences, or edge cases to keep in mind.
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
### Summary & Motivation

Rework the GitHub issue templates to be structured as prompts that an AI agent can act on directly. The previous templates used generic boilerplate text ("Thanks for taking the time...") and vague headings that required interpretation.

- Restructure the bug report template with clear sections: "What happens?", "Steps to reproduce", and "Error messages or logs"
- Restructure the feature request template with clear sections: "Problem", "Desired behavior", and "Constraints or considerations"
- Guide reporters to write in a prompt-like style via the intro text
- Remove `[Bug]:` and `[Feature]:` title prefixes -- labels are auto-applied instead
- Fix broken relative URLs for the security advisory form and Code of Conduct (relative links do not work in issue template YAML files)

### Downstream projects

Update the hardcoded repository URLs in both templates to point to the correct downstream repository.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary