### PR TITLE
Make Aspire base port configurable to support parallel stacks across git worktrees

### DIFF
--- a/.claude/agents/pair-programmer.md
+++ b/.claude/agents/pair-programmer.md
@@ -1,6 +1,6 @@
 ---
 name: pair-programmer
-description: Top-level agent launched via CLI (`[CLI_ALIAS] claude-agent pair-programmer`). General-purpose engineer for direct user collaboration. Never spawn as a sub-agent.
+description: Top-level agent launched using the claude-agent pair-programmer CLI command. General-purpose engineer for direct user collaboration. Never spawn as a sub-agent.
 tools: *
 color: green
 ---

--- a/.claude/agents/regression-tester.md
+++ b/.claude/agents/regression-tester.md
@@ -29,7 +29,7 @@ You persist across the entire [feature]. You maintain context across all tasks.
 - Use `owner@platformplatform.local` / `admin@platformplatform.local` / `member@platformplatform.local`
 - The OTP is always `UNLOCK` on localhost
 - If unable to login with `owner@platformplatform.local`, create a new tenant and invite the other users
-- Access the application at `[APP_URL]`
+- Access the application at `https://app.dev.localhost:<appGateway>` (call the `get_ports` MCP tool to find the current `appGateway` port).
 
 ## What to Test
 

--- a/.claude/agents/team-lead.md
+++ b/.claude/agents/team-lead.md
@@ -1,6 +1,6 @@
 ---
 name: team-lead
-description: Top-level agent launched via CLI (`[CLI_ALIAS] claude-agent team-lead`). Coordinates agent teams and delegates all work to teammates. Never spawn as a sub-agent.
+description: Top-level agent launched using the claude-agent team-lead CLI command. Coordinates agent teams and delegates all work to teammates. Never spawn as a sub-agent.
 tools: *
 color: green
 ---

--- a/.claude/rules/frontend/frontend.md
+++ b/.claude/rules/frontend/frontend.md
@@ -13,7 +13,7 @@ Use LSP tools aggressively for code investigation: `goToDefinition`, `findRefere
 
 ## Browser Testing
 
-Use browser MCP tools to test at `[APP_URL]`. Use `UNLOCK` as OTP verification code (localhost only).
+Use browser MCP tools to test at `https://app.dev.localhost:<appGateway>` (call the `get_ports` MCP tool to find the current `appGateway` port). Use `UNLOCK` as OTP verification code (localhost only).
 
 ## Architecture Overview
 

--- a/.gitignore
+++ b/.gitignore
@@ -430,3 +430,4 @@ application/playwright.combined.config.ts
 
 # Claude Code scheduled-tasks runtime lock
 .claude/scheduled_tasks.lock
+.claude/worktrees

--- a/.mcp.json
+++ b/.mcp.json
@@ -9,8 +9,8 @@
       "args": ["-y", "shadcn@latest", "mcp"]
     },
     "aspire": {
-      "url": "http://localhost:9007/mcp",
-      "type": "http"
+      "command": "aspire",
+      "args": ["agent", "mcp"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -9,7 +9,7 @@
       "args": ["-y", "shadcn@latest", "mcp"]
     },
     "aspire": {
-      "url": "http://localhost:9096/mcp",
+      "url": "http://localhost:9007/mcp",
       "type": "http"
     }
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,21 +2,13 @@
 
 Always use MCP tools (`build`, `test`, `format`, `lint`, `run`, `restart`, `stop`, `end_to_end`) instead of running dotnet/npm/npx commands directly. Run `build` first, then remaining tools with `noBuild=true`.
 
-On MCP failures fall back to the CLI (`[CLI_ALIAS] build --quiet`, `[CLI_ALIAS] test --quiet`, etc.).
+On MCP failures fall back to the developer CLI directly via `cd developer-cli && dotnet run -- <command> --quiet` (e.g., `cd developer-cli && dotnet run -- build --quiet`, `cd developer-cli && dotnet run -- test --quiet`). Do NOT use the global `pp` shim -- it is bound to the original install path and ignores the current worktree.
 
 **Slow:** Aspire restart, backend format, backend lint, end-to-end tests. **Fast:** frontend format/lint, backend test. If any slow operation is needed, run everything in parallel Task agents. End-to-end tests use `waitForAspire=true`.
 
 **Aspire**: The `run`, `restart`, and `stop` MCP tools manage the AppHost. Call the `get_ports` MCP tool to look up service URLs. Use `restart` when backend changes or hot reload breaks. In the agentic workflow, only the Guardian agent calls these. All other agents must notify the Guardian if they need Aspire restarted.
 
 Never commit, amend, or revert without explicit user instruction each time. Commit messages: one descriptive line in imperative form, no description body.
-
-## CLI Alias Configuration
-
-Whenever you see `[CLI_ALIAS]`, replace it with the configured value.
-
-```
-CLI_ALIAS="pp"
-```
 
 ## Product Management Tool
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,17 +6,9 @@ On MCP failures fall back to the CLI (`[CLI_ALIAS] build --quiet`, `[CLI_ALIAS] 
 
 **Slow:** Aspire restart, backend format, backend lint, end-to-end tests. **Fast:** frontend format/lint, backend test. If any slow operation is needed, run everything in parallel Task agents. End-to-end tests use `waitForAspire=true`.
 
-**Aspire**: The `run`, `restart`, and `stop` MCP tools manage the AppHost at [APP_URL]. Use `restart` when backend changes or hot reload breaks. In the agentic workflow, only the Guardian agent calls these. All other agents must notify the Guardian if they need Aspire restarted.
+**Aspire**: The `run`, `restart`, and `stop` MCP tools manage the AppHost. Call the `get_ports` MCP tool to look up service URLs. Use `restart` when backend changes or hot reload breaks. In the agentic workflow, only the Guardian agent calls these. All other agents must notify the Guardian if they need Aspire restarted.
 
 Never commit, amend, or revert without explicit user instruction each time. Commit messages: one descriptive line in imperative form, no description body.
-
-## Application URL
-
-Whenever you see `[APP_URL]`, replace it with the configured value.
-
-```
-APP_URL="https://localhost:9000"
-```
 
 ## CLI Alias Configuration
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Alternatively, open the [PlatformPlatform](./application/PlatformPlatform.slnx) 
 
 On first startup, Aspire will prompt for `stripe-enabled` -- enter `true` to configure Stripe integration (see the optional Stripe setup section below) or `false` to skip.
 
-Once the Aspire dashboard fully loads, click to the WebApp and sign up for a new account (https://localhost:9000/signup). A one-time password (OTP) will be sent to the development mail server, but for local development, you can always use the code `UNLOCK` instead of checking the mail server.
+Once the Aspire dashboard fully loads, click to the WebApp and sign up for a new account (https://app.dev.localhost:9000/signup). A one-time password (OTP) will be sent to the development mail server, but for local development, you can always use the code `UNLOCK` instead of checking the mail server.
 
 ### 3.1 (Optional) Set up Google OAuth for "Sign in with Google" on localhost
 
@@ -272,7 +272,7 @@ PlatformPlatform supports authentication via Google OAuth using OpenID Connect w
 5. Create OAuth client ID:
    - Application type: "Web application"
    - Name: "YourProduct Localhost"
-6. Add Authorized redirect URIs:
+6. Add Authorized redirect URIs (Google does not allow https://app.dev.localhost:9000/):
    - `https://localhost:9000/api/account/authentication/Google/login/callback`
    - `https://localhost:9000/api/account/authentication/Google/signup/callback`
 7. Note the Client ID and Client Secret
@@ -299,9 +299,9 @@ Each developer needs their own Stripe sandbox. The local database stays in sync 
 1. **Create a sandbox**: Go to [Stripe Dashboard](https://dashboard.stripe.com) and create an account. Click the **account picker** (top-left) > **Sandboxes** > **Create**. Name it `dev-yourname` and open it. All subsequent steps are performed inside your sandbox.
 2. **Create products**: Navigate to **Product catalog** > **+ Create product**. Create a `Standard` product with **Recurring** / **Monthly** pricing (e.g., 19 EUR), then a `Premium` product (e.g., 39 EUR). Important: Click **More pricing options** and add `standard_monthly` and `premium_monthly` respectively in the **Lookup key** field.
 3. **Disable non-card payment methods**: Go to **Settings** (gear icon) > **Payments** > **Payment methods**. Turn off every payment method except **Cards** (and **Cartes Bancaires** which cannot be disabled)
-4. **Limit to 1 subscription**: Go to **Settings** > **Payments** > **Checkout and Payment Links**, scroll to **Subscriptions**, and enable **Limit customers to 1 subscription**. Add link to `https://app.yourcompany.com/account/billing` (`https://localhost:9000/account/billing` is not valid)
+4. **Limit to 1 subscription**: Go to **Settings** > **Payments** > **Checkout and Payment Links**, scroll to **Subscriptions**, and enable **Limit customers to 1 subscription**. Add link to `https://app.dev.localhost:9000/account/billing`
 5. **Configure failed payment recovery**: Go to **Settings** > **Billing** > **Subscriptions and emails** > **Manage failed payments**, and configure desired retry behavior
-6. **Configure email notifications**: Go to **Settings** > **Billing** > **Subscriptions and emails** > **Email notifications and customer management**, and enable all settings as you see fit. Set "Use your own custom link" to `https://localhost:9000/account/billing`
+6. **Configure email notifications**: Go to **Settings** > **Billing** > **Subscriptions and emails** > **Email notifications and customer management**, and enable all settings as you see fit. Set "Use your own custom link" to `https://app.dev.localhost:9000/account/billing`
 7. **Enable 3D Secure**: Go to **Settings** > **Billing** > **Subscriptions and emails** > **Manage payments that require confirmation**, and check off **Enable 3D Secure**. The embedded Stripe components support showing e.g. Visa and Danish MitID multi-factor confirmation dialogs
 8. **Set invoice prefix**: Go to **Settings** > **Billing** > **Invoices**. In the **Invoice numbering** section, change the **Invoice prefix** to something meaningful for your organization, and optionally reset the **Invoice sequence** if needed
 9. **Disable payment link in invoice emails**: Go to **Settings** > **Billing** > **Invoices** and uncheck **Include a link to a payment page in the invoice email**

--- a/README.md
+++ b/README.md
@@ -80,7 +80,15 @@ For development, you need .NET, Docker, and Node. And GitHub and Azure CLI for s
     winget install OpenJS.NodeJS
     ```
 
-4.	(Recommended) Install language servers for enhanced Claude Code support:
+4.	(Recommended) Install the [Aspire CLI](https://aspire.dev/get-started/install-cli/) — provides the [Aspire MCP server](https://aspire.dev/get-started/aspire-mcp-server/) so Claude Code can inspect AppHost resources, logs, and traces:
+
+    ```powershell
+    irm https://aspire.dev/install.ps1 | iex
+    ```
+
+    Verify with `aspire --version`. Restart your terminal if the command is not yet on PATH.
+
+5.	(Recommended) Install language servers for enhanced Claude Code support:
 
     ```powershell
     npm install -g typescript-language-server typescript
@@ -115,7 +123,15 @@ Open a terminal and run the following commands (if not installed):
    brew install node
    ```
 
-4. (Recommended) Install language servers for enhanced Claude Code support:
+4. (Recommended) Install the [Aspire CLI](https://aspire.dev/get-started/install-cli/) — provides the [Aspire MCP server](https://aspire.dev/get-started/aspire-mcp-server/) so Claude Code can inspect AppHost resources, logs, and traces:
+
+   ```bash
+   curl -sSL https://aspire.dev/install.sh | bash
+   ```
+
+   Verify with `aspire --version`. Restart your terminal if the command is not yet on PATH.
+
+5. (Recommended) Install language servers for enhanced Claude Code support:
 
    ```bash
    npm install -g typescript-language-server typescript
@@ -167,7 +183,15 @@ Open a terminal and run the following commands (if not installed):
    sudo apt-get install -y nodejs
    ```
 
-5. Trust the HTTPS development certificate
+5. (Recommended) Install the [Aspire CLI](https://aspire.dev/get-started/install-cli/) — provides the [Aspire MCP server](https://aspire.dev/get-started/aspire-mcp-server/) so Claude Code can inspect AppHost resources, logs, and traces
+
+   ```bash
+   curl -sSL https://aspire.dev/install.sh | bash
+   ```
+
+   Verify with `aspire --version`. Restart your terminal if the command is not yet on PATH.
+
+6. Trust the HTTPS development certificate
 
    ```bash
    echo 'export SSL_CERT_DIR="$HOME/.aspnet/dev-certs/trust:${SSL_CERT_DIR:-/usr/lib/ssl/certs}"' >> ~/.bashrc
@@ -181,23 +205,23 @@ Open a terminal and run the following commands (if not installed):
    dotnet dev-certs https --trust
    ```
 
-6. **Log out and log back in** to apply Docker group and shell configuration changes.
+7. **Log out and log back in** to apply Docker group and shell configuration changes.
 
-7. (Recommended) Install language servers for enhanced Claude Code support
+8. (Recommended) Install language servers for enhanced Claude Code support
 
    ```bash
    npm install -g typescript-language-server typescript
    dotnet tool install -g csharp-ls
    ```
 
-8. (Optional) If using Snap Chromium, trust the certificate in its sandbox
+9. (Optional) If using Snap Chromium, trust the certificate in its sandbox
 
    ```bash
    certutil -d sql:$HOME/snap/chromium/current/.pki/nssdb -L >/dev/null 2>&1 || (mkdir -p $HOME/snap/chromium/current/.pki/nssdb && certutil -d sql:$HOME/snap/chromium/current/.pki/nssdb -N --empty-password)
    dotnet dev-certs https --trust
    ```
 
-9. (Optional) Install GitHub CLI and Azure CLI (needed for CI/CD setup)
+10. (Optional) Install GitHub CLI and Azure CLI (needed for CI/CD setup)
 
    ```bash
    (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ With the CLI installed:
 pp run # First time downloading Docker containers will take several minutes
 ```
 
+Pass an optional base port (e.g. `pp run 11000`) to run a parallel stack from another worktree.
+
 Or without the CLI:
 
 ```bash

--- a/application/AppGateway.Tests/LocalhostRedirectTests.cs
+++ b/application/AppGateway.Tests/LocalhostRedirectTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using SharedKernel.Configuration;
 using Xunit;
 
 namespace AppGateway.Tests;
@@ -8,17 +10,17 @@ namespace AppGateway.Tests;
 public sealed class LocalhostRedirectTests(AppGatewayApplicationFactory factory) : IClassFixture<AppGatewayApplicationFactory>
 {
     [Theory]
-    [InlineData("/", "https://app.dev.localhost:9000/")]
-    [InlineData("/some/deep/path", "https://app.dev.localhost:9000/some/deep/path")]
-    [InlineData(
-        "/api/account/authentication/Google/login/callback?code=abc&state=xyz",
-        "https://app.dev.localhost:9000/api/account/authentication/Google/login/callback?code=abc&state=xyz"
-    )]
-    public async Task Request_WhenHostIsLocalhost_ShouldReturn301WithLocationPreservingPathAndQuery(string pathAndQuery, string expectedLocation)
+    [InlineData("/", "/")]
+    [InlineData("/some/deep/path", "/some/deep/path")]
+    [InlineData("/path?state=foo&code=bar", "/path?state=foo&code=bar")]
+    public async Task Request_WhenHostIsLocalhost_ShouldReturn301WithLocationPreservingPathAndQuery(string pathAndQuery, string expectedPathAndQuery)
     {
         // Arrange
+        using var scope = factory.Services.CreateScope();
+        var port = scope.ServiceProvider.GetRequiredService<PortAllocation>().AppGateway;
+        var expectedLocation = $"https://app.dev.localhost:{port}{expectedPathAndQuery}";
         var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
-        var request = new HttpRequestMessage(HttpMethod.Get, $"http://localhost:9000{pathAndQuery}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"http://localhost:{port}{pathAndQuery}");
 
         // Act
         var response = await client.SendAsync(request);

--- a/application/AppGateway/ApiAggregation/ApiAggregationService.cs
+++ b/application/AppGateway/ApiAggregation/ApiAggregationService.cs
@@ -32,21 +32,9 @@ public class ApiAggregationService(
 
         var proxyConfiguration = proxyConfigProvider.GetConfig();
 
-        foreach (var cluster in proxyConfiguration.Clusters.Where(c => c.ClusterId.EndsWith("-api")))
+        foreach (var cluster in proxyConfiguration.Clusters.Where(c => c.ClusterId is "account-api" or "back-office-api"))
         {
-            OpenApiDocument openApiDocument;
-            switch (cluster.ClusterId)
-            {
-                case "account-api":
-                    openApiDocument = await FetchOpenApiDocument(cluster, "ACCOUNT_API_URL");
-                    break;
-                case "back-office-api":
-                    openApiDocument = await FetchOpenApiDocument(cluster, "BACK_OFFICE_API_URL");
-                    break;
-                default:
-                    continue;
-            }
-
+            var openApiDocument = await FetchOpenApiDocument(cluster);
             CombineOpenApiDocuments(aggregatedOpenApiDocument, openApiDocument);
         }
 
@@ -55,10 +43,11 @@ public class ApiAggregationService(
         return aggregatedOpenApiDocument;
     }
 
-    private async Task<OpenApiDocument> FetchOpenApiDocument(ClusterConfig cluster, string environmentVariable)
+    private async Task<OpenApiDocument> FetchOpenApiDocument(ClusterConfig cluster)
     {
-        var clusterBasePath = Environment.GetEnvironmentVariable(environmentVariable)
-                              ?? cluster.Destinations!.Single().Value.Address;
+        // Cluster destinations are already substituted by ClusterDestinationConfigFilter using
+        // PortAllocation in dev and {SERVICE}_API_URL in production.
+        var clusterBasePath = cluster.Destinations!.Single().Value.Address;
 
         var clusterOpenApiUrl = $"{clusterBasePath}/openapi/v1.json";
         logger.LogInformation("Fetching OpenAPI document for cluster {ClusterId} from {Url}", cluster.ClusterId, clusterOpenApiUrl);

--- a/application/AppGateway/Filters/ClusterDestinationConfigFilter.cs
+++ b/application/AppGateway/Filters/ClusterDestinationConfigFilter.cs
@@ -1,22 +1,34 @@
+using SharedKernel.Configuration;
 using Yarp.ReverseProxy.Configuration;
 
 namespace AppGateway.Filters;
 
-public class ClusterDestinationConfigFilter : IProxyConfigFilter
+public class ClusterDestinationConfigFilter(PortAllocation ports) : IProxyConfigFilter
 {
     public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel)
     {
-        return cluster.ClusterId switch
+        // Production deploys (Bicep) set the full URL via {SERVICE}_API_URL environment variables;
+        // that takes priority. Local dev gets ports from PortAllocation and composes https://localhost:{port}.
+        var address = cluster.ClusterId switch
         {
-            "account-api" => ReplaceDestinationAddress(cluster, "ACCOUNT_API_URL"),
-            "account-static" => ReplaceDestinationAddress(cluster, "ACCOUNT_API_URL"),
-            "account-storage" => ReplaceDestinationAddress(cluster, "ACCOUNT_STORAGE_URL"),
-            "back-office-api" => ReplaceDestinationAddress(cluster, "BACK_OFFICE_API_URL"),
-            "back-office-static" => ReplaceDestinationAddress(cluster, "BACK_OFFICE_API_URL"),
-            "main-api" => ReplaceDestinationAddress(cluster, "MAIN_API_URL"),
-            "main-static" => ReplaceDestinationAddress(cluster, "MAIN_API_URL"),
+            "account-api" => ResolveAddress("ACCOUNT_API_URL", ports.AccountApi),
+            "account-static" => ResolveAddress("ACCOUNT_API_URL", ports.AccountStatic),
+            "account-storage" => ResolveStorageAddress("ACCOUNT_STORAGE_URL", ports.Blob),
+            "back-office-api" => ResolveAddress("BACK_OFFICE_API_URL", ports.BackOfficeApi),
+            "back-office-static" => ResolveAddress("BACK_OFFICE_API_URL", ports.BackOfficeStatic),
+            "back-office-storage" => ResolveStorageAddress("BACK_OFFICE_STORAGE_URL", ports.Blob),
+            "main-api" => ResolveAddress("MAIN_API_URL", ports.MainApi),
+            "main-static" => ResolveAddress("MAIN_API_URL", ports.MainStatic),
+            "main-storage" => ResolveStorageAddress("MAIN_STORAGE_URL", ports.Blob),
             _ => throw new InvalidOperationException($"Unknown Cluster ID {cluster.ClusterId}.")
         };
+
+        var destination = cluster.Destinations!.Single();
+        var newDestinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
+        {
+            { destination.Key, destination.Value with { Address = address } }
+        };
+        return new ValueTask<ClusterConfig>(cluster with { Destinations = newDestinations });
     }
 
     public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig? cluster, CancellationToken cancel)
@@ -24,20 +36,17 @@ public class ClusterDestinationConfigFilter : IProxyConfigFilter
         return new ValueTask<RouteConfig>(route);
     }
 
-    private static ValueTask<ClusterConfig> ReplaceDestinationAddress(ClusterConfig cluster, string environmentVariable)
+    private static string ResolveAddress(string productionUrlEnvironmentVariableName, int developmentPort)
     {
-        var destinationAddress = Environment.GetEnvironmentVariable(environmentVariable);
-        if (destinationAddress is null) return new ValueTask<ClusterConfig>(cluster);
+        var productionUrl = Environment.GetEnvironmentVariable(productionUrlEnvironmentVariableName);
+        if (!string.IsNullOrEmpty(productionUrl)) return productionUrl;
+        return $"https://localhost:{developmentPort}";
+    }
 
-        // Each cluster has a dictionary with one and only one destination
-        var destination = cluster.Destinations!.Single();
-
-        // This is read-only, so we'll create a new one with our updates
-        var newDestinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
-        {
-            { destination.Key, destination.Value with { Address = destinationAddress } }
-        };
-
-        return new ValueTask<ClusterConfig>(cluster with { Destinations = newDestinations });
+    private static string ResolveStorageAddress(string productionUrlEnvironmentVariableName, int blobPort)
+    {
+        var productionUrl = Environment.GetEnvironmentVariable(productionUrlEnvironmentVariableName);
+        if (!string.IsNullOrEmpty(productionUrl)) return productionUrl;
+        return $"http://127.0.0.1:{blobPort}/devstoreaccount1";
     }
 }

--- a/application/AppGateway/Middleware/LocalhostRedirectMiddleware.cs
+++ b/application/AppGateway/Middleware/LocalhostRedirectMiddleware.cs
@@ -1,8 +1,9 @@
 using Microsoft.Extensions.Options;
+using SharedKernel.Configuration;
 
 namespace AppGateway.Middleware;
 
-public sealed class LocalhostRedirectMiddleware(IOptions<HostnamesOptions> hostnamesOptions) : IMiddleware
+public sealed class LocalhostRedirectMiddleware(IOptions<HostnamesOptions> hostnamesOptions, PortAllocation ports) : IMiddleware
 {
     private const string LocalhostHost = "localhost";
 
@@ -15,7 +16,7 @@ public sealed class LocalhostRedirectMiddleware(IOptions<HostnamesOptions> hostn
             return next(context);
         }
 
-        var port = context.Request.Host.Port ?? 9000;
+        var port = context.Request.Host.Port ?? ports.AppGateway;
         var location = $"https://{_hostnames.App}:{port}{context.Request.Path}{context.Request.QueryString}";
 
         context.Response.StatusCode = StatusCodes.Status301MovedPermanently;

--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -19,6 +19,8 @@ builder.Services
     .Validate(o => !string.IsNullOrWhiteSpace(o.BackOffice), "Hostnames:BackOffice must be configured.")
     .ValidateOnStart();
 
+builder.Services.AddSingleton(PortAllocation.Load());
+
 var reverseProxyBuilder = builder.Services
     .AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"))
@@ -52,9 +54,14 @@ builder.AddNamedBlobStorages([("account-storage", "ACCOUNT_STORAGE_URL")]);
 
 builder.WebHost.UseKestrel(option => option.AddServerHeader = false);
 
-builder.Services.AddHttpClient(
-    "Account",
-    client => { client.BaseAddress = new Uri(Environment.GetEnvironmentVariable("ACCOUNT_API_URL") ?? "https://localhost:9100"); }
+builder.Services.AddHttpClient("Account", (sp, client) =>
+    {
+        var ports = sp.GetRequiredService<PortAllocation>();
+        var productionUrl = Environment.GetEnvironmentVariable("ACCOUNT_API_URL");
+        client.BaseAddress = !string.IsNullOrEmpty(productionUrl)
+            ? new Uri(productionUrl)
+            : new Uri($"https://localhost:{ports.AccountApi}");
+    }
 );
 
 builder.Services
@@ -89,10 +96,10 @@ app.MapScalarApiReference("/openapi", options =>
 
 app.MapReverseProxy();
 
-app.MapFallback((HttpContext context, IOptions<HostnamesOptions> hostnameOptions) =>
+app.MapFallback((HttpContext context, IOptions<HostnamesOptions> hostnameOptions, PortAllocation ports) =>
     {
         var hostnames = hostnameOptions.Value;
-        var port = context.Request.Host.Port ?? 9000;
+        var port = context.Request.Host.Port ?? ports.AppGateway;
         var problemDetails = new ProblemDetails
         {
             Status = StatusCodes.Status404NotFound,

--- a/application/AppGateway/Properties/launchSettings.json
+++ b/application/AppGateway/Properties/launchSettings.json
@@ -3,7 +3,6 @@
   "profiles": {
     "Api": {
       "commandName": "Project",
-      "applicationUrl": "https://localhost:9000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development"
       }

--- a/application/AppGateway/appsettings.json
+++ b/application/AppGateway/appsettings.json
@@ -267,49 +267,49 @@
       "account-api": {
         "Destinations": {
           "destination": {
-            "Address": "https://localhost:9100"
+            "Address": "https://placeholder.invalid"
           }
         }
       },
       "account-static": {
         "Destinations": {
           "destination": {
-            "Address": "https://localhost:9101"
+            "Address": "https://placeholder.invalid"
           }
         }
       },
       "back-office-api": {
         "Destinations": {
           "destination": {
-            "Address": "https://localhost:9200"
+            "Address": "https://placeholder.invalid"
           }
         }
       },
       "back-office-static": {
         "Destinations": {
           "destination": {
-            "Address": "https://localhost:9201"
+            "Address": "https://placeholder.invalid"
           }
         }
       },
       "main-api": {
         "Destinations": {
           "destination": {
-            "Address": "https://localhost:9300"
+            "Address": "https://placeholder.invalid"
           }
         }
       },
       "main-static": {
         "Destinations": {
           "destination": {
-            "Address": "https://localhost:9301"
+            "Address": "https://placeholder.invalid"
           }
         }
       },
       "account-storage": {
         "Destinations": {
           "destination": {
-            "Address": "http://127.0.0.1:10000/devstoreaccount1"
+            "Address": "https://placeholder.invalid"
           }
         }
       }

--- a/application/AppHost/AppHost.csproj
+++ b/application/AppHost/AppHost.csproj
@@ -16,6 +16,7 @@
         <ProjectReference Include="..\back-office\Workers\BackOffice.Workers.csproj"/>
         <ProjectReference Include="..\main\Api\Main.Api.csproj"/>
         <ProjectReference Include="..\main\Workers\Main.Workers.csproj"/>
+        <ProjectReference Include="..\shared-kernel\SharedKernel\SharedKernel.csproj" IsAspireProjectResource="false"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/application/AppHost/ConfigurationExtensions.cs
+++ b/application/AppHost/ConfigurationExtensions.cs
@@ -4,9 +4,9 @@ public static class ConfigurationExtensions
 {
     extension<TDestination>(IResourceBuilder<TDestination> builder) where TDestination : IResourceWithEnvironment
     {
-        public IResourceBuilder<TDestination> WithUrlConfiguration(string hostname, string applicationBasePath)
+        public IResourceBuilder<TDestination> WithUrlConfiguration(string hostname, int gatewayPort, string applicationBasePath)
         {
-            var baseUrl = $"https://{hostname}:9000";
+            var baseUrl = $"https://{hostname}:{gatewayPort}";
             applicationBasePath = applicationBasePath.TrimEnd('/');
 
             return builder

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Sockets;
 using AppHost;
 using Azure.Storage.Blobs;
-using Microsoft.Extensions.Configuration;
 using Projects;
 using SharedKernel.Configuration;
 
@@ -53,7 +52,7 @@ var azureStorage = builder
             Tag = "latest"
         }
     )
-    .AddBlobs("blobs");
+    .AddBlobs("blob-storage");
 
 builder
     .AddContainer("mail-server", "axllent/mailpit")
@@ -286,7 +285,11 @@ void AddStripeCliContainer()
 
 void CreateBlobContainer(string containerName)
 {
-    var connectionString = builder.Configuration.GetConnectionString("blob-storage");
+    // Build the Azurite connection string dynamically from the actual blob port so this works on
+    // any base port (parallel stacks from git worktrees rely on this). The default development
+    // account key is the well-known Azurite credential and is safe to keep in source.
+    var connectionString =
+        $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:{ports.Blob}/devstoreaccount1";
 
     new Task(() =>
         {

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -33,7 +33,7 @@ var stripeFullyConfigured = stripeConfigured && builder.Configuration["Parameter
 
 var postgresPassword = builder.CreateStablePassword("postgres-password");
 var postgres = builder.AddPostgres("postgres", password: postgresPassword, port: ports.Postgres)
-    .WithDataVolume("platform-platform-postgres-data")
+    .WithDataVolume($"platform-platform{ports.VolumeNameInfix}-postgres-data")
     .WithLifetime(ContainerLifetime.Persistent)
     .WithArgs("-c", "wal_level=logical");
 
@@ -41,7 +41,7 @@ var azureStorage = builder
     .AddAzureStorage("azure-storage")
     .RunAsEmulator(resourceBuilder =>
         {
-            resourceBuilder.WithDataVolume("platform-platform-azure-storage-data");
+            resourceBuilder.WithDataVolume($"platform-platform{ports.VolumeNameInfix}-azure-storage-data");
             resourceBuilder.WithBlobPort(ports.Blob);
             resourceBuilder.WithLifetime(ContainerLifetime.Persistent);
         }

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -4,14 +4,23 @@ using AppHost;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Projects;
+using SharedKernel.Configuration;
 
-// Check for port conflicts before starting
-CheckPortAvailability();
+// Read the port allocation before CreateBuilder so we can set Aspire's dashboard env vars
+// (ASPNETCORE_URLS, DOTNET_DASHBOARD_OTLP_ENDPOINT_URL, etc.) before Aspire reads them.
+var ports = PortAllocation.Load();
+
+OverrideAspireDashboardEnvironmentVariables(ports);
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+CheckPortAvailability(ports);
+
 var appHostname = builder.Configuration["Hostnames:App"] ?? "app.dev.localhost";
 var backOfficeHostname = builder.Configuration["Hostnames:BackOffice"] ?? "back-office.dev.localhost";
+
+var appBaseUrl = $"https://{appHostname}:{ports.AppGateway}";
+var backOfficeBaseUrl = $"https://{backOfficeHostname}:{ports.AppGateway}";
 
 var certificatePassword = await builder.CreateSslCertificateIfNotExists();
 
@@ -23,7 +32,7 @@ var (stripeConfigured, stripePublishableKey, stripeApiKey, stripeWebhookSecret) 
 var stripeFullyConfigured = stripeConfigured && builder.Configuration["Parameters:stripe-webhook-secret"] is not null and not "not-configured";
 
 var postgresPassword = builder.CreateStablePassword("postgres-password");
-var postgres = builder.AddPostgres("postgres", password: postgresPassword, port: 9002)
+var postgres = builder.AddPostgres("postgres", password: postgresPassword, port: ports.Postgres)
     .WithDataVolume("platform-platform-postgres-data")
     .WithLifetime(ContainerLifetime.Persistent)
     .WithArgs("-c", "wal_level=logical");
@@ -33,7 +42,7 @@ var azureStorage = builder
     .RunAsEmulator(resourceBuilder =>
         {
             resourceBuilder.WithDataVolume("platform-platform-azure-storage-data");
-            resourceBuilder.WithBlobPort(10000);
+            resourceBuilder.WithBlobPort(ports.Blob);
             resourceBuilder.WithLifetime(ContainerLifetime.Persistent);
         }
     )
@@ -48,8 +57,8 @@ var azureStorage = builder
 
 builder
     .AddContainer("mail-server", "axllent/mailpit")
-    .WithHttpEndpoint(9003, 8025)
-    .WithEndpoint(9004, 1025)
+    .WithHttpEndpoint(ports.MailpitHttp, 8025)
+    .WithEndpoint(ports.MailpitSmtp, 1025)
     .WithLifetime(ContainerLifetime.Persistent)
     .WithUrlForEndpoint("http", u => u.DisplayText = "Read mail here");
 
@@ -58,21 +67,29 @@ CreateBlobContainer("logos");
 
 var frontendBuild = builder
     .AddJavaScriptApp("frontend-build", "../")
-    .WithEnvironment("CERTIFICATE_PASSWORD", certificatePassword);
+    .WithEnvironment("CERTIFICATE_PASSWORD", certificatePassword)
+    .WithEnvironment("MAIN_STATIC_PORT", ports.MainStatic.ToString())
+    .WithEnvironment("ACCOUNT_STATIC_PORT", ports.AccountStatic.ToString())
+    .WithEnvironment("BACK_OFFICE_STATIC_PORT", ports.BackOfficeStatic.ToString());
 
 var accountDatabase = postgres
     .AddDatabase("account-database", "account");
 
 var accountWorkers = builder
     .AddProject<Account_Workers>("account-workers")
+    .WithEnvironment("KESTREL_PORT", ports.AccountWorkers.ToString())
     .WithReference(accountDatabase)
     .WithReference(azureStorage)
     .WaitFor(accountDatabase);
 
 var accountApi = builder
     .AddProject<Account_Api>("account-api")
-    .WithUrlConfiguration(appHostname, "/account")
-    .WithEnvironment("OAUTH_PUBLIC_URL", "https://localhost:9000")
+    .WithEnvironment("KESTREL_PORT", ports.AccountApi.ToString())
+    .WithUrlConfiguration(appHostname, ports.AppGateway, "/account")
+    // Google OAuth's redirect_uri whitelist requires literal 'localhost', not subdomains like
+    // 'app.dev.localhost'. The callback then 301's via LocalhostRedirectMiddleware back to the
+    // canonical 'app.dev.localhost' so OAuth-state session cookies flow with the redirected request.
+    .WithEnvironment("OAUTH_PUBLIC_URL", "https://localhost:" + ports.AppGateway)
     .WithReference(accountDatabase)
     .WithReference(azureStorage)
     .WithEnvironment("OAuth__Google__ClientId", googleOAuthClientId)
@@ -90,13 +107,15 @@ var backOfficeDatabase = postgres
 
 var backOfficeWorkers = builder
     .AddProject<BackOffice_Workers>("back-office-workers")
+    .WithEnvironment("KESTREL_PORT", ports.BackOfficeWorkers.ToString())
     .WithReference(backOfficeDatabase)
     .WithReference(azureStorage)
     .WaitFor(backOfficeDatabase);
 
 var backOfficeApi = builder
     .AddProject<BackOffice_Api>("back-office-api")
-    .WithUrlConfiguration(backOfficeHostname, "")
+    .WithEnvironment("KESTREL_PORT", ports.BackOfficeApi.ToString())
+    .WithUrlConfiguration(backOfficeHostname, ports.AppGateway, "")
     .WithReference(backOfficeDatabase)
     .WithReference(azureStorage)
     .WaitFor(backOfficeWorkers);
@@ -106,13 +125,15 @@ var mainDatabase = postgres
 
 var mainWorkers = builder
     .AddProject<Main_Workers>("main-workers")
+    .WithEnvironment("KESTREL_PORT", ports.MainWorkers.ToString())
     .WithReference(mainDatabase)
     .WithReference(azureStorage)
     .WaitFor(mainDatabase);
 
 var mainApi = builder
     .AddProject<Main_Api>("main-api")
-    .WithUrlConfiguration(appHostname, "")
+    .WithEnvironment("KESTREL_PORT", ports.MainApi.ToString())
+    .WithUrlConfiguration(appHostname, ports.AppGateway, "")
     .WithReference(mainDatabase)
     .WithReference(azureStorage)
     .WithEnvironment("PUBLIC_GOOGLE_OAUTH_ENABLED", googleOAuthConfigured ? "true" : "false")
@@ -127,6 +148,7 @@ builder
     .WithReference(mainApi)
     .WaitFor(accountApi)
     .WaitFor(frontendBuild)
+    .WithEnvironment("ASPNETCORE_URLS", "https://localhost:" + ports.AppGateway)
     .WithEnvironment("Hostnames__App", appHostname)
     .WithEnvironment("Hostnames__BackOffice", backOfficeHostname)
     .WithUrls(context =>
@@ -134,9 +156,9 @@ builder
             // Replace the auto-published "https" endpoint URL with three explicit dashboard URLs.
             // DisplayOrder: higher values sort higher in the list (Web App > Back Office > Open API).
             context.Urls.Clear();
-            context.Urls.Add(new ResourceUrlAnnotation { Url = $"https://{appHostname}:9000", DisplayText = "Web App", DisplayOrder = 300 });
-            context.Urls.Add(new ResourceUrlAnnotation { Url = $"https://{backOfficeHostname}:9000", DisplayText = "Back Office", DisplayOrder = 200 });
-            context.Urls.Add(new ResourceUrlAnnotation { Url = $"https://{appHostname}:9000/openapi", DisplayText = "Open API", DisplayOrder = 100 });
+            context.Urls.Add(new ResourceUrlAnnotation { Url = appBaseUrl, DisplayText = "Web App", DisplayOrder = 300 });
+            context.Urls.Add(new ResourceUrlAnnotation { Url = backOfficeBaseUrl, DisplayText = "Back Office", DisplayOrder = 200 });
+            context.Urls.Add(new ResourceUrlAnnotation { Url = $"{appBaseUrl}/openapi", DisplayText = "Open API", DisplayOrder = 100 });
         }
     );
 
@@ -153,7 +175,7 @@ void AddStripeCliContainer()
         builder
             .AddContainer("stripe-cli", "stripe/stripe-cli:latest")
             .WithContainerRuntimeArgs("--add-host", $"{appHostname}:host-gateway")
-            .WithArgs("listen", "--forward-to", $"https://{appHostname}:9000/api/account/subscriptions/stripe-webhook", "--skip-verify")
+            .WithArgs("listen", "--forward-to", $"{appBaseUrl}/api/account/subscriptions/stripe-webhook", "--skip-verify")
             .WithEnvironment("STRIPE_API_KEY", stripeApiKey)
             .WithLifetime(ContainerLifetime.Persistent);
     }
@@ -275,10 +297,24 @@ void CreateBlobContainer(string containerName)
     ).Start();
 }
 
-void CheckPortAvailability()
+void OverrideAspireDashboardEnvironmentVariables(PortAllocation portAllocation)
 {
-    var ports = new[] { (9098, "Resource Service"), (9097, "Dashboard"), (9001, "Aspire") };
-    var blocked = ports.Where(p => !IsPortAvailable(p.Item1)).ToList();
+    // Must be set before DistributedApplication.CreateBuilder so Aspire picks them up.
+    Environment.SetEnvironmentVariable("ASPNETCORE_URLS", $"https://localhost:{portAllocation.Aspire}");
+    Environment.SetEnvironmentVariable("DOTNET_DASHBOARD_OTLP_ENDPOINT_URL", $"https://localhost:{portAllocation.OtelEndpoint}");
+    Environment.SetEnvironmentVariable("DOTNET_RESOURCE_SERVICE_ENDPOINT_URL", $"https://localhost:{portAllocation.ResourceService}");
+    Environment.SetEnvironmentVariable("ASPIRE_DASHBOARD_MCP_ENDPOINT_URL", $"http://localhost:{portAllocation.Mcp}/mcp");
+}
+
+void CheckPortAvailability(PortAllocation portAllocation)
+{
+    var portsToCheck = new[]
+    {
+        (portAllocation.ResourceService, "Resource Service"),
+        (portAllocation.OtelEndpoint, "Dashboard"),
+        (portAllocation.Aspire, "Aspire")
+    };
+    var blocked = portsToCheck.Where(p => !IsPortAvailable(p.Item1)).ToList();
 
     if (blocked.Count > 0)
     {

--- a/application/AppHost/Program.cs
+++ b/application/AppHost/Program.cs
@@ -306,7 +306,6 @@ void OverrideAspireDashboardEnvironmentVariables(PortAllocation portAllocation)
     Environment.SetEnvironmentVariable("ASPNETCORE_URLS", $"https://localhost:{portAllocation.Aspire}");
     Environment.SetEnvironmentVariable("DOTNET_DASHBOARD_OTLP_ENDPOINT_URL", $"https://localhost:{portAllocation.OtelEndpoint}");
     Environment.SetEnvironmentVariable("DOTNET_RESOURCE_SERVICE_ENDPOINT_URL", $"https://localhost:{portAllocation.ResourceService}");
-    Environment.SetEnvironmentVariable("ASPIRE_DASHBOARD_MCP_ENDPOINT_URL", $"http://localhost:{portAllocation.Mcp}/mcp");
 }
 
 void CheckPortAvailability(PortAllocation portAllocation)

--- a/application/AppHost/Properties/launchSettings.json
+++ b/application/AppHost/Properties/launchSettings.json
@@ -6,9 +6,7 @@
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
-        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
-        "Dashboard__Mcp__AuthMode": "Unsecured"
+        "DOTNET_ENVIRONMENT": "Development"
       }
     }
   }

--- a/application/AppHost/Properties/launchSettings.json
+++ b/application/AppHost/Properties/launchSettings.json
@@ -4,13 +4,9 @@
     "AppHost": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:9001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:9097",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:9098",
-        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://localhost:9096/mcp",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
         "Dashboard__Mcp__AuthMode": "Unsecured"
       }

--- a/application/account/Api/Program.cs
+++ b/application/account/Api/Program.cs
@@ -7,7 +7,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Configure storage infrastructure like Database, BlobStorage, Logging, Telemetry, Entity Framework DB Context, etc.
 builder
     .AddApiInfrastructure()
-    .AddDevelopmentPort(9100)
+    .AddDevelopmentPort()
     .AddAccountInfrastructure();
 
 // Configure dependency injection services like Repositories, MediatR, Pipelines, FluentValidation validators, etc.

--- a/application/account/Tests/EndpointBaseTest.cs
+++ b/application/account/Tests/EndpointBaseTest.cs
@@ -26,6 +26,9 @@ namespace Account.Tests;
 
 public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : DbContext
 {
+    // Tests use the in-memory test server (WebApplicationFactory); no real listener is bound.
+    // SinglePageAppConfiguration only consumes this as a URI for CSP construction.
+    private const string TestPublicUrl = "https://localhost";
     protected readonly AccessTokenGenerator AccessTokenGenerator;
     protected readonly IEmailClient EmailClient;
     protected readonly Faker Faker = new();
@@ -36,8 +39,8 @@ public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : 
 
     protected EndpointBaseTest()
     {
-        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.PublicUrlKey, "https://localhost:9000");
-        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.CdnUrlKey, "https://localhost:9000/account");
+        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.PublicUrlKey, TestPublicUrl);
+        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.CdnUrlKey, $"{TestPublicUrl}/account");
         Environment.SetEnvironmentVariable(
             "APPLICATIONINSIGHTS_CONNECTION_STRING",
             "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://localhost;LiveEndpoint=https://localhost"

--- a/application/account/Tests/ExternalAuthentication/ExternalAuthenticationTestBase.cs
+++ b/application/account/Tests/ExternalAuthentication/ExternalAuthenticationTestBase.cs
@@ -33,6 +33,9 @@ namespace Account.Tests.ExternalAuthentication;
 
 public abstract class ExternalAuthenticationTestBase : IDisposable
 {
+    // Tests use the in-memory test server (WebApplicationFactory); no real listener is bound.
+    // SinglePageAppConfiguration only consumes this as a URI.
+    protected const string PublicUrl = "https://localhost";
     protected readonly Faker Faker = new();
     protected readonly TimeProvider TimeProvider;
     private readonly WebApplicationFactory<Program> _webApplicationFactory;
@@ -40,8 +43,8 @@ public abstract class ExternalAuthenticationTestBase : IDisposable
 
     protected ExternalAuthenticationTestBase()
     {
-        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.PublicUrlKey, "https://localhost:9000");
-        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.CdnUrlKey, "https://localhost:9000/account");
+        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.PublicUrlKey, PublicUrl);
+        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.CdnUrlKey, $"{PublicUrl}/account");
         Environment.SetEnvironmentVariable(
             "APPLICATIONINSIGHTS_CONNECTION_STRING",
             "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://localhost;LiveEndpoint=https://localhost"
@@ -259,7 +262,7 @@ public abstract class ExternalAuthenticationTestBase : IDisposable
     private static Uri ToAbsoluteUri(string url)
     {
         var uri = new Uri(url, UriKind.RelativeOrAbsolute);
-        return uri.IsAbsoluteUri ? uri : new Uri(new Uri("https://localhost:9000"), url);
+        return uri.IsAbsoluteUri ? uri : new Uri(new Uri(PublicUrl), url);
     }
 
     private static string[] ExtractSetCookieHeaders(HttpResponseMessage response)

--- a/application/account/WebApp/rsbuild.config.ts
+++ b/application/account/WebApp/rsbuild.config.ts
@@ -12,6 +12,19 @@ import { pluginTypeCheck } from "@rsbuild/plugin-type-check";
 
 const customBuildEnv: CustomBuildEnv = {};
 
+function requirePort(name: string): number {
+  // In production builds, port env vars aren't relevant (no dev server). Returning 0 keeps the
+  // dev-server config valid; the dev-server plugin no-ops in production anyway.
+  if (process.env.NODE_ENV === "production") return 0;
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} must be set. rsbuild must be launched via Aspire AppHost.`);
+  const port = Number.parseInt(value, 10);
+  if (!Number.isFinite(port) || port <= 0) throw new Error(`${name} is not a valid positive integer: '${value}'.`);
+  return port;
+}
+
+const accountStaticPort = requirePort("ACCOUNT_STATIC_PORT");
+
 export default defineConfig({
   dev: {
     lazyCompilation: false
@@ -37,7 +50,7 @@ export default defineConfig({
     FileSystemRouterPlugin(),
     RunTimeEnvironmentPlugin(customBuildEnv, { federationOnly: true }),
     LinguiPlugin(),
-    DevelopmentServerPlugin({ port: 9101, liveReload: false }),
+    DevelopmentServerPlugin({ port: accountStaticPort, liveReload: false }),
     ModuleFederationPlugin({
       exposes: {
         "./AccessDeniedPage": "./federated-modules/errorPages/AccessDeniedPage.tsx",

--- a/application/account/Workers/Program.cs
+++ b/application/account/Workers/Program.cs
@@ -8,7 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Configure storage infrastructure like Database, BlobStorage, Logging, Telemetry, Entity Framework DB Context, etc.
 builder
-    .AddDevelopmentPort(9199)
+    .AddDevelopmentPort()
     .AddAccountInfrastructure();
 
 // Configure dependency injection services like Repositories, MediatR, Pipelines, FluentValidation validators, etc.

--- a/application/back-office/Api/Program.cs
+++ b/application/back-office/Api/Program.cs
@@ -7,7 +7,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Configure storage infrastructure like Database, BlobStorage, Logging, Telemetry, Entity Framework DB Context, etc.
 builder
     .AddApiInfrastructure()
-    .AddDevelopmentPort(9200)
+    .AddDevelopmentPort()
     .AddBackOfficeInfrastructure();
 
 // Configure dependency injection services like Repositories, MediatR, Pipelines, FluentValidation validators, etc.

--- a/application/back-office/Tests/EndpointBaseTest.cs
+++ b/application/back-office/Tests/EndpointBaseTest.cs
@@ -25,6 +25,9 @@ namespace BackOffice.Tests;
 
 public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : DbContext
 {
+    // Tests use the in-memory test server (WebApplicationFactory); no real listener is bound.
+    // SinglePageAppConfiguration only consumes this as a URI for CSP construction.
+    private const string TestPublicUrl = "https://localhost";
     protected readonly AccessTokenGenerator AccessTokenGenerator;
     protected readonly IEmailClient EmailClient;
     protected readonly Faker Faker = new();
@@ -35,8 +38,8 @@ public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : 
 
     protected EndpointBaseTest()
     {
-        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.PublicUrlKey, "https://localhost:9000");
-        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.CdnUrlKey, "https://localhost:9000/back-office");
+        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.PublicUrlKey, TestPublicUrl);
+        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.CdnUrlKey, $"{TestPublicUrl}/back-office");
         Environment.SetEnvironmentVariable(
             "APPLICATIONINSIGHTS_CONNECTION_STRING",
             "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://localhost;LiveEndpoint=https://localhost"

--- a/application/back-office/WebApp/rsbuild.config.ts
+++ b/application/back-office/WebApp/rsbuild.config.ts
@@ -11,6 +11,19 @@ import { pluginTypeCheck } from "@rsbuild/plugin-type-check";
 
 const customBuildEnv: CustomBuildEnv = {};
 
+function requirePort(name: string): number {
+  // In production builds, port env vars aren't relevant (no dev server). Returning 0 keeps the
+  // dev-server config valid; the dev-server plugin no-ops in production anyway.
+  if (process.env.NODE_ENV === "production") return 0;
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} must be set. rsbuild must be launched via Aspire AppHost.`);
+  const port = Number.parseInt(value, 10);
+  if (!Number.isFinite(port) || port <= 0) throw new Error(`${name} is not a valid positive integer: '${value}'.`);
+  return port;
+}
+
+const backOfficeStaticPort = requirePort("BACK_OFFICE_STATIC_PORT");
+
 export default defineConfig({
   dev: {
     lazyCompilation: false
@@ -29,6 +42,6 @@ export default defineConfig({
     FileSystemRouterPlugin(),
     RunTimeEnvironmentPlugin(customBuildEnv),
     LinguiPlugin(),
-    DevelopmentServerPlugin({ port: 9201 })
+    DevelopmentServerPlugin({ port: backOfficeStaticPort })
   ]
 });

--- a/application/back-office/WebApp/tests/e2e/back-office-flows.spec.ts
+++ b/application/back-office/WebApp/tests/e2e/back-office-flows.spec.ts
@@ -1,21 +1,24 @@
 import { expect } from "@playwright/test";
 import { test } from "@shared/e2e/fixtures/page-auth";
+import { getBaseUrl } from "@shared/e2e/utils/constants";
 import { createTestContext } from "@shared/e2e/utils/test-assertions";
 import { step } from "@shared/e2e/utils/test-step-wrapper";
 
-const BACK_OFFICE_URL = "https://back-office.dev.localhost:9000/";
-const NAKED_LOCALHOST_URL = "https://localhost:9000/";
-const UNKNOWN_HOST_URL = "https://other.dev.localhost:9000/";
-const APP_CANONICAL_URL = "https://app.dev.localhost:9000";
-const BACK_OFFICE_CANONICAL_URL = "https://back-office.dev.localhost:9000";
+const BASE_URL = new URL(getBaseUrl());
+const PORT = BASE_URL.port;
+const BACK_OFFICE_URL = `https://back-office.dev.localhost:${PORT}/`;
+const NAKED_LOCALHOST_URL = `https://localhost:${PORT}/`;
+const UNKNOWN_HOST_URL = `https://other.dev.localhost:${PORT}/`;
+const APP_CANONICAL_URL = `https://app.dev.localhost:${PORT}`;
+const BACK_OFFICE_CANONICAL_URL = `https://back-office.dev.localhost:${PORT}`;
 
 test.describe("@smoke", () => {
   /**
    * Tests host-based routing for the back-office surface, the naked-localhost redirect, and the AppGateway 404 fallback.
    * Covers:
    * - Back-office shell loads at the back-office.dev.localhost subdomain with the expected page title
-   * - Naked https://localhost:9000 returns HTTP 301 redirecting to https://app.dev.localhost:9000/ (preserves OAuth callback flow)
-   * - Unknown https://other.dev.localhost:9000 returns HTTP 404 with a problem-details body listing canonical URLs
+   * - Naked https://localhost returns HTTP 301 redirecting to the app canonical URL (preserves OAuth callback flow)
+   * - Unknown https://other.dev.localhost returns HTTP 404 with a problem-details body listing canonical URLs
    */
   test("should serve back-office at its subdomain, redirect naked localhost to app, and reject unknown hosts with 404", async ({
     page,

--- a/application/back-office/Workers/Program.cs
+++ b/application/back-office/Workers/Program.cs
@@ -8,7 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Configure storage infrastructure like Database, BlobStorage, Logging, Telemetry, Entity Framework DB Context, etc.
 builder
-    .AddDevelopmentPort(9299)
+    .AddDevelopmentPort()
     .AddBackOfficeInfrastructure();
 
 // Configure dependency injection services like Repositories, MediatR, Pipelines, FluentValidation validators, etc.

--- a/application/main/Api/Program.cs
+++ b/application/main/Api/Program.cs
@@ -7,7 +7,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Configure storage infrastructure like Database, BlobStorage, Logging, Telemetry, Entity Framework DB Context, etc.
 builder
     .AddApiInfrastructure()
-    .AddDevelopmentPort(9300)
+    .AddDevelopmentPort()
     .AddMainInfrastructure();
 
 // Configure dependency injection services like Repositories, MediatR, Pipelines, FluentValidation validators, etc.

--- a/application/main/Tests/EndpointBaseTest.cs
+++ b/application/main/Tests/EndpointBaseTest.cs
@@ -25,6 +25,9 @@ namespace Main.Tests;
 
 public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : DbContext
 {
+    // Tests use the in-memory test server (WebApplicationFactory); no real listener is bound.
+    // SinglePageAppConfiguration only consumes this as a URI for CSP construction.
+    private const string TestPublicUrl = "https://localhost";
     protected readonly AccessTokenGenerator AccessTokenGenerator;
     protected readonly IEmailClient EmailClient;
     protected readonly Faker Faker = new();
@@ -35,8 +38,8 @@ public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : 
 
     protected EndpointBaseTest()
     {
-        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.PublicUrlKey, "https://localhost:9000");
-        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.CdnUrlKey, "https://localhost:9000/main");
+        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.PublicUrlKey, TestPublicUrl);
+        Environment.SetEnvironmentVariable(SinglePageAppConfiguration.CdnUrlKey, $"{TestPublicUrl}/main");
         Environment.SetEnvironmentVariable(
             "APPLICATIONINSIGHTS_CONNECTION_STRING",
             "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://localhost;LiveEndpoint=https://localhost"

--- a/application/main/WebApp/rsbuild.config.ts
+++ b/application/main/WebApp/rsbuild.config.ts
@@ -12,6 +12,20 @@ import { pluginTypeCheck } from "@rsbuild/plugin-type-check";
 
 const customBuildEnv: CustomBuildEnv = {};
 
+function requirePort(name: string): number {
+  // In production builds, port env vars aren't relevant (no dev server). Returning 0 keeps the
+  // module-federation/dev-server config valid; the dev-server plugin no-ops in production anyway.
+  if (process.env.NODE_ENV === "production") return 0;
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} must be set. rsbuild must be launched via Aspire AppHost.`);
+  const port = Number.parseInt(value, 10);
+  if (!Number.isFinite(port) || port <= 0) throw new Error(`${name} is not a valid positive integer: '${value}'.`);
+  return port;
+}
+
+const mainStaticPort = requirePort("MAIN_STATIC_PORT");
+const accountStaticPort = requirePort("ACCOUNT_STATIC_PORT");
+
 export default defineConfig({
   dev: {
     lazyCompilation: false
@@ -30,10 +44,10 @@ export default defineConfig({
     FileSystemRouterPlugin(),
     RunTimeEnvironmentPlugin(customBuildEnv),
     LinguiPlugin(),
-    DevelopmentServerPlugin({ port: 9301 }),
+    DevelopmentServerPlugin({ port: mainStaticPort }),
     ModuleFederationPlugin({
       remotes: {
-        account: { port: 9101 }
+        account: { port: accountStaticPort }
       }
     })
   ]

--- a/application/main/Workers/Program.cs
+++ b/application/main/Workers/Program.cs
@@ -8,7 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Configure storage infrastructure like Database, BlobStorage, Logging, Telemetry, Entity Framework DB Context, etc.
 builder
-    .AddDevelopmentPort(9399)
+    .AddDevelopmentPort()
     .AddMainInfrastructure();
 
 // Configure dependency injection services like Repositories, MediatR, Pipelines, FluentValidation validators, etc.

--- a/application/shared-kernel/SharedKernel/Configuration/ApiDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/ApiDependencyConfiguration.cs
@@ -40,11 +40,21 @@ public static class ApiDependencyConfiguration
             return builder;
         }
 
-        public WebApplicationBuilder AddDevelopmentPort(int port)
+        public WebApplicationBuilder AddDevelopmentPort()
         {
+            // KESTREL_PORT is set by AppHost from the base port in .workspace/port.txt.
+            // Outside Aspire (e.g. unit tests via WebApplicationFactory) ConfigureKestrel is not invoked.
             builder.WebHost.ConfigureKestrel((context, serverOptions) =>
                 {
                     if (!context.HostingEnvironment.IsDevelopment()) return;
+
+                    if (!int.TryParse(Environment.GetEnvironmentVariable("KESTREL_PORT"), out var port) || port <= 0)
+                    {
+                        throw new InvalidOperationException(
+                            "KESTREL_PORT environment variable is required for development startup. Run via Aspire AppHost or set KESTREL_PORT manually."
+                        );
+                    }
+
                     serverOptions.ConfigureEndpointDefaults(listenOptions => listenOptions.UseHttps());
                     serverOptions.ListenLocalhost(port, listenOptions => listenOptions.UseHttps());
                 }

--- a/application/shared-kernel/SharedKernel/Configuration/PortAllocation.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/PortAllocation.cs
@@ -53,6 +53,12 @@ public sealed record PortAllocation(int BasePort)
         MainApi, MainStatic, MainWorkers, AccountApi, AccountStatic, AccountWorkers, BackOfficeApi, BackOfficeStatic, BackOfficeWorkers
     ];
 
+    // Empty on the default base port so existing developers' Docker volumes are reused unchanged on
+    // upgrade; non-empty on any other base port so parallel Aspire stacks (typically run from
+    // separate git worktrees with different .workspace/port.txt values) get isolated volumes
+    // instead of corrupting each other's state.
+    public string VolumeNameInfix => BasePort == DefaultBasePort ? string.Empty : $"-{BasePort}";
+
     // Resolves the repository root by walking up from AppContext.BaseDirectory looking for the
     // .git folder (always present in a checked-out repo, including git worktrees where .git is a
     // file pointing at the real worktree directory), then reads or bootstraps .workspace/port.txt.

--- a/application/shared-kernel/SharedKernel/Configuration/PortAllocation.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/PortAllocation.cs
@@ -23,8 +23,6 @@ public sealed record PortAllocation(int BasePort)
 
     public int MailpitHttp => BasePort + 5;
 
-    public int Mcp => BasePort + 7;
-
     public int OtelEndpoint => BasePort + 8;
 
     public int ResourceService => BasePort + 9;
@@ -49,7 +47,7 @@ public sealed record PortAllocation(int BasePort)
 
     public int[] AllPorts =>
     [
-        AppGateway, Aspire, Postgres, Blob, MailpitSmtp, MailpitHttp, Mcp, OtelEndpoint, ResourceService,
+        AppGateway, Aspire, Postgres, Blob, MailpitSmtp, MailpitHttp, OtelEndpoint, ResourceService,
         MainApi, MainStatic, MainWorkers, AccountApi, AccountStatic, AccountWorkers, BackOfficeApi, BackOfficeStatic, BackOfficeWorkers
     ];
 

--- a/application/shared-kernel/SharedKernel/Configuration/PortAllocation.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/PortAllocation.cs
@@ -86,6 +86,23 @@ public sealed record PortAllocation(int BasePort)
         return new PortAllocation(basePort);
     }
 
+    // Atomically writes the base port to .workspace/port.txt under the given repository root.
+    // Callers (e.g., the developer CLI's positional base-port argument on run/restart) use this to
+    // update the file before any code path lazily loads PortAllocation -- otherwise the lazy load
+    // would race with the write and could bootstrap with the default port.
+    public static void WriteBasePort(string repositoryRoot, int basePort)
+    {
+        if (basePort <= 0) throw new ArgumentOutOfRangeException(nameof(basePort), basePort, "Base port must be a positive integer.");
+
+        var workspaceDirectory = Path.Combine(repositoryRoot, WorkspaceDirectoryName);
+        var portFilePath = Path.Combine(workspaceDirectory, PortFileName);
+        var temporaryFilePath = portFilePath + ".tmp";
+
+        Directory.CreateDirectory(workspaceDirectory);
+        File.WriteAllText(temporaryFilePath, $"{basePort}{Environment.NewLine}");
+        File.Move(temporaryFilePath, portFilePath, true);
+    }
+
     private static string FindRepositoryRoot(string startDirectory)
     {
         var current = new DirectoryInfo(startDirectory);

--- a/application/shared-kernel/SharedKernel/Configuration/PortAllocation.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/PortAllocation.cs
@@ -1,0 +1,104 @@
+namespace SharedKernel.Configuration;
+
+// Single source of truth for the local development port allocation. Reads .workspace/port.txt
+// (single integer, whitespace-tolerant). If the file is missing, self-bootstraps with the default
+// base port so the first run on a fresh checkout just works. Throws on a present-but-invalid file.
+public sealed record PortAllocation(int BasePort)
+{
+    private const int DefaultBasePort = 9000;
+
+    private const string WorkspaceDirectoryName = ".workspace";
+
+    private const string PortFileName = "port.txt";
+
+    public int AppGateway => BasePort;
+
+    public int Aspire => BasePort + 1;
+
+    public int Postgres => BasePort + 2;
+
+    public int Blob => BasePort + 3;
+
+    public int MailpitSmtp => BasePort + 4;
+
+    public int MailpitHttp => BasePort + 5;
+
+    public int Mcp => BasePort + 7;
+
+    public int OtelEndpoint => BasePort + 8;
+
+    public int ResourceService => BasePort + 9;
+
+    public int MainApi => BasePort + 10;
+
+    public int MainStatic => BasePort + 11;
+
+    public int MainWorkers => BasePort + 12;
+
+    public int AccountApi => BasePort + 13;
+
+    public int AccountStatic => BasePort + 14;
+
+    public int AccountWorkers => BasePort + 15;
+
+    public int BackOfficeApi => BasePort + 16;
+
+    public int BackOfficeStatic => BasePort + 17;
+
+    public int BackOfficeWorkers => BasePort + 18;
+
+    public int[] AllPorts =>
+    [
+        AppGateway, Aspire, Postgres, Blob, MailpitSmtp, MailpitHttp, Mcp, OtelEndpoint, ResourceService,
+        MainApi, MainStatic, MainWorkers, AccountApi, AccountStatic, AccountWorkers, BackOfficeApi, BackOfficeStatic, BackOfficeWorkers
+    ];
+
+    // Resolves the repository root by walking up from AppContext.BaseDirectory looking for the
+    // .git folder (always present in a checked-out repo, including git worktrees where .git is a
+    // file pointing at the real worktree directory), then reads or bootstraps .workspace/port.txt.
+    // Use LoadFrom(repositoryRoot) when AppContext.BaseDirectory is outside the repo (e.g., a
+    // single-file CLI binary published to the user's home directory).
+    public static PortAllocation Load()
+    {
+        return LoadFrom(FindRepositoryRoot(AppContext.BaseDirectory));
+    }
+
+    public static PortAllocation LoadFrom(string repositoryRoot)
+    {
+        var workspaceDirectory = Path.Combine(repositoryRoot, WorkspaceDirectoryName);
+        var portFilePath = Path.Combine(workspaceDirectory, PortFileName);
+
+        if (!File.Exists(portFilePath))
+        {
+            Directory.CreateDirectory(workspaceDirectory);
+            File.WriteAllText(portFilePath, $"{DefaultBasePort}{Environment.NewLine}");
+            return new PortAllocation(DefaultBasePort);
+        }
+
+        var content = File.ReadAllText(portFilePath).Trim();
+        if (!int.TryParse(content, out var basePort) || basePort <= 0)
+        {
+            throw new InvalidOperationException(
+                $"Port allocation file '{portFilePath}' must contain a positive integer. Got: '{content}'."
+            );
+        }
+
+        return new PortAllocation(basePort);
+    }
+
+    private static string FindRepositoryRoot(string startDirectory)
+    {
+        var current = new DirectoryInfo(startDirectory);
+        while (current is not null)
+        {
+            // .git is a directory in normal checkouts and a file in git worktrees -- both count.
+            var gitMarker = Path.Combine(current.FullName, ".git");
+            if (Directory.Exists(gitMarker) || File.Exists(gitMarker)) return current.FullName;
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate the repository root walking up from '{startDirectory}'. Expected a '.git' directory or file."
+        );
+    }
+}

--- a/application/shared-kernel/SharedKernel/Configuration/PortAllocation.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/PortAllocation.cs
@@ -92,6 +92,13 @@ public sealed record PortAllocation(int BasePort)
         return new PortAllocation(basePort);
     }
 
+    // True if .workspace/port.txt already exists -- distinguishes a fresh worktree from a configured one.
+    public static bool PortFileExists(string repositoryRoot)
+    {
+        var portFilePath = Path.Combine(repositoryRoot, WorkspaceDirectoryName, PortFileName);
+        return File.Exists(portFilePath);
+    }
+
     // Atomically writes the base port to .workspace/port.txt under the given repository root.
     // Callers (e.g., the developer CLI's positional base-port argument on run/restart) use this to
     // update the file before any code path lazily loads PortAllocation -- otherwise the lazy load

--- a/application/shared-kernel/SharedKernel/Configuration/SharedDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/SharedDependencyConfiguration.cs
@@ -150,7 +150,9 @@ public static class SharedDependencyConfiguration
             }
             else
             {
-                services.AddTransient<IEmailClient, DevelopmentEmailClient>();
+                services
+                    .AddSingleton(_ => PortAllocation.Load())
+                    .AddTransient<IEmailClient, DevelopmentEmailClient>();
             }
 
             return services;

--- a/application/shared-kernel/SharedKernel/Integrations/Email/DevelopmentEmailClient.cs
+++ b/application/shared-kernel/SharedKernel/Integrations/Email/DevelopmentEmailClient.cs
@@ -1,11 +1,13 @@
 using System.Net.Mail;
+using SharedKernel.Configuration;
 
 namespace SharedKernel.Integrations.Email;
 
-public sealed class DevelopmentEmailClient : IEmailClient
+public sealed class DevelopmentEmailClient(PortAllocation ports) : IEmailClient
 {
     private const string Sender = "no-reply@localhost";
-    private readonly SmtpClient _emailSender = new("localhost", 9004);
+
+    private readonly SmtpClient _emailSender = new("localhost", ports.MailpitSmtp);
 
     public Task SendAsync(string recipient, string subject, string htmlContent, CancellationToken cancellationToken)
     {

--- a/application/shared-webapp/tests/e2e/utils/constants.ts
+++ b/application/shared-webapp/tests/e2e/utils/constants.ts
@@ -4,7 +4,30 @@
  * Shared constants for End2End tests
  */
 
-const DEFAULT_BASE_URL = "https://app.dev.localhost:9000";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+function readBasePort(): number {
+  // Walk up from this file (application/shared-webapp/tests/e2e/utils) to the repo root and read
+  // .workspace/port.txt. E2E tests must have an explicit port file — silent defaulting would mask
+  // setup problems in deterministic test environments.
+  const repoRoot = resolve(__dirname, "..", "..", "..", "..", "..");
+  const portFile = join(repoRoot, ".workspace", "port.txt");
+  if (!existsSync(portFile)) {
+    throw new Error(
+      "E2E tests require .workspace/port.txt to exist. Start Aspire AppHost first to bootstrap it."
+    );
+  }
+  const content = readFileSync(portFile, "utf8").trim();
+  const parsed = Number.parseInt(content, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`.workspace/port.txt must contain a positive integer port number. Got: '${content}'`);
+  }
+  return parsed;
+}
+
+const BASE_PORT = readBasePort();
+const DEFAULT_BASE_URL = `https://app.dev.localhost:${BASE_PORT}`;
 
 export const isWindows = process.platform === "win32";
 export const isLinux = process.platform === "linux";

--- a/application/turbo.json
+++ b/application/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["CERTIFICATE_PASSWORD"],
+  "globalEnv": ["CERTIFICATE_PASSWORD", "MAIN_STATIC_PORT", "ACCOUNT_STATIC_PORT", "BACK_OFFICE_STATIC_PORT"],
   "tasks": {
     "build": {
       "inputs": ["$TURBO_DEFAULT$", "shared/lib/api/*.Api.json"],
@@ -18,7 +18,7 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "env": ["CERTIFICATE_PASSWORD"],
+      "env": ["CERTIFICATE_PASSWORD", "MAIN_STATIC_PORT", "ACCOUNT_STATIC_PORT", "BACK_OFFICE_STATIC_PORT"],
       "dependsOn": ["dev:setup"]
     },
     "dev:setup": {

--- a/developer-cli/Commands/ClaudeAgentCommand.cs
+++ b/developer-cli/Commands/ClaudeAgentCommand.cs
@@ -35,6 +35,7 @@ public class ClaudeAgentCommand : Command
         {
             // Check for optional LSP prerequisites (non-blocking)
             Prerequisite.Recommend(Prerequisite.TypeScriptLanguageServer, Prerequisite.CSharpLanguageServer);
+            Prerequisite.WarnIfAspireCliDoesNotMatchSdk();
 
             // If no agent type provided, prompt for selection
             if (string.IsNullOrEmpty(agentType))

--- a/developer-cli/Commands/End2EndCommand.cs
+++ b/developer-cli/Commands/End2EndCommand.cs
@@ -94,7 +94,7 @@ public partial class End2EndCommand : Command
         );
     }
 
-    private static string BaseUrl => Environment.GetEnvironmentVariable("PUBLIC_URL") ?? "https://app.dev.localhost:9000";
+    private static string BaseUrl => Environment.GetEnvironmentVariable("PUBLIC_URL") ?? $"https://app.dev.localhost:{RunCommand.Ports.AppGateway}";
 
     private static string DefaultsFilePath => Path.Combine(Configuration.WorkspaceFolder, "developer-cli", "end-to-end-tests", "e2e-defaults.json");
 

--- a/developer-cli/Commands/McpCommand.cs
+++ b/developer-cli/Commands/McpCommand.cs
@@ -547,7 +547,6 @@ public static partial class DeveloperCliMcpTools
                 blob = ports.Blob,
                 mailpitSmtp = ports.MailpitSmtp,
                 mailpitHttp = ports.MailpitHttp,
-                mcp = ports.Mcp,
                 otelEndpoint = ports.OtelEndpoint,
                 resourceService = ports.ResourceService,
                 mainApi = ports.MainApi,

--- a/developer-cli/Commands/McpCommand.cs
+++ b/developer-cli/Commands/McpCommand.cs
@@ -507,17 +507,23 @@ public static partial class DeveloperCliMcpTools
     }
 
     [McpServerTool]
-    [Description("Start .NET Aspire AppHost on the configured base port from .workspace/port.txt. Call get_ports to discover the actual URL. Fails if already running -- use Restart to replace a running instance, or Stop to stop it.")]
-    public static Task<string> Run()
+    [Description("Start .NET Aspire AppHost. By default uses the base port from .workspace/port.txt. Pass basePort to override (writes the new value to .workspace/port.txt) -- useful for running parallel stacks from different git worktrees. Call get_ports to discover the actual URL. Fails if already running -- use Restart to replace a running instance, or Stop to stop it.")]
+    public static Task<string> Run(
+        [Description("Optional base port. When set, overwrites .workspace/port.txt. Leave unset to use the existing base port.")]
+        int? basePort = null)
     {
-        return ExecuteAspireLifecycleCommand("run", "Run", $"Aspire started successfully in detached mode at https://app.dev.localhost:{RunCommand.Ports.AppGateway}");
+        var gatewayPort = basePort ?? RunCommand.Ports.AppGateway;
+        return ExecuteAspireLifecycleCommand("run", "Run", $"Aspire started successfully in detached mode at https://app.dev.localhost:{gatewayPort}", basePort);
     }
 
     [McpServerTool]
-    [Description("Stop any running Aspire AppHost and start a fresh instance. Use after backend changes or when hot reload breaks.")]
-    public static Task<string> Restart()
+    [Description("Stop any running Aspire AppHost and start a fresh instance. Pass basePort to override the base port (writes the new value to .workspace/port.txt). Use after backend changes or when hot reload breaks.")]
+    public static Task<string> Restart(
+        [Description("Optional base port. When set, overwrites .workspace/port.txt. Leave unset to use the existing base port.")]
+        int? basePort = null)
     {
-        return ExecuteAspireLifecycleCommand("restart", "Restart", $"Aspire restarted successfully in detached mode at https://app.dev.localhost:{RunCommand.Ports.AppGateway}");
+        var gatewayPort = basePort ?? RunCommand.Ports.AppGateway;
+        return ExecuteAspireLifecycleCommand("restart", "Restart", $"Aspire restarted successfully in detached mode at https://app.dev.localhost:{gatewayPort}", basePort);
     }
 
     [McpServerTool]
@@ -557,15 +563,16 @@ public static partial class DeveloperCliMcpTools
         );
     }
 
-    private static async Task<string> ExecuteAspireLifecycleCommand(string cliCommand, string toolName, string successMessage)
+    private static async Task<string> ExecuteAspireLifecycleCommand(string cliCommand, string toolName, string successMessage, int? basePort = null)
     {
-        McpDebugLog.Log($"TOOL INVOKED: {toolName} (no parameters)");
+        McpDebugLog.Log($"TOOL INVOKED: {toolName} (basePort={(basePort.HasValue ? basePort.Value.ToString() : "default")})");
         var stopwatch = Stopwatch.StartNew();
 
         try
         {
             var developerCliPath = Path.Combine(Configuration.SourceCodeFolder, "developer-cli");
-            var args = new List<string> { "run", "--project", developerCliPath, cliCommand };
+            var args = new List<string> { "run", "--project", developerCliPath, "--", cliCommand };
+            if (basePort.HasValue) args.Add(basePort.Value.ToString());
 
             var processStartInfo = new ProcessStartInfo
             {

--- a/developer-cli/Commands/McpCommand.cs
+++ b/developer-cli/Commands/McpCommand.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using DeveloperCli.Installation;
 using Microsoft.Extensions.DependencyInjection;
@@ -506,17 +507,17 @@ public static partial class DeveloperCliMcpTools
     }
 
     [McpServerTool]
-    [Description("Start .NET Aspire AppHost at https://app.dev.localhost:9000. Fails if already running -- use Restart to replace a running instance, or Stop to stop it.")]
+    [Description("Start .NET Aspire AppHost on the configured base port from .workspace/port.txt. Call get_ports to discover the actual URL. Fails if already running -- use Restart to replace a running instance, or Stop to stop it.")]
     public static Task<string> Run()
     {
-        return ExecuteAspireLifecycleCommand("run", "Run", "Aspire started successfully in detached mode at https://app.dev.localhost:9000");
+        return ExecuteAspireLifecycleCommand("run", "Run", $"Aspire started successfully in detached mode at https://app.dev.localhost:{RunCommand.Ports.AppGateway}");
     }
 
     [McpServerTool]
     [Description("Stop any running Aspire AppHost and start a fresh instance. Use after backend changes or when hot reload breaks.")]
     public static Task<string> Restart()
     {
-        return ExecuteAspireLifecycleCommand("restart", "Restart", "Aspire restarted successfully in detached mode at https://app.dev.localhost:9000");
+        return ExecuteAspireLifecycleCommand("restart", "Restart", $"Aspire restarted successfully in detached mode at https://app.dev.localhost:{RunCommand.Ports.AppGateway}");
     }
 
     [McpServerTool]
@@ -524,6 +525,36 @@ public static partial class DeveloperCliMcpTools
     public static Task<string> Stop()
     {
         return ExecuteAspireLifecycleCommand("stop", "Stop", "Aspire stopped successfully");
+    }
+
+    [McpServerTool]
+    [Description("Get the local development port allocation as JSON. Use this to discover the actual ports for any local URLs (AppGateway, Aspire dashboard, individual APIs, static dev servers, etc.).")]
+    public static string GetPorts()
+    {
+        var ports = RunCommand.Ports;
+        return JsonSerializer.Serialize(new
+            {
+                basePort = ports.BasePort,
+                appGateway = ports.AppGateway,
+                aspire = ports.Aspire,
+                postgres = ports.Postgres,
+                blob = ports.Blob,
+                mailpitSmtp = ports.MailpitSmtp,
+                mailpitHttp = ports.MailpitHttp,
+                mcp = ports.Mcp,
+                otelEndpoint = ports.OtelEndpoint,
+                resourceService = ports.ResourceService,
+                mainApi = ports.MainApi,
+                mainStatic = ports.MainStatic,
+                mainWorkers = ports.MainWorkers,
+                accountApi = ports.AccountApi,
+                accountStatic = ports.AccountStatic,
+                accountWorkers = ports.AccountWorkers,
+                backOfficeApi = ports.BackOfficeApi,
+                backOfficeStatic = ports.BackOfficeStatic,
+                backOfficeWorkers = ports.BackOfficeWorkers
+            }, new JsonSerializerOptions { WriteIndented = true }
+        );
     }
 
     private static async Task<string> ExecuteAspireLifecycleCommand(string cliCommand, string toolName, string successMessage)

--- a/developer-cli/Commands/McpCommand.cs
+++ b/developer-cli/Commands/McpCommand.cs
@@ -513,7 +513,7 @@ public static partial class DeveloperCliMcpTools
         int? basePort = null)
     {
         var gatewayPort = basePort ?? RunCommand.Ports.AppGateway;
-        return ExecuteAspireLifecycleCommand("run", "Run", $"Aspire started successfully in detached mode at https://app.dev.localhost:{gatewayPort}", basePort);
+        return ExecuteAspireLifecycleCommand("run", "Run", $"Aspire is starting on https://app.dev.localhost:{gatewayPort}", basePort);
     }
 
     [McpServerTool]
@@ -523,7 +523,7 @@ public static partial class DeveloperCliMcpTools
         int? basePort = null)
     {
         var gatewayPort = basePort ?? RunCommand.Ports.AppGateway;
-        return ExecuteAspireLifecycleCommand("restart", "Restart", $"Aspire restarted successfully in detached mode at https://app.dev.localhost:{gatewayPort}", basePort);
+        return ExecuteAspireLifecycleCommand("restart", "Restart", $"Aspire is restarting on https://app.dev.localhost:{gatewayPort}", basePort);
     }
 
     [McpServerTool]

--- a/developer-cli/Commands/RestartCommand.cs
+++ b/developer-cli/Commands/RestartCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using DeveloperCli.Installation;
+using SharedKernel.Configuration;
 
 namespace DeveloperCli.Commands;
 
@@ -33,10 +34,10 @@ public class RestartCommand : Command
     {
         Prerequisite.Ensure(Prerequisite.Dotnet, Prerequisite.Node, Prerequisite.Docker);
 
-        // Stop the running stack on the OLD port before writing the new one; otherwise the stop
-        // logic would look for processes on the new port and miss the still-running old stack.
-        if (RunCommand.IsAspireRunning())
+        // Skip stop in a fresh worktree (no port.txt) -- nothing to stop, and the check would otherwise false-positive on another worktree's stack.
+        if (PortAllocation.PortFileExists(Configuration.SourceCodeFolder) && RunCommand.IsAspireRunning())
         {
+            // Stop on the OLD port before writing the new one; otherwise stop would look at the new port and miss the running old stack.
             RunCommand.StopAspire();
         }
 

--- a/developer-cli/Commands/RestartCommand.cs
+++ b/developer-cli/Commands/RestartCommand.cs
@@ -10,15 +10,18 @@ public class RestartCommand : Command
 {
     public RestartCommand() : base("restart", "Stops any running Aspire AppHost and starts a fresh instance")
     {
+        var basePortArgument = new Argument<int?>("basePort") { Description = "Optional base port. If provided, written to .workspace/port.txt before Aspire starts.", DefaultValueFactory = _ => null };
         var watchOption = new Option<bool>("--watch", "-w") { Description = "Enable watch mode for hot reload" };
         var attachOption = new Option<bool>("--attach", "-a") { Description = "Keep the CLI process attached to the Aspire process (detached is the default)" };
         var publicUrlOption = new Option<string?>("--public-url") { Description = "Set the PUBLIC_URL environment variable for the app (e.g., https://example.ngrok-free.app)" };
 
+        Arguments.Add(basePortArgument);
         Options.Add(watchOption);
         Options.Add(attachOption);
         Options.Add(publicUrlOption);
 
         SetAction(parseResult => Execute(
+                parseResult.GetValue(basePortArgument),
                 parseResult.GetValue(watchOption),
                 parseResult.GetValue(attachOption),
                 parseResult.GetValue(publicUrlOption)
@@ -26,14 +29,18 @@ public class RestartCommand : Command
         );
     }
 
-    private static void Execute(bool watch, bool attach, string? publicUrl)
+    private static void Execute(int? basePort, bool watch, bool attach, string? publicUrl)
     {
         Prerequisite.Ensure(Prerequisite.Dotnet, Prerequisite.Node, Prerequisite.Docker);
 
+        // Stop the running stack on the OLD port before writing the new one; otherwise the stop
+        // logic would look for processes on the new port and miss the still-running old stack.
         if (RunCommand.IsAspireRunning())
         {
             RunCommand.StopAspire();
         }
+
+        RunCommand.WriteBasePortIfProvided(basePort);
 
         RunCommand.CheckForPortConflicts();
 

--- a/developer-cli/Commands/RunCommand.cs
+++ b/developer-cli/Commands/RunCommand.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using DeveloperCli.Installation;
 using DeveloperCli.Utilities;
+using SharedKernel.Configuration;
 using Spectre.Console;
 
 namespace DeveloperCli.Commands;
@@ -10,9 +11,15 @@ namespace DeveloperCli.Commands;
 /// </summary>
 public class RunCommand : Command
 {
-    internal const int AspirePort = 9001;
-    internal const int DashboardPort = 9097;
-    internal const int ResourceServicePort = 9098;
+    // The CLI binary is published outside the repo, so PortAllocation.Load (which walks up from
+    // AppContext.BaseDirectory) cannot find the repo. Use the CLI's known SourceCodeFolder instead.
+    private static readonly Lazy<PortAllocation> LazyPorts = new(() => PortAllocation.LoadFrom(Configuration.SourceCodeFolder));
+
+    internal static PortAllocation Ports => LazyPorts.Value;
+
+    internal static int AspirePort => Ports.Aspire;
+    internal static int DashboardPort => Ports.OtelEndpoint;
+    internal static int ResourceServicePort => Ports.ResourceService;
 
     public RunCommand() : base("run", "Runs Aspire AppHost (use --watch for hot reload)")
     {
@@ -154,7 +161,8 @@ public class RunCommand : Command
 
         if (Configuration.IsWindows)
         {
-            // Kill all dotnet and rsbuild-node processes on ports 9000-9999
+            // Kill dotnet and rsbuild-node processes listening on any port in the explicit allocation.
+            var allPorts = Ports.AllPorts;
             var netstatOutput = ProcessHelper.StartProcess("""cmd /c "netstat -ano | findstr LISTENING" """, redirectOutput: true, exitOnError: false);
             if (!string.IsNullOrWhiteSpace(netstatOutput))
             {
@@ -169,7 +177,7 @@ public class RunCommand : Command
                     var portIndex = address.LastIndexOf(':');
                     if (portIndex == -1) continue;
 
-                    if (!int.TryParse(address[(portIndex + 1)..], out var port) || port < 9000 || port > 9999) continue;
+                    if (!int.TryParse(address[(portIndex + 1)..], out var port) || !allPorts.Contains(port)) continue;
 
                     var pid = parts[^1];
                     if (!processedPids.Add(pid)) continue;
@@ -259,17 +267,15 @@ public class RunCommand : Command
             ? $"dotnet watch --non-interactive --project {appHostProjectPath}"
             : $"dotnet run --project {appHostProjectPath}";
 
+        // AppHost reads .workspace/port.txt itself and overrides the Aspire dashboard env vars
+        // before CreateBuilder. PUBLIC_URL is the only env var the CLI needs to forward.
+        var envVars = publicUrl is not null
+            ? new[] { ("PUBLIC_URL", publicUrl) }
+            : Array.Empty<(string Name, string Value)>();
+
         if (attach)
         {
-            if (publicUrl is not null)
-            {
-                ProcessHelper.StartProcess(command, Configuration.ApplicationFolder, waitForExit: true, environmentVariables: ("PUBLIC_URL", publicUrl));
-            }
-            else
-            {
-                ProcessHelper.StartProcess(command, Configuration.ApplicationFolder, waitForExit: true);
-            }
-
+            ProcessHelper.StartProcess(command, Configuration.ApplicationFolder, waitForExit: true, environmentVariables: envVars);
             return;
         }
 
@@ -283,14 +289,7 @@ public class RunCommand : Command
                 ? $"sh -c \"script -q -t 0 '{logPath}' {command} > /dev/null 2>&1 &\""
                 : $"sh -c \"script -q -f -c '{command}' '{logPath}' > /dev/null 2>&1 &\"";
 
-        if (publicUrl is not null)
-        {
-            ProcessHelper.StartProcess(detachedCommand, Configuration.ApplicationFolder, waitForExit: false, environmentVariables: ("PUBLIC_URL", publicUrl));
-        }
-        else
-        {
-            ProcessHelper.StartProcess(detachedCommand, Configuration.ApplicationFolder, waitForExit: false);
-        }
+        ProcessHelper.StartProcess(detachedCommand, Configuration.ApplicationFolder, waitForExit: false, environmentVariables: envVars);
 
         TailLogUntilReady(logPath);
     }
@@ -375,7 +374,7 @@ public class RunCommand : Command
         AnsiConsole.MarkupLine("[blue]Starting ngrok tunnel...[/]");
 
         // Start ngrok in detached mode
-        var ngrokCommand = $"ngrok http --url={subdomain}.ngrok-free.app https://app.dev.localhost:9000";
+        var ngrokCommand = $"ngrok http --url={subdomain}.ngrok-free.app https://app.dev.localhost:{Ports.AppGateway}";
 
         // Use shell to handle backgrounding properly on macOS/Linux
         ProcessHelper.StartProcess(

--- a/developer-cli/Commands/RunCommand.cs
+++ b/developer-cli/Commands/RunCommand.cs
@@ -11,27 +11,20 @@ namespace DeveloperCli.Commands;
 /// </summary>
 public class RunCommand : Command
 {
-    // The CLI binary is published outside the repo, so PortAllocation.Load (which walks up from
-    // AppContext.BaseDirectory) cannot find the repo. Use the CLI's known SourceCodeFolder instead.
-    private static readonly Lazy<PortAllocation> LazyPorts = new(() => PortAllocation.LoadFrom(Configuration.SourceCodeFolder));
-
-    internal static PortAllocation Ports => LazyPorts.Value;
-
-    internal static int AspirePort => Ports.Aspire;
-    internal static int DashboardPort => Ports.OtelEndpoint;
-    internal static int ResourceServicePort => Ports.ResourceService;
-
     public RunCommand() : base("run", "Runs Aspire AppHost (use --watch for hot reload)")
     {
+        var basePortArgument = new Argument<int?>("basePort") { Description = "Optional base port. If provided, written to .workspace/port.txt before Aspire starts.", DefaultValueFactory = _ => null };
         var watchOption = new Option<bool>("--watch", "-w") { Description = "Enable watch mode for hot reload" };
         var attachOption = new Option<bool>("--attach", "-a") { Description = "Keep the CLI process attached to the Aspire process (detached is the default)" };
         var publicUrlOption = new Option<string?>("--public-url") { Description = "Set the PUBLIC_URL environment variable for the app (e.g., https://example.ngrok-free.app)" };
 
+        Arguments.Add(basePortArgument);
         Options.Add(watchOption);
         Options.Add(attachOption);
         Options.Add(publicUrlOption);
 
         SetAction(parseResult => Execute(
+                parseResult.GetValue(basePortArgument),
                 parseResult.GetValue(watchOption),
                 parseResult.GetValue(attachOption),
                 parseResult.GetValue(publicUrlOption)
@@ -39,19 +32,49 @@ public class RunCommand : Command
         );
     }
 
-    private static void Execute(bool watch, bool attach, string? publicUrl)
+    // The CLI binary is published outside the repo, so PortAllocation.Load (which walks up from
+    // AppContext.BaseDirectory) cannot find the repo. Use the CLI's known SourceCodeFolder instead.
+    // Re-read on every access so a run/restart invocation with a positional base port picks up the
+    // freshly written .workspace/port.txt without any cached PortAllocation lingering from earlier
+    // in the call.
+    internal static PortAllocation Ports => PortAllocation.LoadFrom(Configuration.SourceCodeFolder);
+
+    internal static int AspirePort => Ports.Aspire;
+
+    internal static int DashboardPort => Ports.OtelEndpoint;
+
+    internal static int ResourceServicePort => Ports.ResourceService;
+
+    private static void Execute(int? basePort, bool watch, bool attach, string? publicUrl)
     {
         Prerequisite.Ensure(Prerequisite.Dotnet, Prerequisite.Node, Prerequisite.Docker);
 
+        // Aspire is detected via the *currently configured* port. If a caller asks to start on a
+        // new port while Aspire still runs on the old one, refuse early with a clear remediation;
+        // updating port.txt now would orphan the running stack and break IsAspireRunning() below.
         if (IsAspireRunning())
         {
-            AnsiConsole.MarkupLine($"[yellow]Aspire AppHost is already running on port {AspirePort}. Run 'pp stop' to stop it or 'pp restart' to start a fresh instance.[/]");
+            var alias = Configuration.AliasName;
+            var message = basePort is null
+                ? $"Aspire AppHost is already running on port {AspirePort}. Run '{alias} stop' to stop it or '{alias} restart' to start a fresh instance."
+                : $"Aspire AppHost is already running on port {AspirePort}. Run '{alias} stop' first or use '{alias} restart {basePort}' to switch.";
+            AnsiConsole.MarkupLine($"[yellow]{message}[/]");
             Environment.Exit(1);
         }
+
+        WriteBasePortIfProvided(basePort);
 
         CheckForPortConflicts();
 
         StartAspireAppHost(watch, attach, publicUrl);
+    }
+
+    internal static void WriteBasePortIfProvided(int? basePort)
+    {
+        if (basePort is null) return;
+
+        PortAllocation.WriteBasePort(Configuration.SourceCodeFolder, basePort.Value);
+        AnsiConsole.MarkupLine($"[blue]Set base port to {basePort.Value}.[/]");
     }
 
     internal static bool IsAspireRunning()

--- a/developer-cli/Commands/RunCommand.cs
+++ b/developer-cli/Commands/RunCommand.cs
@@ -49,10 +49,9 @@ public class RunCommand : Command
     {
         Prerequisite.Ensure(Prerequisite.Dotnet, Prerequisite.Node, Prerequisite.Docker);
 
-        // Aspire is detected via the *currently configured* port. If a caller asks to start on a
-        // new port while Aspire still runs on the old one, refuse early with a clear remediation;
-        // updating port.txt now would orphan the running stack and break IsAspireRunning() below.
-        if (IsAspireRunning())
+        // Refuse if Aspire is already on the currently configured port -- updating port.txt now would orphan the running stack.
+        // Skipped in a fresh worktree (no port.txt) where the check would false-positive on another worktree's stack.
+        if (PortAllocation.PortFileExists(Configuration.SourceCodeFolder) && IsAspireRunning())
         {
             var alias = Configuration.AliasName;
             var message = basePort is null

--- a/developer-cli/Commands/UpdatePackagesCommand.cs
+++ b/developer-cli/Commands/UpdatePackagesCommand.cs
@@ -94,6 +94,7 @@ public sealed class UpdatePackagesCommand : Command
             }
 
             UpdateAspireSdkVersion(dryRun);
+            Prerequisite.WarnIfAspireCliDoesNotMatchSdk();
             await UpdateDotnetToolsAsync(dryRun);
         }
 

--- a/developer-cli/DeveloperCli.csproj
+++ b/developer-cli/DeveloperCli.csproj
@@ -31,4 +31,11 @@
         <None Remove="DeveloperCli.slnx.DotSettings" />
         <None Remove="Directory.Build.props" />
     </ItemGroup>
+    <ItemGroup>
+        <!-- Linked source from shared-kernel: developer-cli is a single-file CLI that intentionally
+             stays isolated from shared-kernel's heavy dependency closure (MediatR, EFCore, NSwag,
+             OpenTelemetry, multiple Azure SDKs). PortAllocation is the shared definition; AppGateway
+             and AppHost get it natively, developer-cli compiles the same file. -->
+        <Compile Include="..\application\shared-kernel\SharedKernel\Configuration\PortAllocation.cs" Link="Utilities\PortAllocation.cs"/>
+    </ItemGroup>
 </Project>

--- a/developer-cli/Installation/Prerequisite.cs
+++ b/developer-cli/Installation/Prerequisite.cs
@@ -46,6 +46,33 @@ public abstract record Prerequisite
         AnsiConsole.WriteLine();
     }
 
+    // Warns if the Aspire CLI is missing or its version does not match Aspire.AppHost.Sdk in
+    // AppHost.csproj. Soft warning -- the CLI is only required for the Aspire MCP integration,
+    // not for running the AppHost.
+    public static void WarnIfAspireCliDoesNotMatchSdk()
+    {
+        var appHostCsproj = Path.Combine(Configuration.ApplicationFolder, "AppHost", "AppHost.csproj");
+        if (!File.Exists(appHostCsproj)) return;
+
+        var sdkMatch = Regex.Match(File.ReadAllText(appHostCsproj), @"<Project\s+Sdk=""Aspire\.AppHost\.Sdk/(\d+\.\d+\.\d+)""");
+        if (!sdkMatch.Success) return;
+        var requiredVersion = sdkMatch.Groups[1].Value;
+
+        var versionOutput = ProcessHelper.StartProcess("aspire --version", Configuration.ApplicationFolder, true, exitOnError: false, throwOnError: false);
+        var installedMatch = Regex.Match(versionOutput, @"\d+\.\d+\.\d+");
+        var installedVersion = installedMatch.Success ? installedMatch.Value : null;
+
+        if (installedVersion == requiredVersion) return;
+
+        var installCommand = Configuration.IsWindows
+            ? "irm https://aspire.dev/install.ps1 | iex"
+            : "curl -sSL https://aspire.dev/install.sh | bash";
+        var current = installedVersion is null ? "not installed" : $"installed {installedVersion}";
+        AnsiConsole.MarkupLine($"[yellow]Recommended: Aspire CLI {requiredVersion} (matches AppHost.csproj), {current}. Install:[/]");
+        AnsiConsole.MarkupLine($"[yellow]  {installCommand}[/]");
+        AnsiConsole.WriteLine();
+    }
+
     protected abstract bool CheckExists();
 }
 

--- a/developer-cli/Program.cs
+++ b/developer-cli/Program.cs
@@ -34,6 +34,7 @@ if (!isMcpCommand && !args.Contains("-q") && !args.Contains("--quiet"))
         var figletText = new FigletText(solutionName);
         AnsiConsole.Write(figletText);
         Prerequisite.Recommend(Prerequisite.TypeScriptLanguageServer, Prerequisite.CSharpLanguageServer);
+        Prerequisite.WarnIfAspireCliDoesNotMatchSdk();
     }
 
     AnsiConsole.WriteLine($"Source code folder: {Configuration.SourceCodeFolder} \n");


### PR DESCRIPTION
### Summary & Motivation

Centralize the local-development port allocation behind a single source of truth (`.workspace/port.txt`) and propagate the base port through every layer that previously hardcoded `9000` and friends. Two motivations: enable running multiple Aspire stacks simultaneously from separate git worktrees (each stack on its own non-overlapping port range, with isolated Docker volumes), and remove the scattered hardcoded ports that drifted out of sync across rsbuild configs, test fixtures, the gateway, and the AppHost.

- Add `PortAllocation` in the shared kernel as the canonical source for the base port. Self-bootstraps `.workspace/port.txt` to `9000` on first read and computes derived offsets for Aspire dashboard, Postgres, Azurite, gateway, per-SCS API/static/workers, OTel, and MCP
- Accept an optional positional `basePort` argument on `pp run` / `pp restart` and the corresponding MCP tools; written atomically to `.workspace/port.txt` before any code path lazily loads `PortAllocation`
- Suffix Docker volume names with the base port for non-default stacks (e.g., `platform-platform-11000-postgres-data`) so parallel Azurite and Postgres containers do not corrupt each other's state
- Allow `pp run` and `pp restart` to operate in a fresh worktree (no `port.txt`) without false-positive collision warnings against another worktree's running stack
- Switch the Aspire MCP server from HTTP transport (hardcoded `localhost:9007`) to stdio transport via the Aspire CLI so the integration works on any base port. The README prerequisites now include Aspire CLI install steps for Windows, macOS, and Linux
- Warn when the locally installed Aspire CLI version does not match the `Aspire.AppHost.Sdk` pinned in `AppHost.csproj`
- Inject the blob storage connection string from Aspire (renaming the endpoint to `blob-storage`) so SCS clients honor the dynamic Azurite port instead of falling back to the SDK default `127.0.0.1:10000`
- Soften MCP `run`/`restart` success messages to "Aspire is starting on ..." since the underlying CLI is fire-and-forget; callers should verify with `get_ports` or `list_apphosts`
- Add a `get_ports` MCP tool returning the full port allocation as JSON, and ignore `.claude/worktrees` for local worktree management

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary