### PR TITLE
Upgrade GitHub Actions to latest major versions to avoid Node 20 deprecation

### DIFF
--- a/.github/workflows/_deploy-container.yml
+++ b/.github/workflows/_deploy-container.yml
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifacts_name }}
           path: ${{ inputs.artifacts_path }}

--- a/.github/workflows/_deploy-container.yml
+++ b/.github/workflows/_deploy-container.yml
@@ -58,7 +58,7 @@ jobs:
           path: ${{ inputs.artifacts_path }}
 
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ env.SERVICE_PRINCIPAL_ID }}
           tenant-id: ${{ env.TENANT_ID }}
@@ -83,7 +83,7 @@ jobs:
       # For staging, build and push the image
       - name: Setup Docker Buildx
         if: inputs.azure_environment == 'stage'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and Push Container Image
         if: inputs.azure_environment == 'stage'

--- a/.github/workflows/_deploy-infrastructure.yml
+++ b/.github/workflows/_deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
           bicep --version
 
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ inputs.service_principal_id }}
           tenant-id: ${{ inputs.tenant_id }}
@@ -132,7 +132,7 @@ jobs:
           bicep --version
 
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ inputs.service_principal_id }}
           tenant-id: ${{ inputs.tenant_id }}
@@ -152,7 +152,7 @@ jobs:
         run: bash ./cloud-infrastructure/cluster/deploy-cluster.sh ${{ inputs.unique_prefix }} ${{ inputs.azure_environment }} ${{ inputs.cluster_location }} ${{ inputs.cluster_location_acronym }} ${{ inputs.postgres_admin_object_id }} ${{ inputs.domain_name }} --apply
 
       - name: Refresh Azure Tokens # The previous step may take a while, so we refresh the token to avoid timeouts
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ inputs.service_principal_id }}
           tenant-id: ${{ inputs.tenant_id }}

--- a/.github/workflows/_deploy-infrastructure.yml
+++ b/.github/workflows/_deploy-infrastructure.yml
@@ -57,7 +57,7 @@ jobs:
           fi
           echo "should_deploy=$should_deploy" >> $GITHUB_OUTPUT
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Bicep CLI
         run: |
@@ -122,7 +122,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Bicep CLI
         run: |

--- a/.github/workflows/_migrate-database.yml
+++ b/.github/workflows/_migrate-database.yml
@@ -73,7 +73,7 @@ jobs:
         run: dotnet build ${{ inputs.relative_startup_project }}
 
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ inputs.service_principal_id }}
           tenant-id: ${{ env.TENANT_ID }}
@@ -248,7 +248,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ inputs.service_principal_id }}
           tenant-id: ${{ env.TENANT_ID }}

--- a/.github/workflows/_migrate-database.yml
+++ b/.github/workflows/_migrate-database.yml
@@ -57,10 +57,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: application/global.json
 
@@ -150,7 +150,7 @@ jobs:
 
       - name: Upload Migration Script
         if: steps.generate-migration-script.outputs.has_migrations_to_apply == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: migration-script-${{ inputs.azure_environment }}-${{ inputs.cluster_location_acronym }}
           path: application/migration.sql
@@ -158,7 +158,7 @@ jobs:
       - name: Generate Migration Information
         id: migration-info
         if: steps.generate-migration-script.outputs.has_migrations_to_apply == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           MIGRATION_JSON: ${{ steps.generate-migration-script.outputs.migration_json }}
           MIGRATION_SCRIPT: ${{ steps.generate-migration-script.outputs.migration_script }}
@@ -185,7 +185,7 @@ jobs:
 
       - name: Add Migration Information to Pull Request
         if: github.event_name == 'pull_request' && steps.generate-migration-script.outputs.has_migrations_to_apply == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           MIGRATION_INFO: ${{ steps.migration-info.outputs.markdown }}
         with:
@@ -221,7 +221,7 @@ jobs:
 
       - name: Add Migration Information to Summary
         if: steps.generate-migration-script.outputs.has_migrations_to_apply == 'true' && inputs.azure_environment == 'prod'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           MIGRATION_INFO: ${{ steps.migration-info.outputs.markdown }}
         with:
@@ -245,7 +245,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Azure
         uses: azure/login@v2
@@ -255,7 +255,7 @@ jobs:
           subscription-id: ${{ inputs.subscription_id }}
 
       - name: Download Migration Script
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: migration-script-${{ inputs.azure_environment }}-${{ inputs.cluster_location_acronym }}
           path: .
@@ -280,7 +280,7 @@ jobs:
           echo "Migrations applied successfully!"
 
       - name: Display Migration Summary
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: core.summary.addRaw(`✅ Migrations successfully applied to \`${{ inputs.database_name }}\` database on \`${{ inputs.azure_environment }}\`.`).write();
 

--- a/.github/workflows/account.yml
+++ b/.github/workflows/account.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate Version
         id: generate_version
@@ -64,7 +64,7 @@ jobs:
           echo "deploy_production=$deploy_production" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -73,7 +73,7 @@ jobs:
         run: npm ci
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: application/global.json
 
@@ -95,7 +95,7 @@ jobs:
           dotnet user-secrets set "authentication-token-signing-key" "$(openssl rand -base64 64)" --id $USER_SECRETS_ID
 
       - name: Setup Java JDK for SonarScanner
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "microsoft"
           java-version: "17"
@@ -135,7 +135,7 @@ jobs:
 
       - name: Save API Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: account-api
           path: application/account/Api/publish/**/*
@@ -148,7 +148,7 @@ jobs:
 
       - name: Save Workers Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: account-workers
           path: application/account/Workers/publish/**/*
@@ -160,10 +160,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -172,7 +172,7 @@ jobs:
         run: npm ci
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: application/global.json
 

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate Version
         id: generate_version
@@ -57,7 +57,7 @@ jobs:
           echo "deploy_production=$deploy_production" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -66,7 +66,7 @@ jobs:
         run: npm ci
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: application/global.json
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Save Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-gateway
           path: application/AppGateway/publish/**/*
@@ -104,10 +104,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -116,7 +116,7 @@ jobs:
         run: npm ci
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: application/global.json
 

--- a/.github/workflows/back-office.yml
+++ b/.github/workflows/back-office.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate Version
         id: generate_version
@@ -64,7 +64,7 @@ jobs:
           echo "deploy_production=$deploy_production" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -73,7 +73,7 @@ jobs:
         run: npm ci
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: application/global.json
 
@@ -95,7 +95,7 @@ jobs:
           dotnet user-secrets set "authentication-token-signing-key" "$(openssl rand -base64 64)" --id $USER_SECRETS_ID
 
       - name: Setup Java JDK for SonarScanner
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "microsoft"
           java-version: "17"
@@ -135,7 +135,7 @@ jobs:
 
       - name: Save API Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: back-office-api
           path: application/back-office/Api/publish/**/*
@@ -148,7 +148,7 @@ jobs:
 
       - name: Save Workers Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: back-office-workers
           path: application/back-office/Workers/publish/**/*
@@ -160,10 +160,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -172,7 +172,7 @@ jobs:
         run: npm ci
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: application/global.json
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate Version
         id: generate_version
@@ -64,7 +64,7 @@ jobs:
           echo "deploy_production=$deploy_production" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -73,7 +73,7 @@ jobs:
         run: npm ci
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: application/global.json
 
@@ -95,7 +95,7 @@ jobs:
           dotnet user-secrets set "authentication-token-signing-key" "$(openssl rand -base64 64)" --id $USER_SECRETS_ID
 
       - name: Setup Java JDK for SonarScanner
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "microsoft"
           java-version: "17"
@@ -135,7 +135,7 @@ jobs:
 
       - name: Save API Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: main-api
           path: application/main/Api/publish/**/*
@@ -148,7 +148,7 @@ jobs:
 
       - name: Save Workers Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: main-workers
           path: application/main/Workers/publish/**/*
@@ -160,10 +160,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -172,7 +172,7 @@ jobs:
         run: npm ci
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: application/global.json
 

--- a/.github/workflows/pull-request-conventions.yml
+++ b/.github/workflows/pull-request-conventions.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
### Summary & Motivation

Upgrade all GitHub Actions to their latest major versions ahead of the Node.js 20 deprecation deadline on June 2nd, 2026. GitHub will force JavaScript actions to run with Node.js 24 by default after that date.

- `actions/checkout` v4 → v6, `actions/setup-node` v4 → v6, `actions/setup-dotnet` v4 → v5, `actions/setup-java` v4 → v5
- `actions/upload-artifact` v4 → v7, `actions/download-artifact` v4 → v8, `actions/github-script` v7 → v8
- `azure/login` v2 → v3, `docker/setup-buildx-action` v3 → v4

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary