### PR TITLE
Move shared translations into Shared WebApp

### DIFF
--- a/.claude/rules/frontend/translations.md
+++ b/.claude/rules/frontend/translations.md
@@ -14,13 +14,16 @@ Guidelines for implementing translations and internationalization in the fronten
 3. Always use plain English text in translation markers
 4. Don't hardcode text without proper translation wrappers
 5. Use "Sentence case" for everything (buttons, menus, headings, etc.)
-6. **Lingui macros work in `shared-webapp/ui` components**. The SWC plugin runs in source-build mode across all workspace packages, and each self-contained system's `createLinguiConfig()` includes `shared-webapp/ui/**/*.{ts,tsx}` in its extraction scope. This means every shared UI component auto-generates catalog entries in every self-contained system (main, account, back-office) independently. Prefer macros over threading translatable text through props -- only accept a text prop when a consumer genuinely needs to override the default (e.g., context-specific wording). Note: shared strings must be translated in every self-contained system's `*.po` files -- translation workflow must keep all three self-contained systems in sync
+6. **Catalogs are split between the shared component library and each self-contained system**:
+   - Markers in `application/shared-webapp/ui/**` extract to `application/shared-webapp/ui/translations/locale/{locale}.po` — one shared catalog used by every app
+   - Markers in `application/<system>/WebApp/**` extract to that system's `shared/translations/locale/{locale}.po`
+   - At runtime, `createFederatedTranslation` merges them: shared underneath, system on top, federated remote (e.g. account loaded into main) on top of that
+   - Translate each shared string **once** in the shared catalog, not in every system's catalog
+   - Prefer Lingui macros inside `shared-webapp/ui` components over threading translatable text through props -- only accept a text prop when a consumer genuinely needs to override the default (e.g., context-specific wording)
 7. Translation workflow:
-   - Translation files are in `shared/translations/locale/` (e.g., `da-DK.po`, `en-US.po`)
-   - After adding/changing `<Trans>` or t\`\` markers, the `*.po` files are auto-generated/updated by the build system
-   - Don't manually add or remove entries to `*.po` files
-   - After auto-generation, translate all new/updated entries in `*.po` files for all supported languages
-   - Only translate `msgstr` values—never change `msgid` values
+   - After adding/changing `<Trans>` or t\`\` markers, the `*.po` files are auto-regenerated on build
+   - Don't manually add or remove `msgid` entries -- only translate `msgstr` values
+   - After auto-generation, translate all new/updated entries for all supported languages
 8. **Use correct language-specific characters** in translations -- e.g., Danish requires æøå/ÆØÅ, not ae/oe/aa substitutes. Never approximate with ASCII equivalents
 9. Don't translate fully dynamic content such as variable values or dynamic text
 9. **Domain terminology consistency**:

--- a/application/account/WebApp/package.json
+++ b/application/account/WebApp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "npm run update-translations && npm run swagger && rsbuild build",
+    "build": "npm run swagger && rsbuild build",
     "check": "oxfmt --check && oxlint",
     "dev": "rsbuild dev",
     "dev:setup": "npm run update-translations && npm run swagger",

--- a/application/account/WebApp/routes/components/-components/PreviewAvatarMenu.tsx
+++ b/application/account/WebApp/routes/components/-components/PreviewAvatarMenu.tsx
@@ -2,6 +2,7 @@ import { t } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
 import { Trans } from "@lingui/react/macro";
 import { preferredLocaleKey } from "@repo/infrastructure/translations/constants";
+import localeMap from "@repo/infrastructure/translations/i18n.config.json";
 import { type Locale, translationContext } from "@repo/infrastructure/translations/TranslationContext";
 import { Avatar, AvatarFallback } from "@repo/ui/components/Avatar";
 import {
@@ -81,7 +82,9 @@ function FakeProfileCard() {
 export function PreviewAvatarMenu() {
   const isCollapsed = useContext(collapsedContext);
   const { theme, setTheme, resolvedTheme } = useTheme();
-  const { setLocale, getLocaleInfo, locales } = use(translationContext);
+  const { setLocale } = use(translationContext);
+  const locales = Object.keys(localeMap) as Locale[];
+  const getLocaleInfo = (locale: Locale) => localeMap[locale];
   const { i18n } = useLingui();
   const currentLocale = i18n.locale as Locale;
   const [currentZoomLevel, setCurrentZoomLevel] = useState("1");

--- a/application/account/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account/WebApp/shared/translations/locale/da-DK.po
@@ -13,10 +13,6 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: @lingui/cli\n"
 
-#. placeholder {0}: -diffDays
-msgid "{0, plural, one {# day ago} other {# days ago}}"
-msgstr "{0, plural, one {for # dag siden} other {for # dage siden}}"
-
 #. placeholder {0}: result.value
 msgid "{0, plural, one {# hour ago} other {# hours ago}}"
 msgstr "{0, plural, one {# time siden} other {# timer siden}}"
@@ -63,9 +59,6 @@ msgstr "{0}/måned"
 
 msgid "{deletedCount} users permanently deleted"
 msgstr "{deletedCount} brugere slettet permanent"
-
-msgid "{diffDays, plural, one {In # day} other {In # days}}"
-msgstr "{diffDays, plural, one {Om # dag} other {Om # dage}}"
 
 msgid "{price}/month"
 msgstr "{price}/måned"
@@ -479,9 +472,6 @@ msgstr "Bunddrawer"
 msgid "Bottom sheet"
 msgstr "Bundsheet"
 
-msgid "Breadcrumb"
-msgstr "Brødkrumme"
-
 msgid "Breadcrumb — custom separator"
 msgstr "Brødkrumme — brugerdefineret skilletegn"
 
@@ -665,12 +655,6 @@ msgstr "By"
 msgid "Clear"
 msgstr "Ryd"
 
-msgid "Clear date"
-msgstr "Ryd dato"
-
-msgid "Clear dates"
-msgstr "Ryd datoer"
-
 msgid "Clear filters"
 msgstr "Ryd filtre"
 
@@ -683,14 +667,8 @@ msgstr "Klik på en række for at åbne sidepanelet. Brug Shift eller Cmd/Ctrl s
 msgid "Close"
 msgstr "Luk"
 
-msgid "Close menu"
-msgstr "Luk menu"
-
 msgid "Close recipe details"
 msgstr "Luk opskriftsdetaljer"
-
-msgid "Close sidebar"
-msgstr "Luk sidemenu"
 
 msgid "Close user profile"
 msgstr "Luk brugerprofil"
@@ -794,9 +772,6 @@ msgstr "Land"
 msgid "Create"
 msgstr "Opret"
 
-msgid "Create <0>{search}</0>"
-msgstr "Opret <0>{search}</0>"
-
 msgid "Create new account"
 msgstr "Opret ny konto"
 
@@ -892,9 +867,6 @@ msgstr "Afslå"
 
 msgid "Declining..."
 msgstr "Afslår..."
-
-msgid "Decrease"
-msgstr "Formindsk"
 
 msgid "Default"
 msgstr "Standard"
@@ -1022,9 +994,6 @@ msgstr "Slip et billede i et vilkårligt kort — AspectRatio holder feltet fast
 
 msgid "Drop anywhere to add to the gallery"
 msgstr "Slip et vilkårligt sted for at tilføje til galleriet"
-
-msgid "Drop files here, or click to browse"
-msgstr "Slip filer her, eller klik for at vælge"
 
 msgid "Drop your filter controls here. The sheet handles scrolling and dismissal."
 msgstr "Placér dine filterkontroller her. Sheet håndterer scrolling og lukning."
@@ -1266,12 +1235,6 @@ msgstr "Gå til kontoindstillinger"
 msgid "Go to home"
 msgstr "Gå til forsiden"
 
-msgid "Go to next page"
-msgstr "Gå til næste side"
-
-msgid "Go to previous page"
-msgstr "Gå til forrige side"
-
 msgid "Google"
 msgstr "Google"
 
@@ -1322,9 +1285,6 @@ msgstr "I selve appen er sidemenuen fixed-positioneret, gemmer sin tilstand og b
 
 msgid "Include cooking notes"
 msgstr "Inkluder tilberedningsnoter"
-
-msgid "Increase"
-msgstr "Forøg"
 
 msgid "Indeterminate"
 msgstr "Ubestemt"
@@ -1524,9 +1484,6 @@ msgstr "Linkvarianter"
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-msgid "Loading"
-msgstr ""
-
 msgid "Loading..."
 msgstr "Indlæser..."
 
@@ -1647,9 +1604,6 @@ msgstr "Midte"
 msgid "Mobile"
 msgstr "Mobil"
 
-msgid "Mobile navigation menu"
-msgstr "Mobilnavigationsmenu"
-
 msgid "Mobile-first sheet with a drag handle and swipe-to-dismiss. Reach for it when content is short and the user should be able to flick it away. Left and right drawers are narrow by default; top and bottom span the full width unless you constrain DrawerContent with mx-auto and max-w-*."
 msgstr "Mobile-first panel med trækhåndtag og swipe-to-dismiss. Brug det når indholdet er kort og brugeren skal kunne flicke det væk. Venstre- og højre-drawers er smalle som standard; top og bund spænder fuld bredde med mindre du begrænser DrawerContent med mx-auto og max-w-*."
 
@@ -1667,9 +1621,6 @@ msgstr "Flere eksportmuligheder"
 
 msgid "More merge options"
 msgstr "Flere fletmuligheder"
-
-msgid "More pages"
-msgstr "Flere sider"
 
 msgid "More save options"
 msgstr "Flere gemgemuligheder"
@@ -1812,14 +1763,8 @@ msgstr "Kun ejere kan ændre brugerroller"
 msgid "Only trusted personnel access data through Azure AD authentication"
 msgstr "Kun betroet personale får adgang til data gennem Azure AD autentificering"
 
-msgid "Open calendar"
-msgstr ""
-
 msgid "Open command palette"
 msgstr "Åbn kommandopalette"
-
-msgid "Open navigation menu"
-msgstr "Åbn navigationsmenu"
 
 msgid "Open side pane"
 msgstr "Åbn sidepanel"
@@ -1871,9 +1816,6 @@ msgstr "Siden blev ikke fundet"
 
 msgid "Page Views"
 msgstr "Sidevisninger"
-
-msgid "Pagination"
-msgstr "Paginering"
 
 msgid "Palak paneer"
 msgstr "Palak paneer"
@@ -2192,9 +2134,6 @@ msgstr "Justerbar app-skal"
 msgid "Resizable panels"
 msgstr "Justerbare paneler"
 
-msgid "Resize sidebar"
-msgstr "Ændr bredde på sidepanel"
-
 msgid "Responsive layout"
 msgstr "Responsivt layout"
 
@@ -2343,9 +2282,6 @@ msgstr "Vælg land"
 msgid "Select dates"
 msgstr "Vælg datoer"
 
-msgid "Select time zone"
-msgstr "Vælg tidszone"
-
 msgid "Select with groups"
 msgstr "Vælg med grupper"
 
@@ -2424,9 +2360,6 @@ msgstr "Vis detaljer"
 msgid "Show dismissable banner"
 msgstr "Vis afliveligt banner"
 
-msgid "Show more"
-msgstr "Vis flere"
-
 msgid "Show search filters"
 msgstr "Vis søgefiltre"
 
@@ -2483,9 +2416,6 @@ msgstr "Enkelt-udfoldning vs multi-udfoldning"
 
 msgid "Skeleton"
 msgstr "Skelet"
-
-msgid "Skip to main content"
-msgstr "Spring til hovedindhold"
 
 msgid "SLA"
 msgstr "SLA"
@@ -2722,9 +2652,6 @@ msgstr "Titel"
 msgid "To delete your account, please contact our support team."
 msgstr "For at slette din konto bedes du kontakte vores supportteam."
 
-msgid "Today"
-msgstr "I dag"
-
 msgid "Toggle bold"
 msgstr "Skift fed"
 
@@ -2737,17 +2664,11 @@ msgstr "Skiftegruppe"
 msgid "Toggle italic"
 msgstr "Skift kursiv"
 
-msgid "Toggle sidebar"
-msgstr "Skift sidepanel"
-
 msgid "Toggle underline"
 msgstr "Skift understregning"
 
 msgid "Tom yum soup"
 msgstr "Tom yum-suppe"
-
-msgid "Tomorrow"
-msgstr "I morgen"
 
 msgid "Tonkotsu ramen"
 msgstr "Tonkotsu ramen"

--- a/application/account/WebApp/shared/translations/locale/en-US.po
+++ b/application/account/WebApp/shared/translations/locale/en-US.po
@@ -13,10 +13,6 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: @lingui/cli\n"
 
-#. placeholder {0}: -diffDays
-msgid "{0, plural, one {# day ago} other {# days ago}}"
-msgstr "{0, plural, one {# day ago} other {# days ago}}"
-
 #. placeholder {0}: result.value
 msgid "{0, plural, one {# hour ago} other {# hours ago}}"
 msgstr "{0, plural, one {# hour ago} other {# hours ago}}"
@@ -63,9 +59,6 @@ msgstr "{0}/month"
 
 msgid "{deletedCount} users permanently deleted"
 msgstr "{deletedCount} users permanently deleted"
-
-msgid "{diffDays, plural, one {In # day} other {In # days}}"
-msgstr "{diffDays, plural, one {In # day} other {In # days}}"
 
 msgid "{price}/month"
 msgstr "{price}/month"
@@ -481,9 +474,6 @@ msgstr "Bottom drawer"
 msgid "Bottom sheet"
 msgstr "Bottom sheet"
 
-msgid "Breadcrumb"
-msgstr "Breadcrumb"
-
 msgid "Breadcrumb — custom separator"
 msgstr "Breadcrumb — custom separator"
 
@@ -667,12 +657,6 @@ msgstr "City"
 msgid "Clear"
 msgstr "Clear"
 
-msgid "Clear date"
-msgstr "Clear date"
-
-msgid "Clear dates"
-msgstr "Clear dates"
-
 msgid "Clear filters"
 msgstr "Clear filters"
 
@@ -685,14 +669,8 @@ msgstr "Click a row to open the side pane. Use Shift or Cmd/Ctrl with click or a
 msgid "Close"
 msgstr "Close"
 
-msgid "Close menu"
-msgstr "Close menu"
-
 msgid "Close recipe details"
 msgstr "Close recipe details"
-
-msgid "Close sidebar"
-msgstr "Close sidebar"
 
 msgid "Close user profile"
 msgstr "Close user profile"
@@ -796,9 +774,6 @@ msgstr "Country"
 msgid "Create"
 msgstr "Create"
 
-msgid "Create <0>{search}</0>"
-msgstr "Create <0>{search}</0>"
-
 msgid "Create new account"
 msgstr "Create new account"
 
@@ -894,9 +869,6 @@ msgstr "Decline"
 
 msgid "Declining..."
 msgstr "Declining..."
-
-msgid "Decrease"
-msgstr "Decrease"
 
 msgid "Default"
 msgstr "Default"
@@ -1024,9 +996,6 @@ msgstr "Drop an image into any card — AspectRatio keeps the slot size fixed re
 
 msgid "Drop anywhere to add to the gallery"
 msgstr "Drop anywhere to add to the gallery"
-
-msgid "Drop files here, or click to browse"
-msgstr "Drop files here, or click to browse"
 
 msgid "Drop your filter controls here. The sheet handles scrolling and dismissal."
 msgstr "Drop your filter controls here. The sheet handles scrolling and dismissal."
@@ -1268,12 +1237,6 @@ msgstr "Go to account settings"
 msgid "Go to home"
 msgstr "Go to home"
 
-msgid "Go to next page"
-msgstr "Go to next page"
-
-msgid "Go to previous page"
-msgstr "Go to previous page"
-
 msgid "Google"
 msgstr "Google"
 
@@ -1324,9 +1287,6 @@ msgstr "In the real app the sidebar is fixed-positioned, persists its state and 
 
 msgid "Include cooking notes"
 msgstr "Include cooking notes"
-
-msgid "Increase"
-msgstr "Increase"
 
 msgid "Indeterminate"
 msgstr "Indeterminate"
@@ -1526,9 +1486,6 @@ msgstr "Link variants"
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-msgid "Loading"
-msgstr "Loading"
-
 msgid "Loading..."
 msgstr "Loading..."
 
@@ -1649,9 +1606,6 @@ msgstr "Middle"
 msgid "Mobile"
 msgstr "Mobile"
 
-msgid "Mobile navigation menu"
-msgstr "Mobile navigation menu"
-
 msgid "Mobile-first sheet with a drag handle and swipe-to-dismiss. Reach for it when content is short and the user should be able to flick it away. Left and right drawers are narrow by default; top and bottom span the full width unless you constrain DrawerContent with mx-auto and max-w-*."
 msgstr "Mobile-first sheet with a drag handle and swipe-to-dismiss. Reach for it when content is short and the user should be able to flick it away. Left and right drawers are narrow by default; top and bottom span the full width unless you constrain DrawerContent with mx-auto and max-w-*."
 
@@ -1669,9 +1623,6 @@ msgstr "More export options"
 
 msgid "More merge options"
 msgstr "More merge options"
-
-msgid "More pages"
-msgstr "More pages"
 
 msgid "More save options"
 msgstr "More save options"
@@ -1814,14 +1765,8 @@ msgstr "Only owners can change user roles"
 msgid "Only trusted personnel access data through Azure AD authentication"
 msgstr "Only trusted personnel access data through Azure AD authentication"
 
-msgid "Open calendar"
-msgstr "Open calendar"
-
 msgid "Open command palette"
 msgstr "Open command palette"
-
-msgid "Open navigation menu"
-msgstr "Open navigation menu"
 
 msgid "Open side pane"
 msgstr "Open side pane"
@@ -1873,9 +1818,6 @@ msgstr "Page not found"
 
 msgid "Page Views"
 msgstr "Page Views"
-
-msgid "Pagination"
-msgstr "Pagination"
 
 msgid "Palak paneer"
 msgstr "Palak paneer"
@@ -2194,9 +2136,6 @@ msgstr "Resizable app shell"
 msgid "Resizable panels"
 msgstr "Resizable panels"
 
-msgid "Resize sidebar"
-msgstr "Resize sidebar"
-
 msgid "Responsive layout"
 msgstr "Responsive layout"
 
@@ -2345,9 +2284,6 @@ msgstr "Select country"
 msgid "Select dates"
 msgstr "Select dates"
 
-msgid "Select time zone"
-msgstr "Select time zone"
-
 msgid "Select with groups"
 msgstr "Select with groups"
 
@@ -2426,9 +2362,6 @@ msgstr "Show details"
 msgid "Show dismissable banner"
 msgstr "Show dismissable banner"
 
-msgid "Show more"
-msgstr "Show more"
-
 msgid "Show search filters"
 msgstr "Show search filters"
 
@@ -2485,9 +2418,6 @@ msgstr "Single-expand vs multi-expand"
 
 msgid "Skeleton"
 msgstr "Skeleton"
-
-msgid "Skip to main content"
-msgstr "Skip to main content"
 
 msgid "SLA"
 msgstr "SLA"
@@ -2724,9 +2654,6 @@ msgstr "Title"
 msgid "To delete your account, please contact our support team."
 msgstr "To delete your account, please contact our support team."
 
-msgid "Today"
-msgstr "Today"
-
 msgid "Toggle bold"
 msgstr "Toggle bold"
 
@@ -2739,17 +2666,11 @@ msgstr "Toggle group"
 msgid "Toggle italic"
 msgstr "Toggle italic"
 
-msgid "Toggle sidebar"
-msgstr "Toggle sidebar"
-
 msgid "Toggle underline"
 msgstr "Toggle underline"
 
 msgid "Tom yum soup"
 msgstr "Tom yum soup"
-
-msgid "Tomorrow"
-msgstr "Tomorrow"
 
 msgid "Tonkotsu ramen"
 msgstr "Tonkotsu ramen"
@@ -3181,4 +3102,4 @@ msgid "YouTube"
 msgstr "YouTube"
 
 msgid "Zoom"
-msgstr "Zoom"
+msgstr "Zoomtest-modify"

--- a/application/back-office/WebApp/package.json
+++ b/application/back-office/WebApp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "npm run update-translations && npm run swagger && rsbuild build",
+    "build": "npm run swagger && rsbuild build",
     "check": "oxfmt --check && oxlint",
     "dev": "rsbuild dev",
     "dev:setup": "npm run update-translations && npm run swagger",

--- a/application/back-office/WebApp/shared/translations/locale/da-DK.po
+++ b/application/back-office/WebApp/shared/translations/locale/da-DK.po
@@ -13,78 +13,26 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: @lingui/cli\n"
 
-#. placeholder {0}: -diffDays
-msgid "{0, plural, one {# day ago} other {# days ago}}"
-msgstr "{0, plural, one {for # dag siden} other {for # dage siden}}"
-
-msgid "{diffDays, plural, one {In # day} other {In # days}}"
-msgstr "{diffDays, plural, one {Om # dag} other {Om # dage}}"
-
 msgid "Access denied"
 msgstr "Adgang nægtet"
 
 msgid "An unexpected error occurred while processing your request."
 msgstr "Der opstod en uventet fejl ved behandlingen."
 
-msgid "Breadcrumb"
-msgstr "Brødkrumme"
-
-msgid "Clear date"
-msgstr "Ryd dato"
-
-msgid "Clear dates"
-msgstr "Ryd datoer"
-
-msgid "Close"
-msgstr ""
-
-msgid "Close menu"
-msgstr "Luk menu"
-
-msgid "Close sidebar"
-msgstr "Luk sidemenu"
-
 msgid "Contact your administrator if you believe this is a mistake."
 msgstr "Kontakt din administrator, hvis du mener, dette er en fejl."
-
-msgid "Create <0>{search}</0>"
-msgstr "Opret <0>{search}</0>"
 
 msgid "Dashboard"
 msgstr "Dashboard"
 
-msgid "Decrease"
-msgstr "Formindsk"
-
-msgid "Drop files here, or click to browse"
-msgstr ""
-
 msgid "Go to home"
 msgstr "Gå til forsiden"
-
-msgid "Go to next page"
-msgstr "Gå til næste side"
-
-msgid "Go to previous page"
-msgstr "Gå til forrige side"
 
 msgid "Hide details"
 msgstr "Skjul detaljer"
 
-msgid "Increase"
-msgstr "Forøg"
-
-msgid "Leave"
-msgstr "Forlad"
-
-msgid "Loading"
-msgstr ""
-
 msgid "Log out"
 msgstr "Log ud"
-
-msgid "Main content"
-msgstr "Hovedindhold"
 
 msgid "Main navigation"
 msgstr "Hovednavigation"
@@ -92,32 +40,11 @@ msgstr "Hovednavigation"
 msgid "Manage tenants, view system data, see exceptions, and perform various tasks for operational and support teams."
 msgstr "Administrer lejere, se systemdata, se undtagelser og udfør forskellige opgaver for drifts- og supportteams."
 
-msgid "Mobile navigation menu"
-msgstr "Mobilnavigationsmenu"
-
-msgid "More pages"
-msgstr "Flere sider"
-
 msgid "Navigation"
 msgstr "Navigation"
 
-msgid "Next"
-msgstr "Næste"
-
-msgid "No results found"
-msgstr "Ingen resultater fundet"
-
-msgid "Open calendar"
-msgstr ""
-
-msgid "Open navigation menu"
-msgstr "Åbn navigationsmenu"
-
 msgid "Page not found"
 msgstr "Siden blev ikke fundet"
-
-msgid "Pagination"
-msgstr "Paginering"
 
 msgid "PlatformPlatform logo"
 msgstr "PlatformPlatform logo"
@@ -128,59 +55,20 @@ msgstr "Tjek venligst URL'en eller vend tilbage til forsiden."
 msgid "Please try again or return to the home page."
 msgstr "Prøv venligst igen eller vend tilbage til forsiden."
 
-msgid "Previous"
-msgstr "Forrige"
-
-msgid "Resize sidebar"
-msgstr "Ændr bredde på sidepanel"
-
-msgid "Select dates"
-msgstr "Vælg datoer"
-
-msgid "Select time zone"
-msgstr "Vælg tidszone"
-
 msgid "Show details"
 msgstr "Vis detaljer"
-
-msgid "Show more"
-msgstr "Vis flere"
-
-msgid "Skip to main content"
-msgstr "Spring til hovedindhold"
 
 msgid "Something went wrong"
 msgstr "Noget gik galt"
 
-msgid "Stay"
-msgstr "Bliv"
-
 msgid "The page you are looking for does not exist or was moved."
 msgstr "Siden du leder efter findes ikke eller er blevet flyttet."
-
-msgid "Today"
-msgstr "I dag"
-
-msgid "Toggle sidebar"
-msgstr "Vis/skjul sidepanel"
-
-msgid "Tomorrow"
-msgstr "I morgen"
 
 msgid "Try again"
 msgstr "Prøv igen"
 
-msgid "Unsaved changes"
-msgstr "Ugemte ændringer"
-
 msgid "Welcome to the Back Office"
 msgstr "Velkommen til Back Office"
 
-msgid "Yesterday"
-msgstr "I går"
-
 msgid "You do not have permission to access this page."
 msgstr "Du har ikke tilladelse til at tilgaa denne side."
-
-msgid "You have unsaved changes. If you leave now, your changes will be lost."
-msgstr "Du har ugemte ændringer. Hvis du forlader nu, går dine ændringer tabt."

--- a/application/back-office/WebApp/shared/translations/locale/en-US.po
+++ b/application/back-office/WebApp/shared/translations/locale/en-US.po
@@ -13,78 +13,26 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. placeholder {0}: -diffDays
-msgid "{0, plural, one {# day ago} other {# days ago}}"
-msgstr "{0, plural, one {# day ago} other {# days ago}}"
-
-msgid "{diffDays, plural, one {In # day} other {In # days}}"
-msgstr "{diffDays, plural, one {In # day} other {In # days}}"
-
 msgid "Access denied"
 msgstr "Access denied"
 
 msgid "An unexpected error occurred while processing your request."
 msgstr "An unexpected error occurred while processing your request."
 
-msgid "Breadcrumb"
-msgstr "Breadcrumb"
-
-msgid "Clear date"
-msgstr "Clear date"
-
-msgid "Clear dates"
-msgstr "Clear dates"
-
-msgid "Close"
-msgstr "Close"
-
-msgid "Close menu"
-msgstr "Close menu"
-
-msgid "Close sidebar"
-msgstr "Close sidebar"
-
 msgid "Contact your administrator if you believe this is a mistake."
 msgstr "Contact your administrator if you believe this is a mistake."
-
-msgid "Create <0>{search}</0>"
-msgstr "Create <0>{search}</0>"
 
 msgid "Dashboard"
 msgstr "Dashboard"
 
-msgid "Decrease"
-msgstr "Decrease"
-
-msgid "Drop files here, or click to browse"
-msgstr "Drop files here, or click to browse"
-
 msgid "Go to home"
 msgstr "Go to home"
-
-msgid "Go to next page"
-msgstr "Go to next page"
-
-msgid "Go to previous page"
-msgstr "Go to previous page"
 
 msgid "Hide details"
 msgstr "Hide details"
 
-msgid "Increase"
-msgstr "Increase"
-
-msgid "Leave"
-msgstr "Leave"
-
-msgid "Loading"
-msgstr "Loading"
-
 msgid "Log out"
 msgstr "Log out"
-
-msgid "Main content"
-msgstr "Main content"
 
 msgid "Main navigation"
 msgstr "Main navigation"
@@ -92,32 +40,11 @@ msgstr "Main navigation"
 msgid "Manage tenants, view system data, see exceptions, and perform various tasks for operational and support teams."
 msgstr "Manage tenants, view system data, see exceptions, and perform various tasks for operational and support teams."
 
-msgid "Mobile navigation menu"
-msgstr "Mobile navigation menu"
-
-msgid "More pages"
-msgstr "More pages"
-
 msgid "Navigation"
 msgstr "Navigation"
 
-msgid "Next"
-msgstr "Next"
-
-msgid "No results found"
-msgstr "No results found"
-
-msgid "Open calendar"
-msgstr "Open calendar"
-
-msgid "Open navigation menu"
-msgstr "Open navigation menu"
-
 msgid "Page not found"
 msgstr "Page not found"
-
-msgid "Pagination"
-msgstr "Pagination"
 
 msgid "PlatformPlatform logo"
 msgstr "PlatformPlatform logo"
@@ -128,59 +55,20 @@ msgstr "Please check the URL or return to the home page."
 msgid "Please try again or return to the home page."
 msgstr "Please try again or return to the home page."
 
-msgid "Previous"
-msgstr "Previous"
-
-msgid "Resize sidebar"
-msgstr "Resize sidebar"
-
-msgid "Select dates"
-msgstr "Select dates"
-
-msgid "Select time zone"
-msgstr "Select time zone"
-
 msgid "Show details"
 msgstr "Show details"
-
-msgid "Show more"
-msgstr "Show more"
-
-msgid "Skip to main content"
-msgstr "Skip to main content"
 
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
-msgid "Stay"
-msgstr "Stay"
-
 msgid "The page you are looking for does not exist or was moved."
 msgstr "The page you are looking for does not exist or was moved."
-
-msgid "Today"
-msgstr "Today"
-
-msgid "Toggle sidebar"
-msgstr "Toggle sidebar"
-
-msgid "Tomorrow"
-msgstr "Tomorrow"
 
 msgid "Try again"
 msgstr "Try again"
 
-msgid "Unsaved changes"
-msgstr "Unsaved changes"
-
 msgid "Welcome to the Back Office"
 msgstr "Welcome to the Back Office"
 
-msgid "Yesterday"
-msgstr "Yesterday"
-
 msgid "You do not have permission to access this page."
 msgstr "You do not have permission to access this page."
-
-msgid "You have unsaved changes. If you leave now, your changes will be lost."
-msgstr "You have unsaved changes. If you leave now, your changes will be lost."

--- a/application/main/WebApp/package.json
+++ b/application/main/WebApp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "npm run update-translations && npm run swagger && rsbuild build",
+    "build": "npm run swagger && rsbuild build",
     "check": "oxfmt --check && oxlint",
     "dev": "rsbuild dev",
     "dev:setup": "npm run update-translations && npm run swagger",

--- a/application/main/WebApp/shared/translations/locale/da-DK.po
+++ b/application/main/WebApp/shared/translations/locale/da-DK.po
@@ -13,60 +13,20 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: @lingui/cli\n"
 
-#. placeholder {0}: -diffDays
-msgid "{0, plural, one {# day ago} other {# days ago}}"
-msgstr "{0, plural, one {for # dag siden} other {for # dage siden}}"
-
-msgid "{diffDays, plural, one {In # day} other {In # days}}"
-msgstr "{diffDays, plural, one {Om # dag} other {Om # dage}}"
-
-msgid "Breadcrumb"
-msgstr "Brødkrumme"
-
 msgid "Burning the midnight oil, {firstName}?"
 msgstr "Sidder du stadig oppe, {firstName}?"
 
 msgid "Burning the midnight oil?"
 msgstr "Sidder du stadig oppe?"
 
-msgid "Clear date"
-msgstr "Ryd dato"
-
-msgid "Clear dates"
-msgstr "Ryd datoer"
-
-msgid "Close"
-msgstr "Luk"
-
-msgid "Close menu"
-msgstr "Luk menu"
-
-msgid "Close sidebar"
-msgstr "Luk sidemenu"
-
-msgid "Create <0>{search}</0>"
-msgstr "Opret <0>{search}</0>"
-
 msgid "Dashboard"
 msgstr "Dashboard"
-
-msgid "Decrease"
-msgstr "Formindsk"
-
-msgid "Drop files here, or click to browse"
-msgstr "Slip filer her, eller klik for at vælge"
 
 msgid "Get started"
 msgstr "Kom i gang"
 
 msgid "Go to app"
 msgstr "Gå til app"
-
-msgid "Go to next page"
-msgstr "Gå til næste side"
-
-msgid "Go to previous page"
-msgstr "Gå til forrige side"
 
 msgid "Good afternoon"
 msgstr "God eftermiddag"
@@ -89,95 +49,23 @@ msgstr "God morgen, {firstName}"
 msgid "Here's your overview of what's happening."
 msgstr "Her er dit overblik over hvad der sker."
 
-msgid "Increase"
-msgstr "Forøg"
-
-msgid "Leave"
-msgstr "Forlad"
-
-msgid "Loading"
-msgstr ""
-
 msgid "Log in"
 msgstr "Log ind"
-
-msgid "Main content"
-msgstr "Hovedindhold"
 
 msgid "Main navigation"
 msgstr "Hovednavigation"
 
-msgid "Mobile navigation menu"
-msgstr "Mobilnavigationsmenu"
-
-msgid "More pages"
-msgstr "Flere sider"
-
 msgid "Navigation"
 msgstr "Navigation"
-
-msgid "Next"
-msgstr "Næste"
-
-msgid "No results found"
-msgstr "Ingen resultater fundet"
-
-msgid "Open calendar"
-msgstr ""
-
-msgid "Open navigation menu"
-msgstr "Åbn navigationsmenu"
-
-msgid "Pagination"
-msgstr "Paginering"
-
-msgid "Previous"
-msgstr "Forrige"
 
 msgid "Replace this sample page with your own product information and branding."
 msgstr "Erstat denne eksempelside med dine egne produktinformationer og branding."
 
-msgid "Resize sidebar"
-msgstr "Ændr bredde på sidepanel"
-
-msgid "Select dates"
-msgstr "Vælg datoer"
-
-msgid "Select time zone"
-msgstr "Vælg tidszone"
-
-msgid "Show more"
-msgstr "Vis flere"
-
-msgid "Skip to main content"
-msgstr "Spring til hovedindhold"
-
-msgid "Stay"
-msgstr "Bliv"
-
 msgid "This is where your personalized dashboard content will appear. Stay tuned for updates."
 msgstr "Her vil dit personlige dashboard-indhold blive vist. Hold dig opdateret."
 
-msgid "Today"
-msgstr "I dag"
-
-msgid "Toggle sidebar"
-msgstr "Skift sidepanel"
-
-msgid "Tomorrow"
-msgstr "I morgen"
-
-msgid "Unsaved changes"
-msgstr "Ugemte ændringer"
-
 msgid "Welcome to PlatformPlatform"
 msgstr "Velkommen til PlatformPlatform"
-
-msgid "Yesterday"
-msgstr "I går"
-
-msgid "You have unsaved changes. If you leave now, your changes will be lost."
-msgstr "Du har ugemte ændringer. Hvis du forlader nu, går dine ændringer tabt."
 
 msgid "You successfully deployed PlatformPlatform! 🎉"
 msgstr "Du har installeret PlatformPlatform med succes! 🎉"

--- a/application/main/WebApp/shared/translations/locale/en-US.po
+++ b/application/main/WebApp/shared/translations/locale/en-US.po
@@ -13,60 +13,20 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. placeholder {0}: -diffDays
-msgid "{0, plural, one {# day ago} other {# days ago}}"
-msgstr "{0, plural, one {# day ago} other {# days ago}}"
-
-msgid "{diffDays, plural, one {In # day} other {In # days}}"
-msgstr "{diffDays, plural, one {In # day} other {In # days}}"
-
-msgid "Breadcrumb"
-msgstr "Breadcrumb"
-
 msgid "Burning the midnight oil, {firstName}?"
 msgstr "Burning the midnight oil, {firstName}?"
 
 msgid "Burning the midnight oil?"
 msgstr "Burning the midnight oil?"
 
-msgid "Clear date"
-msgstr "Clear date"
-
-msgid "Clear dates"
-msgstr "Clear dates"
-
-msgid "Close"
-msgstr "Close"
-
-msgid "Close menu"
-msgstr "Close menu"
-
-msgid "Close sidebar"
-msgstr "Close sidebar"
-
-msgid "Create <0>{search}</0>"
-msgstr "Create <0>{search}</0>"
-
 msgid "Dashboard"
 msgstr "Dashboard"
-
-msgid "Decrease"
-msgstr "Decrease"
-
-msgid "Drop files here, or click to browse"
-msgstr "Drop files here, or click to browse"
 
 msgid "Get started"
 msgstr "Get started"
 
 msgid "Go to app"
 msgstr "Go to app"
-
-msgid "Go to next page"
-msgstr "Go to next page"
-
-msgid "Go to previous page"
-msgstr "Go to previous page"
 
 msgid "Good afternoon"
 msgstr "Good afternoon"
@@ -89,95 +49,23 @@ msgstr "Good morning, {firstName}"
 msgid "Here's your overview of what's happening."
 msgstr "Here's your overview of what's happening."
 
-msgid "Increase"
-msgstr "Increase"
-
-msgid "Leave"
-msgstr "Leave"
-
-msgid "Loading"
-msgstr "Loading"
-
 msgid "Log in"
 msgstr "Log in"
-
-msgid "Main content"
-msgstr "Main content"
 
 msgid "Main navigation"
 msgstr "Main navigation"
 
-msgid "Mobile navigation menu"
-msgstr "Mobile navigation menu"
-
-msgid "More pages"
-msgstr "More pages"
-
 msgid "Navigation"
 msgstr "Navigation"
-
-msgid "Next"
-msgstr "Next"
-
-msgid "No results found"
-msgstr "No results found"
-
-msgid "Open calendar"
-msgstr "Open calendar"
-
-msgid "Open navigation menu"
-msgstr "Open navigation menu"
-
-msgid "Pagination"
-msgstr "Pagination"
-
-msgid "Previous"
-msgstr "Previous"
 
 msgid "Replace this sample page with your own product information and branding."
 msgstr "Replace this sample page with your own product information and branding."
 
-msgid "Resize sidebar"
-msgstr "Resize sidebar"
-
-msgid "Select dates"
-msgstr "Select dates"
-
-msgid "Select time zone"
-msgstr "Select time zone"
-
-msgid "Show more"
-msgstr "Show more"
-
-msgid "Skip to main content"
-msgstr "Skip to main content"
-
-msgid "Stay"
-msgstr "Stay"
-
 msgid "This is where your personalized dashboard content will appear. Stay tuned for updates."
 msgstr "This is where your personalized dashboard content will appear. Stay tuned for updates."
 
-msgid "Today"
-msgstr "Today"
-
-msgid "Toggle sidebar"
-msgstr "Toggle sidebar"
-
-msgid "Tomorrow"
-msgstr "Tomorrow"
-
-msgid "Unsaved changes"
-msgstr "Unsaved changes"
-
 msgid "Welcome to PlatformPlatform"
 msgstr "Welcome to PlatformPlatform"
-
-msgid "Yesterday"
-msgstr "Yesterday"
-
-msgid "You have unsaved changes. If you leave now, your changes will be lost."
-msgstr "You have unsaved changes. If you leave now, your changes will be lost."
 
 msgid "You successfully deployed PlatformPlatform! 🎉"
 msgstr "You successfully deployed PlatformPlatform! 🎉"

--- a/application/shared-webapp/infrastructure/translations/createFederatedTranslation.ts
+++ b/application/shared-webapp/infrastructure/translations/createFederatedTranslation.ts
@@ -72,17 +72,29 @@ async function loadRemoteTranslations(remoteName: string, locale: Locale): Promi
 }
 
 /**
+ * Load translations from `@repo/ui` (the shared component library catalog).
+ * These are merged underneath the host SPA's own messages so the host can override.
+ */
+async function loadSharedTranslations(locale: Locale): Promise<Messages | null> {
+  try {
+    const module = await import(`@repo/ui/translations/locale/${locale}.ts`);
+    return module?.messages ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Creates a translation loader that merges translations from federated modules
  */
 function createFederatedLoader(
   baseLoader: (locale: Locale) => Promise<LocaleFile>
 ): (locale: Locale) => Promise<LocaleFile> {
   return async (locale: Locale): Promise<LocaleFile> => {
-    // Load base translations first
-    const baseMessages = await baseLoader(locale);
+    const [sharedMessages, baseMessages] = await Promise.all([loadSharedTranslations(locale), baseLoader(locale)]);
 
-    // Load and merge translations from all configured remotes
-    const allMessages = { ...baseMessages.messages };
+    // Precedence (last write wins): shared < own < federated remote
+    const allMessages = { ...sharedMessages, ...baseMessages.messages };
 
     await Promise.all(
       FEDERATED_TRANSLATION_REMOTES.map(async (remoteName) => {

--- a/application/shared-webapp/infrastructure/translations/createLinguiConfig.ts
+++ b/application/shared-webapp/infrastructure/translations/createLinguiConfig.ts
@@ -11,12 +11,7 @@ export function createLinguiConfig(): LinguiConfig {
     catalogs: [
       {
         path: "<rootDir>/shared/translations/locale/{locale}",
-        include: [
-          "<rootDir>/**/*.ts",
-          "<rootDir>/**/*.tsx",
-          "<rootDir>/../../shared-webapp/ui/**/*.ts",
-          "<rootDir>/../../shared-webapp/ui/**/*.tsx"
-        ],
+        include: ["<rootDir>/**/*.ts", "<rootDir>/**/*.tsx"],
         exclude: ["**/node_modules/**", "**/dist", "**/*.d.ts", "**/*.test.*", "**/.*"]
       }
     ],

--- a/application/shared-webapp/ui/lingui.config.ts
+++ b/application/shared-webapp/ui/lingui.config.ts
@@ -1,0 +1,18 @@
+import type { LinguiConfig } from "@lingui/conf";
+
+import { formatter } from "@lingui/format-po";
+
+const config: LinguiConfig = {
+  locales: ["en-US", "da-DK"],
+  sourceLocale: "en-US",
+  catalogs: [
+    {
+      path: "<rootDir>/translations/locale/{locale}",
+      include: ["<rootDir>/**/*.ts", "<rootDir>/**/*.tsx"],
+      exclude: ["**/node_modules/**", "**/dist", "**/*.d.ts", "**/*.test.*", "**/.*"]
+    }
+  ],
+  format: formatter({ origins: false })
+};
+
+export default config;

--- a/application/shared-webapp/ui/package.json
+++ b/application/shared-webapp/ui/package.json
@@ -42,7 +42,8 @@
     "dev": "tsc -p . -w",
     "dev:setup": "rimraf ./dist && npm run copyImages && tsc -p .",
     "format": "oxfmt && (oxlint --fix || true)",
-    "lint": "oxlint --deny-warnings"
+    "lint": "oxlint --deny-warnings",
+    "update-translations": "lingui extract --clean && lingui compile --typescript"
   },
   "dependencies": {
     "@base-ui/react": "1.2.0",

--- a/application/shared-webapp/ui/translations/locale/da-DK.po
+++ b/application/shared-webapp/ui/translations/locale/da-DK.po
@@ -1,0 +1,126 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-04-26 17:39+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: da-DK\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. placeholder {0}: -diffDays
+msgid "{0, plural, one {# day ago} other {# days ago}}"
+msgstr "{0, plural, one {for # dag siden} other {for # dage siden}}"
+
+msgid "{diffDays, plural, one {In # day} other {In # days}}"
+msgstr "{diffDays, plural, one {Om # dag} other {Om # dage}}"
+
+msgid "Breadcrumb"
+msgstr "Brødkrumme"
+
+msgid "Clear date"
+msgstr "Ryd dato"
+
+msgid "Clear dates"
+msgstr "Ryd datoer"
+
+msgid "Close"
+msgstr "Luk"
+
+msgid "Close menu"
+msgstr "Luk menu"
+
+msgid "Close sidebar"
+msgstr "Luk sidemenu"
+
+msgid "Create <0>{search}</0>"
+msgstr "Opret <0>{search}</0>"
+
+msgid "Decrease"
+msgstr "Formindsk"
+
+msgid "Drop files here, or click to browse"
+msgstr "Slip filer her, eller klik for at vælge"
+
+msgid "Go to next page"
+msgstr "Gå til næste side"
+
+msgid "Go to previous page"
+msgstr "Gå til forrige side"
+
+msgid "Increase"
+msgstr "Forøg"
+
+msgid "Leave"
+msgstr "Forlad"
+
+msgid "Loading"
+msgstr ""
+
+msgid "Main content"
+msgstr "Hovedindhold"
+
+msgid "Mobile navigation menu"
+msgstr "Mobilnavigationsmenu"
+
+msgid "More pages"
+msgstr "Flere sider"
+
+msgid "Next"
+msgstr "Næste"
+
+msgid "No results found"
+msgstr "Ingen resultater fundet"
+
+msgid "Open calendar"
+msgstr ""
+
+msgid "Open navigation menu"
+msgstr "Åbn navigationsmenu"
+
+msgid "Pagination"
+msgstr "Paginering"
+
+msgid "Previous"
+msgstr "Forrige"
+
+msgid "Resize sidebar"
+msgstr "Ændr bredde på sidepanel"
+
+msgid "Select dates"
+msgstr "Vælg datoer"
+
+msgid "Select time zone"
+msgstr "Vælg tidszone"
+
+msgid "Show more"
+msgstr "Vis flere"
+
+msgid "Skip to main content"
+msgstr "Spring til hovedindhold"
+
+msgid "Stay"
+msgstr "Bliv"
+
+msgid "Today"
+msgstr "I dag"
+
+msgid "Toggle sidebar"
+msgstr "Skift sidepanel"
+
+msgid "Tomorrow"
+msgstr "I morgen"
+
+msgid "Unsaved changes"
+msgstr "Ugemte ændringer"
+
+msgid "Yesterday"
+msgstr "I går"
+
+msgid "You have unsaved changes. If you leave now, your changes will be lost."
+msgstr "Du har ugemte ændringer. Hvis du forlader nu, vil dine ændringer gå tabt."

--- a/application/shared-webapp/ui/translations/locale/en-US.po
+++ b/application/shared-webapp/ui/translations/locale/en-US.po
@@ -1,0 +1,126 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-04-26 17:39+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en-US\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. placeholder {0}: -diffDays
+msgid "{0, plural, one {# day ago} other {# days ago}}"
+msgstr "{0, plural, one {# day ago} other {# days ago}}"
+
+msgid "{diffDays, plural, one {In # day} other {In # days}}"
+msgstr "{diffDays, plural, one {In # day} other {In # days}}"
+
+msgid "Breadcrumb"
+msgstr "Breadcrumb"
+
+msgid "Clear date"
+msgstr "Clear date"
+
+msgid "Clear dates"
+msgstr "Clear dates"
+
+msgid "Close"
+msgstr "Close"
+
+msgid "Close menu"
+msgstr "Close menu"
+
+msgid "Close sidebar"
+msgstr "Close sidebar"
+
+msgid "Create <0>{search}</0>"
+msgstr "Create <0>{search}</0>"
+
+msgid "Decrease"
+msgstr "Decrease"
+
+msgid "Drop files here, or click to browse"
+msgstr "Drop files here, or click to browse"
+
+msgid "Go to next page"
+msgstr "Go to next page"
+
+msgid "Go to previous page"
+msgstr "Go to previous page"
+
+msgid "Increase"
+msgstr "Increase"
+
+msgid "Leave"
+msgstr "Leave"
+
+msgid "Loading"
+msgstr "Loading"
+
+msgid "Main content"
+msgstr "Main content"
+
+msgid "Mobile navigation menu"
+msgstr "Mobile navigation menu"
+
+msgid "More pages"
+msgstr "More pages"
+
+msgid "Next"
+msgstr "Next"
+
+msgid "No results found"
+msgstr "No results found"
+
+msgid "Open calendar"
+msgstr "Open calendar"
+
+msgid "Open navigation menu"
+msgstr "Open navigation menu"
+
+msgid "Pagination"
+msgstr "Pagination"
+
+msgid "Previous"
+msgstr "Previous"
+
+msgid "Resize sidebar"
+msgstr "Resize sidebar"
+
+msgid "Select dates"
+msgstr "Select dates"
+
+msgid "Select time zone"
+msgstr "Select time zone"
+
+msgid "Show more"
+msgstr "Show more"
+
+msgid "Skip to main content"
+msgstr "Skip to main content"
+
+msgid "Stay"
+msgstr "Stay"
+
+msgid "Today"
+msgstr "Today"
+
+msgid "Toggle sidebar"
+msgstr "Toggle sidebar"
+
+msgid "Tomorrow"
+msgstr "Tomorrow"
+
+msgid "Unsaved changes"
+msgstr "Unsaved changes"
+
+msgid "Yesterday"
+msgstr "Yesterday"
+
+msgid "You have unsaved changes. If you leave now, your changes will be lost."
+msgstr "You have unsaved changes. If you leave now, your changes will be lost."

--- a/application/turbo.json
+++ b/application/turbo.json
@@ -5,6 +5,10 @@
     "build": {
       "inputs": ["$TURBO_DEFAULT$", "shared/lib/api/*.Api.json"],
       "outputs": ["dist/**", "tests/test-results/**"],
+      "dependsOn": ["^build", "update-translations"]
+    },
+    "update-translations": {
+      "cache": false,
       "dependsOn": ["^build"]
     },
     "check": {


### PR DESCRIPTION
# Centralize shared-webapp/ui translations into a single Lingui catalog

### Summary & Motivation

Each self-contained system (account, main, back-office) used to extract translatable strings from both its own source AND `application/shared-webapp/ui/**/*.{ts,tsx}` into its own `.po` files. Every shared `<Trans>` ended up duplicated across three catalogs — a Danish translation for a shared `<Trans>Save</Trans>` had to be maintained in three places, and re-extractions across systems would drift out of sync.

This change gives `shared-webapp/ui` its own Lingui catalog and merges catalogs at runtime so each shared string is translated once.

- Add `application/shared-webapp/ui/lingui.config.ts` rooted at `shared-webapp/ui/translations/locale/{locale}` and scanning only `shared-webapp/ui/**/*.{ts,tsx}`.
- Add `update-translations` script to `application/shared-webapp/ui/package.json`.
- Strip the `shared-webapp/ui` glob from `createLinguiConfig()` so each system extracts only its own strings.
- Update `createFederatedTranslation` to dynamic-import the shared catalog alongside the host's own and merge messages with precedence shared < own < federated remote.
- Migrate 35 of 37 existing Danish translations from the old `account/da-DK.po` into the new shared `da-DK.po`. The remaining 2 strings (`Loading`, `Open calendar`) had no prior Danish translation.
- Re-extract each system's catalogs to drop now-orphaned shared entries.

### Build pipeline fix

A long-standing turbo cache issue caused the frontend build to hit the cache and skip `lingui extract`, leaving `.po` files stale until manually invalidated. Wire `update-translations` as an uncached turbo task that `build` depends on, and remove `update-translations` from each WebApp's npm `build` script chain so turbo invokes it via the dep.

### Federation context fix in PreviewAvatarMenu

The `Language` submenu under the avatar on the `/components` page rendered with zero items because `use(translationContext)` returned the default value (`locales: []`). Each federated module bundles its own copy of `@repo/ui` (where `translationContext` is defined via `createContext`), so the host's context provider does not propagate across the federation boundary. Read `locales` directly from `i18n.config.json` instead, matching the workaround already used in `usePreferences.tsx`. Locale changes still route correctly via the document-level `locale-change-request` event.

### Documentation

Update `.claude/rules/frontend/translations.md` — items 6 and 7 reflect the split catalog architecture and the uncached `update-translations` task. All other items and examples are preserved verbatim.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
