### PR TITLE
Improve Application Insights telemetry and wire AppGateway into the cluster's workspace

### DIFF
--- a/.github/workflows/account.yml
+++ b/.github/workflows/account.yml
@@ -107,11 +107,11 @@ jobs:
         run: |
           if [[ "${{ vars.SONAR_PROJECT_KEY }}" == "" ]] || [[ "${{ vars.SONAR_ORGANIZATION }}" == "" ]] || [[ "${{ secrets.SONAR_TOKEN }}" == "" ]]; then
             echo "SonarCloud is not enabled. Skipping SonarCloud analysis."
-            dotnet build account/Account.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }} /p:SourceRevisionId=${{ steps.generate_version.outputs.short_sha }} &&
+            dotnet build account/Account.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.event.pull_request.head.sha || github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }} &&
             dotnet test account/Account.slnf --no-build
           else
             dotnet sonarscanner begin /k:"${{ vars.SONAR_PROJECT_KEY }}" /o:"${{ vars.SONAR_ORGANIZATION }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.dotcover.reportsPaths="coverage/dotCover.html" &&
-            dotnet build account/Account.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }} /p:SourceRevisionId=${{ steps.generate_version.outputs.short_sha }} &&
+            dotnet build account/Account.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.event.pull_request.head.sha || github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }} &&
             dotnet dotcover test account/Account.slnf --no-build --dcOutput=coverage/dotCover.html --dcReportType=HTML --dcFilters="+:Account*;+:SharedKernel;-:*.Tests;-:type=*.AppHost.*" &&
             dotnet sonarscanner end
           fi
@@ -135,7 +135,7 @@ jobs:
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/account
         run: |
-          dotnet publish ./Api/Account.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
+          dotnet publish ./Api/Account.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.event.pull_request.head.sha || github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
       - name: Save API Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v7
@@ -147,7 +147,7 @@ jobs:
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/account
         run: |
-          dotnet publish ./Workers/Account.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
+          dotnet publish ./Workers/Account.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.event.pull_request.head.sha || github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
       - name: Save Workers Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/account.yml
+++ b/.github/workflows/account.yml
@@ -48,9 +48,8 @@ jobs:
       - name: Generate Version
         id: generate_version
         run: |
-          # Strip leading 0s of Hours and Minutes after midnight
-          MINUTE=$(printf "%s" $(date +"%-H%M") | sed 's/^0*//')
-          VERSION=$(date +"%Y.%-m.%-d.")$MINUTE
+          # Zero-padded so versions sort lexicographically and clock-time is unambiguous (e.g. 0904, not 94)
+          VERSION=$(date +"%Y.%m.%d.%H%M")
           echo "Generated version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
@@ -108,11 +107,11 @@ jobs:
         run: |
           if [[ "${{ vars.SONAR_PROJECT_KEY }}" == "" ]] || [[ "${{ vars.SONAR_ORGANIZATION }}" == "" ]] || [[ "${{ secrets.SONAR_TOKEN }}" == "" ]]; then
             echo "SonarCloud is not enabled. Skipping SonarCloud analysis."
-            dotnet build account/Account.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} &&
+            dotnet build account/Account.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }} /p:SourceRevisionId=${{ steps.generate_version.outputs.short_sha }} &&
             dotnet test account/Account.slnf --no-build
           else
             dotnet sonarscanner begin /k:"${{ vars.SONAR_PROJECT_KEY }}" /o:"${{ vars.SONAR_ORGANIZATION }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.dotcover.reportsPaths="coverage/dotCover.html" &&
-            dotnet build account/Account.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} &&
+            dotnet build account/Account.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }} /p:SourceRevisionId=${{ steps.generate_version.outputs.short_sha }} &&
             dotnet dotcover test account/Account.slnf --no-build --dcOutput=coverage/dotCover.html --dcReportType=HTML --dcFilters="+:Account*;+:SharedKernel;-:*.Tests;-:type=*.AppHost.*" &&
             dotnet sonarscanner end
           fi
@@ -136,8 +135,7 @@ jobs:
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/account
         run: |
-          dotnet publish ./Api/Account.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }}
-
+          dotnet publish ./Api/Account.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
       - name: Save API Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v7
@@ -149,8 +147,7 @@ jobs:
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/account
         run: |
-          dotnet publish ./Workers/Account.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }}
-
+          dotnet publish ./Workers/Account.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
       - name: Save Workers Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -41,9 +41,8 @@ jobs:
       - name: Generate Version
         id: generate_version
         run: |
-          # Strip leading 0s of Hours and Minutes after midnight
-          MINUTE=$(printf "%s" $(date +"%-H%M") | sed 's/^0*//')
-          VERSION=$(date +"%Y.%-m.%-d.")$MINUTE
+          # Zero-padded so versions sort lexicographically and clock-time is unambiguous (e.g. 0904, not 94)
+          VERSION=$(date +"%Y.%m.%d.%H%M")
           echo "Generated version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
@@ -82,14 +81,12 @@ jobs:
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application
         run: |
-          dotnet build PlatformPlatform.slnx --no-restore /p:Version=${{ steps.generate_version.outputs.version }}
-
+          dotnet build PlatformPlatform.slnx --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
       - name: Publish Build
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application
         run: |
-          dotnet publish ./AppGateway/AppGateway.csproj --no-restore --configuration Release --output ./AppGateway/publish /p:Version=${{ steps.generate_version.outputs.version }}
-
+          dotnet publish ./AppGateway/AppGateway.csproj --no-restore --configuration Release --output ./AppGateway/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
       - name: Save Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/app-gateway.yml
+++ b/.github/workflows/app-gateway.yml
@@ -81,12 +81,12 @@ jobs:
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application
         run: |
-          dotnet build PlatformPlatform.slnx --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
+          dotnet build PlatformPlatform.slnx --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.event.pull_request.head.sha || github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
       - name: Publish Build
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application
         run: |
-          dotnet publish ./AppGateway/AppGateway.csproj --no-restore --configuration Release --output ./AppGateway/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
+          dotnet publish ./AppGateway/AppGateway.csproj --no-restore --configuration Release --output ./AppGateway/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.event.pull_request.head.sha || github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
       - name: Save Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,11 +107,11 @@ jobs:
         run: |
           if [[ "${{ vars.SONAR_PROJECT_KEY }}" == "" ]] || [[ "${{ vars.SONAR_ORGANIZATION }}" == "" ]] || [[ "${{ secrets.SONAR_TOKEN }}" == "" ]]; then
             echo "SonarCloud is not enabled. Skipping SonarCloud analysis."
-            dotnet build main/Main.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }} /p:SourceRevisionId=${{ steps.generate_version.outputs.short_sha }} &&
+            dotnet build main/Main.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.event.pull_request.head.sha || github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }} &&
             dotnet test main/Main.slnf --no-build
           else
             dotnet sonarscanner begin /k:"${{ vars.SONAR_PROJECT_KEY }}" /o:"${{ vars.SONAR_ORGANIZATION }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.dotcover.reportsPaths="coverage/dotCover.html" &&
-            dotnet build main/Main.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }} /p:SourceRevisionId=${{ steps.generate_version.outputs.short_sha }} &&
+            dotnet build main/Main.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.event.pull_request.head.sha || github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }} &&
             dotnet dotcover test main/Main.slnf --no-build --dcOutput=coverage/dotCover.html --dcReportType=HTML --dcFilters="+:Main*;+:SharedKernel;-:*.Tests;-:type=*.AppHost.*" &&
             dotnet sonarscanner end
           fi
@@ -130,7 +130,7 @@ jobs:
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/main
         run: |
-          dotnet publish ./Api/Main.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
+          dotnet publish ./Api/Main.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.event.pull_request.head.sha || github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
       - name: Save API Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v7
@@ -142,7 +142,7 @@ jobs:
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/main
         run: |
-          dotnet publish ./Workers/Main.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
+          dotnet publish ./Workers/Main.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.event.pull_request.head.sha || github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
       - name: Save Workers Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,9 +48,8 @@ jobs:
       - name: Generate Version
         id: generate_version
         run: |
-          # Strip leading 0s of Hours and Minutes after midnight
-          MINUTE=$(printf "%s" $(date +"%-H%M") | sed 's/^0*//')
-          VERSION=$(date +"%Y.%-m.%-d.")$MINUTE
+          # Zero-padded so versions sort lexicographically and clock-time is unambiguous (e.g. 0904, not 94)
+          VERSION=$(date +"%Y.%m.%d.%H%M")
           echo "Generated version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
@@ -108,11 +107,11 @@ jobs:
         run: |
           if [[ "${{ vars.SONAR_PROJECT_KEY }}" == "" ]] || [[ "${{ vars.SONAR_ORGANIZATION }}" == "" ]] || [[ "${{ secrets.SONAR_TOKEN }}" == "" ]]; then
             echo "SonarCloud is not enabled. Skipping SonarCloud analysis."
-            dotnet build main/Main.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} &&
+            dotnet build main/Main.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }} /p:SourceRevisionId=${{ steps.generate_version.outputs.short_sha }} &&
             dotnet test main/Main.slnf --no-build
           else
             dotnet sonarscanner begin /k:"${{ vars.SONAR_PROJECT_KEY }}" /o:"${{ vars.SONAR_ORGANIZATION }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.dotcover.reportsPaths="coverage/dotCover.html" &&
-            dotnet build main/Main.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} &&
+            dotnet build main/Main.slnf --no-restore /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }} /p:SourceRevisionId=${{ steps.generate_version.outputs.short_sha }} &&
             dotnet dotcover test main/Main.slnf --no-build --dcOutput=coverage/dotCover.html --dcReportType=HTML --dcFilters="+:Main*;+:SharedKernel;-:*.Tests;-:type=*.AppHost.*" &&
             dotnet sonarscanner end
           fi
@@ -131,8 +130,7 @@ jobs:
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/main
         run: |
-          dotnet publish ./Api/Main.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }}
-
+          dotnet publish ./Api/Main.Api.csproj --no-restore --configuration Release --output ./Api/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
       - name: Save API Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v7
@@ -144,8 +142,7 @@ jobs:
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         working-directory: application/main
         run: |
-          dotnet publish ./Workers/Main.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }}
-
+          dotnet publish ./Workers/Main.Workers.csproj --no-restore --configuration Release --output ./Workers/publish /p:Version=${{ steps.generate_version.outputs.version }} /p:DeploymentCommitHash=${{ github.sha }} /p:DeploymentGithubActionId=${{ github.run_id }}
       - name: Save Workers Artifacts
         if: ${{ steps.determine_deployment.outputs.deploy_staging == 'true' }}
         uses: actions/upload-artifact@v7

--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -12,7 +12,7 @@ using SharedKernel.Configuration;
 var builder = WebApplication.CreateBuilder(args);
 
 // Wire OpenTelemetry, Azure Monitor exporter, and Application Insights so AppGateway requests,
-// dependencies, traces, and logs surface in the cluster's App Insights workspace alongside the APIs.
+// dependencies, traces, and logs surface in the cluster's Application Insights workspace alongside the APIs.
 builder.AddSharedTelemetry();
 
 builder.Services

--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -11,6 +11,10 @@ using SharedKernel.Configuration;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Wire OpenTelemetry, Azure Monitor exporter, and Application Insights so AppGateway requests,
+// dependencies, traces, and logs surface in the cluster's App Insights workspace alongside the APIs.
+builder.AddSharedTelemetry();
+
 builder.Services
     .AddOptions<HostnamesOptions>()
     .Bind(builder.Configuration.GetSection(HostnamesOptions.SectionName))

--- a/application/Directory.Build.props
+++ b/application/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+
+    <!-- Bake build provenance into every assembly so deployed binaries carry their own metadata,
+         readable at runtime regardless of how or where they are run. -->
+    <ItemGroup>
+        <AssemblyMetadata Include="DeploymentCommitHash" Value="$(DeploymentCommitHash)" Condition="'$(DeploymentCommitHash)' != ''" />
+        <AssemblyMetadata Include="DeploymentGithubActionId" Value="$(DeploymentGithubActionId)" Condition="'$(DeploymentGithubActionId)' != ''" />
+    </ItemGroup>
+
+</Project>

--- a/application/account/Directory.Build.props
+++ b/application/account/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
 
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <PropertyGroup>
         <UseArtifactsOutput>false</UseArtifactsOutput>
     </PropertyGroup>

--- a/application/main/Directory.Build.props
+++ b/application/main/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
 
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <PropertyGroup>
         <UseArtifactsOutput>false</UseArtifactsOutput>
     </PropertyGroup>

--- a/application/shared-kernel/Directory.Build.props
+++ b/application/shared-kernel/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
 
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <PropertyGroup>
         <UseArtifactsOutput>true</UseArtifactsOutput>
     </PropertyGroup>

--- a/application/shared-kernel/SharedKernel/Configuration/ApiDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/ApiDependencyConfiguration.cs
@@ -117,8 +117,12 @@ public static class ApiDependencyConfiguration
 
         private IServiceCollection AddApiExecutionContext()
         {
-            // Add the execution context service that will be used to make current user information available to the application
-            return services.AddScoped<IExecutionContext, HttpExecutionContext>();
+            // Add the execution context service that will be used to make current user information available to the application.
+            // OpenTelemetryEnricher depends on IExecutionContext, so it lives here -- AppGateway has no per-request execution
+            // context and only emits transport-level traces via AddSharedTelemetry.
+            return services
+                .AddScoped<IExecutionContext, HttpExecutionContext>()
+                .AddScoped<OpenTelemetryEnricher>();
         }
     }
 

--- a/application/shared-kernel/SharedKernel/Configuration/ApiDependencyConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/ApiDependencyConfiguration.cs
@@ -291,7 +291,7 @@ public static class ApiDependencyConfiguration
             // This is required when running behind a reverse proxy like YARP or Azure Container Apps
             return services.Configure<ForwardedHeadersOptions>(options =>
                 {
-                    // X-Forwarded-For surfaces real upstream client IPs in App Insights / logs.
+                    // X-Forwarded-For surfaces real upstream client IPs in Application Insights / logs.
                     // X-Forwarded-Proto sets Request.Scheme so generated absolute URLs use https.
                     // X-Forwarded-Host is intentionally NOT enabled: each Azure container app
                     // registers only the SPA it serves (see Account.Api Program.cs), so endpoint

--- a/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
@@ -263,7 +263,15 @@ public static class SharedInfrastructureConfiguration
                         tracing
                             .AddProcessor(new DeploymentTagsProcessor())
                             .AddAspNetCoreInstrumentation(options =>
-                                options.EnrichWithHttpRequest = PublicHostTelemetryEnricher.Enrich
+                                {
+                                    options.EnrichWithHttpRequest = PublicHostTelemetryEnricher.Enrich;
+                                    // 4xx is a client problem (validation, auth, missing route); the server handled it.
+                                    // Mark OK so Application Insights doesn't flag it; only 5xx is a real server error.
+                                    options.EnrichWithHttpResponse = (activity, response) =>
+                                    {
+                                        if (response.StatusCode is >= 400 and < 500) activity.SetStatus(ActivityStatusCode.Ok);
+                                    };
+                                }
                             )
                             .AddGrpcClientInstrumentation()
                             .AddHttpClientInstrumentation(options =>

--- a/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
@@ -15,6 +15,7 @@ using Npgsql;
 using OpenTelemetry.Instrumentation.AspNetCore;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using SharedKernel.Integrations.BlobStorage;
 using SharedKernel.Telemetry;
@@ -25,7 +26,36 @@ public static class SharedInfrastructureConfiguration
 {
     public static readonly bool IsRunningInAzure = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID") is not null;
 
+    public static readonly string? ServiceVersion = ResolveServiceVersion();
+
+    // Baked into the assembly at build time via /p:DeploymentCommitHash=<sha>
+    // /p:DeploymentGithubActionId=<run_id> in the deployment workflows. The Directory.Build.props at
+    // /application emits AssemblyMetadata attributes from those properties so each artifact carries
+    // its own provenance -- pulling and running the image anywhere produces the same telemetry stamp.
+    public static readonly string? DeploymentCommitHash = GetAssemblyMetadata("DeploymentCommitHash");
+
+    public static readonly string? DeploymentGithubActionId = GetAssemblyMetadata("DeploymentGithubActionId");
+
     public static DefaultAzureCredential DefaultAzureCredential => GetDefaultAzureCredential();
+
+    private static string? ResolveServiceVersion()
+    {
+        // The .NET SDK auto-appends "+<source revision id>" to AssemblyInformationalVersion when
+        // building inside a git checkout. Strip it so application_Version stays clean (the commit
+        // SHA travels separately as the deployment.commit_hash custom dimension).
+        var informationalVersion = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (informationalVersion is null) return Assembly.GetEntryAssembly()?.GetName().Version?.ToString();
+
+        var plusIndex = informationalVersion.IndexOf('+');
+        return plusIndex < 0 ? informationalVersion : informationalVersion[..plusIndex];
+    }
+
+    private static string? GetAssemblyMetadata(string key)
+    {
+        return Assembly.GetEntryAssembly()?
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == key)?.Value;
+    }
 
     private static DefaultAzureCredential GetDefaultAzureCredential()
     {
@@ -65,6 +95,17 @@ public static class SharedInfrastructureConfiguration
             builder
                 .AddConfigureOpenTelemetry()
                 .AddOpenTelemetryExporters();
+
+            // Register service.version AFTER UseAzureMonitor so it wins the resource merge against
+            // the Azure Container Apps detector, which otherwise sets service.version to the revision
+            // name. The deployment.* tags travel as activity tags via DeploymentTagsProcessor since
+            // Azure Monitor only surfaces a fixed set of resource attributes on AppRequests.
+            if (ServiceVersion is not null)
+            {
+                builder.Services.AddOpenTelemetry().ConfigureResource(resource =>
+                    resource.AddAttributes([new KeyValuePair<string, object>("service.version", ServiceVersion)])
+                );
+            }
 
             builder.Services.AddApplicationInsightsTelemetry();
 
@@ -220,6 +261,7 @@ public static class SharedInfrastructureConfiguration
                         if (builder.Environment.IsDevelopment()) tracing.SetSampler(new AlwaysOnSampler());
 
                         tracing
+                            .AddProcessor(new DeploymentTagsProcessor())
                             .AddAspNetCoreInstrumentation(options =>
                                 options.EnrichWithHttpRequest = PublicHostTelemetryEnricher.Enrich
                             )

--- a/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
@@ -44,17 +44,29 @@ public static class SharedInfrastructureConfiguration
                 .AddAzureKeyVaultConfiguration()
                 .ConfigureDatabaseContext<T>(connectionName)
                 .AddDefaultBlobStorage()
-                .AddConfigureOpenTelemetry()
-                .AddOpenTelemetryExporters();
+                .AddSharedTelemetry();
 
             builder.Services
-                .AddApplicationInsightsTelemetry()
                 .ConfigureHttpClientDefaults(http =>
                     {
                         http.AddStandardResilienceHandler(); // Turn on resilience by default
                         http.AddServiceDiscovery(); // Turn on service discovery by default
                     }
                 );
+
+            return builder;
+        }
+
+        // Wires OpenTelemetry tracing/logging/metrics, the Azure Monitor exporter, and Application
+        // Insights without requiring a DbContext. AppGateway and other database-less hosts should call
+        // this directly; AddSharedInfrastructure<T> calls it as part of the full bundle.
+        public IHostApplicationBuilder AddSharedTelemetry()
+        {
+            builder
+                .AddConfigureOpenTelemetry()
+                .AddOpenTelemetryExporters();
+
+            builder.Services.AddApplicationInsightsTelemetry();
 
             return builder;
         }
@@ -259,7 +271,6 @@ public static class SharedInfrastructureConfiguration
             services
                 .AddApplicationInsightsTelemetry(applicationInsightsServiceOptions)
                 .AddApplicationInsightsTelemetryProcessor<EndpointTelemetryFilter>()
-                .AddScoped<OpenTelemetryEnricher>()
                 .AddSingleton<ITelemetryInitializer, ApplicationInsightsTelemetryInitializer>();
 
             if (!IsRunningInAzure)

--- a/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
@@ -207,7 +207,14 @@ public static class SharedInfrastructureConfiguration
                         // We want to view all traces in development
                         if (builder.Environment.IsDevelopment()) tracing.SetSampler(new AlwaysOnSampler());
 
-                        tracing.AddAspNetCoreInstrumentation().AddGrpcClientInstrumentation().AddHttpClientInstrumentation();
+                        tracing
+                            .AddAspNetCoreInstrumentation(options =>
+                                options.EnrichWithHttpRequest = PublicHostTelemetryEnricher.Enrich
+                            )
+                            .AddGrpcClientInstrumentation()
+                            .AddHttpClientInstrumentation(options =>
+                                options.EnrichWithHttpRequestMessage = PublicHostTelemetryEnricher.EnrichOutbound
+                            );
                     }
                 );
 

--- a/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/SinglePageApp/SinglePageAppConfiguration.cs
@@ -47,7 +47,11 @@ public class SinglePageAppConfiguration
         // single-SPA hosts and EF Core migration generation (where neither env vars nor overrides are set).
         PublicUrl = publicUrlOverride ?? Environment.GetEnvironmentVariable(PublicUrlKey) ?? string.Empty;
         CdnUrl = cdnUrlOverride ?? Environment.GetEnvironmentVariable(CdnUrlKey) ?? string.Empty;
-        var applicationVersion = Assembly.GetEntryAssembly()!.GetName().Version!.ToString();
+        // InformationalVersion preserves the zero-padded format ("2026.05.02.0914") that
+        // System.Version-based parsing would otherwise reduce to "2026.5.2.914".
+        var applicationVersion =
+            Assembly.GetEntryAssembly()!.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? Assembly.GetEntryAssembly()!.GetName().Version!.ToString();
 
         StaticRuntimeEnvironment = new Dictionary<string, string>
         {

--- a/application/shared-kernel/SharedKernel/Telemetry/ApplicationInsightsTelemetryInitializer.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/ApplicationInsightsTelemetryInitializer.cs
@@ -1,4 +1,5 @@
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using SharedKernel.ExecutionContext;
 
@@ -7,6 +8,7 @@ namespace SharedKernel.Telemetry;
 public class ApplicationInsightsTelemetryInitializer : ITelemetryInitializer
 {
     private static readonly AsyncLocal<IExecutionContext> ExecutionContext = new();
+    private static readonly AsyncLocal<string?> PublicUrlOverride = new();
 
     public void Initialize(ITelemetry telemetry)
     {
@@ -15,6 +17,16 @@ public class ApplicationInsightsTelemetryInitializer : ITelemetryInitializer
         if (executionContext is null)
         {
             return;
+        }
+
+        // Override the request URL with the public host when the AI SDK path emits a RequestTelemetry.
+        // OpenTelemetry instrumentation is the primary source of request telemetry (see
+        // PublicHostTelemetryEnricher) -- this branch is belt-and-suspenders for any AI-SDK-only path.
+        var publicUrl = PublicUrlOverride.Value;
+        if (publicUrl is not null && telemetry is RequestTelemetry requestTelemetry &&
+            Uri.TryCreate(publicUrl, UriKind.Absolute, out var absoluteUri))
+        {
+            requestTelemetry.Url = absoluteUri;
         }
 
         telemetry.Context.Location.Ip = executionContext.ClientIpAddress.ToString();
@@ -50,6 +62,11 @@ public class ApplicationInsightsTelemetryInitializer : ITelemetryInitializer
     public static void SetContext(IExecutionContext executionContext)
     {
         ExecutionContext.Value = executionContext;
+    }
+
+    public static void SetPublicUrl(string? publicUrl)
+    {
+        PublicUrlOverride.Value = publicUrl;
     }
 
     private static void AddCustomProperty(ITelemetry telemetry, string name, object? value)

--- a/application/shared-kernel/SharedKernel/Telemetry/ApplicationInsightsTelemetryInitializer.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/ApplicationInsightsTelemetryInitializer.cs
@@ -1,6 +1,7 @@
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
+using SharedKernel.Configuration;
 using SharedKernel.ExecutionContext;
 
 namespace SharedKernel.Telemetry;
@@ -12,6 +13,16 @@ public class ApplicationInsightsTelemetryInitializer : ITelemetryInitializer
 
     public void Initialize(ITelemetry telemetry)
     {
+        // Apply deployment metadata to every telemetry item, including PageViews/Exceptions/Metrics
+        // forwarded from the SPA via /api/track (where IExecutionContext is not always set).
+        if (SharedInfrastructureConfiguration.ServiceVersion is not null)
+        {
+            telemetry.Context.Component.Version = SharedInfrastructureConfiguration.ServiceVersion;
+        }
+
+        AddCustomProperty(telemetry, "deployment.commit_hash", SharedInfrastructureConfiguration.DeploymentCommitHash);
+        AddCustomProperty(telemetry, "deployment.github_action_id", SharedInfrastructureConfiguration.DeploymentGithubActionId);
+
         var executionContext = ExecutionContext.Value;
 
         if (executionContext is null)

--- a/application/shared-kernel/SharedKernel/Telemetry/DeploymentTagsProcessor.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/DeploymentTagsProcessor.cs
@@ -1,0 +1,39 @@
+using OpenTelemetry;
+using SharedKernel.Configuration;
+
+namespace SharedKernel.Telemetry;
+
+// Stamps deployment provenance (commit SHA + GitHub Actions run ID, baked into the assembly via
+// AssemblyMetadata attributes) onto every span on start. Activity tags surface as customDimensions
+// on AppRequests / AppDependencies in App Insights -- arbitrary OpenTelemetry resource attributes
+// are stored in an internal hash table and aren't queryable, so resource attributes don't work for
+// this. The values are read once at startup; this class does no per-request work beyond two SetTag
+// calls.
+public sealed class DeploymentTagsProcessor : BaseProcessor<Activity>
+{
+    private static readonly KeyValuePair<string, object?>[] Tags = BuildTags();
+
+    public override void OnStart(Activity activity)
+    {
+        foreach (var (key, value) in Tags)
+        {
+            activity.SetTag(key, value);
+        }
+    }
+
+    private static KeyValuePair<string, object?>[] BuildTags()
+    {
+        var tags = new List<KeyValuePair<string, object?>>(2);
+        if (SharedInfrastructureConfiguration.DeploymentCommitHash is not null)
+        {
+            tags.Add(new KeyValuePair<string, object?>("deployment.commit_hash", SharedInfrastructureConfiguration.DeploymentCommitHash));
+        }
+
+        if (SharedInfrastructureConfiguration.DeploymentGithubActionId is not null)
+        {
+            tags.Add(new KeyValuePair<string, object?>("deployment.github_action_id", SharedInfrastructureConfiguration.DeploymentGithubActionId));
+        }
+
+        return tags.ToArray();
+    }
+}

--- a/application/shared-kernel/SharedKernel/Telemetry/DeploymentTagsProcessor.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/DeploymentTagsProcessor.cs
@@ -5,7 +5,7 @@ namespace SharedKernel.Telemetry;
 
 // Stamps deployment provenance (commit SHA + GitHub Actions run ID, baked into the assembly via
 // AssemblyMetadata attributes) onto every span on start. Activity tags surface as customDimensions
-// on AppRequests / AppDependencies in App Insights -- arbitrary OpenTelemetry resource attributes
+// on AppRequests / AppDependencies in Application Insights -- arbitrary OpenTelemetry resource attributes
 // are stored in an internal hash table and aren't queryable, so resource attributes don't work for
 // this. The values are read once at startup; this class does no per-request work beyond two SetTag
 // calls.

--- a/application/shared-kernel/SharedKernel/Telemetry/EndpointTelemetryFilter.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/EndpointTelemetryFilter.cs
@@ -13,12 +13,20 @@ public class EndpointTelemetryFilter(ITelemetryProcessor telemetryProcessor)
 {
     public static readonly ImmutableHashSet<string> ExcludedPaths = ImmutableHashSet.Create(
         StringComparer.OrdinalIgnoreCase,
-        "/swagger", "/internal-api/live", "/internal-api/ready", "/api/track"
+        // Internal endpoints
+        "/swagger", "/internal-api/live", "/internal-api/ready", "/api/track",
+        // Common scanner-probe path prefixes -- folders that look like accidentally-deployed sources or developer tooling.
+        // We don't serve any of these, so any request matching is bot traffic.
+        "/config/", "/src/", "/web/", "/env/", "/server/", "/portal/", "/docker/", "/backend/", "/.well-known/", "/.git/", "/sitemap",
+        "/wp-", "/Properties/", "/appsettings.", "/.vercel/", "/.vscode/", "/.idea/", "/secured/", "/tsconfig."
     );
 
     public static readonly ImmutableHashSet<string> ExcludedFileExtensions = ImmutableHashSet.Create(
         StringComparer.OrdinalIgnoreCase,
-        ".js", ".css", ".png", ".jpg", ".ico", ".map", ".svg", ".woff", ".woff2", "webp"
+        // Static assets the SPA serves successfully -- noise on every page load
+        ".js", ".css", ".png", ".jpg", ".ico", ".map", ".svg", ".woff", ".woff2", "webp",
+        // Common scanner-probe file extensions -- secrets, source code, and editor artifacts no legitimate route would have
+        ".env", ".yml", ".yaml", ".properties", ".bak", ".old", ".ini", ".config", ".rb", ".py", ".ts", ".sql", ".sh", ".htaccess", ".php", ".local", ".envrc", ".sample", "~"
     );
 
     public void Process(ITelemetry item)

--- a/application/shared-kernel/SharedKernel/Telemetry/PublicHostTelemetryEnricher.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/PublicHostTelemetryEnricher.cs
@@ -1,0 +1,130 @@
+using Microsoft.AspNetCore.Http;
+using SharedKernel.Configuration;
+
+namespace SharedKernel.Telemetry;
+
+// Overrides the request tags OpenTelemetry's ASP.NET Core instrumentation captures at request start
+// (before middleware runs), so they reflect the original caller rather than the immediate proxy peer:
+//   - server.address / url.* use each service's own Request.Host, trimmed to "<service>.internal" for
+//     internal ACA FQDNs, defaulted to https in Azure, with the redundant default :443/:80 stripped.
+//     AppGateway shows the public hostname; backend services show "<service>.internal", which is the
+//     conventional layered view in distributed tracing.
+//   - client.address comes from X-Forwarded-For so the App Insights geo lookup resolves to the real
+//     browser IP instead of the Azure Container Apps ingress envoy in the cluster's region. The header
+//     is set by the external ingress, which strips client-supplied values, so spoofing is not possible.
+public static class PublicHostTelemetryEnricher
+{
+    public static void Enrich(Activity activity, HttpRequest request)
+    {
+        var parts = ResolvePublicUrlParts(request);
+        if (parts is not null)
+        {
+            var (publicHost, publicScheme, fullUrl) = parts.Value;
+            var (hostName, explicitPort) = ParseHost(publicHost);
+
+            activity.SetTag("server.address", hostName);
+            activity.SetTag("url.scheme", publicScheme);
+            activity.SetTag("url.full", fullUrl);
+            // Older semconv tag still consumed by some Azure Monitor mappings.
+            activity.SetTag("http.url", fullUrl);
+            // null skips server.port so App Insights' URL builder doesn't render the redundant :443/:80.
+            activity.SetTag("server.port", explicitPort);
+        }
+
+        var clientAddress = ResolveClientAddress(request);
+        if (clientAddress is not null)
+        {
+            // Set only the OTel semconv tag. Azure Monitor maps client.address to the dedicated
+            // ClientIp field (anonymized to 0.0.0.0 after geo lookup). Do NOT also set http.client_ip:
+            // Azure Monitor treats it as a custom property, leaks the raw IP into customDimensions, and
+            // bypasses anonymization -- a PII violation.
+            activity.SetTag("client.address", clientAddress);
+        }
+    }
+
+    private static string? ResolveClientAddress(HttpRequest request)
+    {
+        var forwardedFor = request.Headers["X-Forwarded-For"].ToString();
+        if (string.IsNullOrEmpty(forwardedFor)) return null;
+
+        // Leftmost entry is the original client; any entries after it are intermediate proxies.
+        var separatorIndex = forwardedFor.IndexOf(',');
+        var leftmost = (separatorIndex < 0 ? forwardedFor : forwardedFor[..separatorIndex]).Trim();
+        return leftmost.Length == 0 ? null : leftmost;
+    }
+
+    // Trims the env-specific suffix from outbound ACA internal FQDNs so dependency spans show
+    // e.g. "account-api.internal/..." instead of "account-api.internal.<env>.azurecontainerapps.io".
+    public static void EnrichOutbound(Activity activity, HttpRequestMessage request)
+    {
+        if (request.RequestUri is null) return;
+
+        var host = request.RequestUri.Host;
+        var trimmedHost = TrimAzureContainerAppsSuffix(host);
+        if (trimmedHost == host) return;
+
+        var trimmedUrl = request.RequestUri.AbsoluteUri.Replace(host, trimmedHost, StringComparison.OrdinalIgnoreCase);
+
+        activity.SetTag("server.address", trimmedHost);
+        activity.SetTag("url.full", trimmedUrl);
+    }
+
+    public static string? BuildPublicUrl(HttpRequest request)
+    {
+        return ResolvePublicUrlParts(request)?.FullUrl;
+    }
+
+    private static (string Host, string Scheme, string FullUrl)? ResolvePublicUrlParts(HttpRequest request)
+    {
+        var hostValue = request.Host.Value ?? string.Empty;
+        if (hostValue.Length == 0) return null;
+
+        // Use Request.Host -- the host this service actually received -- and trim the env suffix
+        // when it's an internal ACA FQDN. AppGateway's Request.Host is the public hostname set by
+        // ACA's external ingress; backend services see "<service>.internal.<env>...", which the
+        // trim reduces to "<service>.internal". This keeps each layer's URL truthful instead of
+        // overwriting backends with the public host via X-Forwarded-Host.
+        var publicHost = TrimAzureContainerAppsSuffix(hostValue);
+
+        var publicScheme = request.Headers["X-Forwarded-Proto"].ToString();
+        if (string.IsNullOrEmpty(publicScheme))
+        {
+            // ACA terminates TLS at the envoy so Kestrel-facing scheme is http; default to https
+            // when running in Azure rather than mislabelling the public URL.
+            publicScheme = SharedInfrastructureConfiguration.IsRunningInAzure ? "https" : request.Scheme;
+        }
+
+        publicHost = StripDefaultPort(publicHost, publicScheme);
+
+        var fullUrl = $"{publicScheme}://{publicHost}{request.PathBase}{request.Path}{request.QueryString}";
+        return (publicHost, publicScheme, fullUrl);
+    }
+
+    private static string TrimAzureContainerAppsSuffix(string host)
+    {
+        var internalIndex = host.IndexOf(".internal.", StringComparison.OrdinalIgnoreCase);
+        if (internalIndex < 0 || !host.EndsWith(".azurecontainerapps.io", StringComparison.OrdinalIgnoreCase)) return host;
+        return host[..(internalIndex + ".internal".Length)];
+    }
+
+    private static string StripDefaultPort(string host, string scheme)
+    {
+        var colonIndex = host.IndexOf(':');
+        if (colonIndex < 0) return host;
+        if (!int.TryParse(host[(colonIndex + 1)..], out var port)) return host;
+        if ((scheme == "https" && port == 443) || (scheme == "http" && port == 80)) return host[..colonIndex];
+        return host;
+    }
+
+    // Default ports were already stripped, so any remaining port is explicit and non-default.
+    private static (string Host, int? Port) ParseHost(string hostHeader)
+    {
+        var separatorIndex = hostHeader.IndexOf(':');
+        if (separatorIndex < 0) return (hostHeader, null);
+
+        var hostName = hostHeader[..separatorIndex];
+        return int.TryParse(hostHeader[(separatorIndex + 1)..], out var port)
+            ? (hostName, port)
+            : (hostName, null);
+    }
+}

--- a/application/shared-kernel/SharedKernel/Telemetry/PublicHostTelemetryEnricher.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/PublicHostTelemetryEnricher.cs
@@ -9,7 +9,7 @@ namespace SharedKernel.Telemetry;
 //     internal ACA FQDNs, defaulted to https in Azure, with the redundant default :443/:80 stripped.
 //     AppGateway shows the public hostname; backend services show "<service>.internal", which is the
 //     conventional layered view in distributed tracing.
-//   - client.address comes from X-Forwarded-For so the App Insights geo lookup resolves to the real
+//   - client.address comes from X-Forwarded-For so the Application Insights geo lookup resolves to the real
 //     browser IP instead of the Azure Container Apps ingress envoy in the cluster's region. The header
 //     is set by the external ingress, which strips client-supplied values, so spoofing is not possible.
 public static class PublicHostTelemetryEnricher
@@ -27,7 +27,7 @@ public static class PublicHostTelemetryEnricher
             activity.SetTag("url.full", fullUrl);
             // Older semconv tag still consumed by some Azure Monitor mappings.
             activity.SetTag("http.url", fullUrl);
-            // null skips server.port so App Insights' URL builder doesn't render the redundant :443/:80.
+            // null skips server.port so Application Insights' URL builder doesn't render the redundant :443/:80.
             activity.SetTag("server.port", explicitPort);
         }
 

--- a/application/shared-kernel/SharedKernel/Telemetry/TelemetryContextMiddleware.cs
+++ b/application/shared-kernel/SharedKernel/Telemetry/TelemetryContextMiddleware.cs
@@ -9,6 +9,7 @@ public sealed class TelemetryContextMiddleware(IExecutionContext executionContex
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
         ApplicationInsightsTelemetryInitializer.SetContext(executionContext);
+        ApplicationInsightsTelemetryInitializer.SetPublicUrl(PublicHostTelemetryEnricher.BuildPublicUrl(context.Request));
 
         openTelemetryEnricher.Apply();
 


### PR DESCRIPTION
### Summary & Motivation

Application Insights had three issues that made the cluster's telemetry hard to read: backend requests logged the internal Azure Container Apps FQDN instead of the public hostname, AppGateway emitted no telemetry at all, and the `application_Version` field rendered the Container Apps revision name (e.g. `back-office--2026-5-1-2111-6768`) instead of the deployed assembly version.

- Override the OpenTelemetry `url.full` / `server.address` / `url.scheme` tags and the Application Insights `RequestTelemetry.Url` with each service's actual `Request.Host` so AppGateway logs show the public hostname (set by the external ingress) and backend services show `<service>.internal` -- the conventional layered view in distributed tracing.
- Trim the env-specific suffix from internal Azure Container Apps FQDNs so backend hosts render as `account-api.internal` instead of `account-api.internal.calmflower-a7c97a21.swedencentral.azurecontainerapps.io`. Apply the same trim to outbound HttpClient telemetry so dependency spans match.
- Default the scheme to `https` when running in Azure if `X-Forwarded-Proto` is missing, and skip `server.port` for default `:443`/`:80` so the URL field stops rendering the redundant port.
- Override the OpenTelemetry `client.address` tag from `X-Forwarded-For` so the App Insights geo lookup resolves to the real browser IP. The instrumentation captures `client.address` at request start, before `UseForwardedHeaders` runs, which on AppGateway leaves it pointing at the Azure Container Apps ingress envoy in the cluster's region. The override is logging-only and safe because the external ingress strips client-supplied `X-Forwarded-For` before adding its own.
- Add `PublicHostTelemetryEnricher` to the OpenTelemetry ASP.NET Core and HttpClient pipelines, plus an `ApplicationInsightsTelemetryInitializer`, so every override applies to both telemetry stacks.
- Wire AppGateway into Application Insights via a new `AddSharedTelemetry()` extension that bundles the OpenTelemetry, Azure Monitor, and Application Insights registrations without requiring a `DbContext`. AppGateway calls it from `Program.cs`; `AddSharedInfrastructure<T>` continues to call it as part of the full bundle for the APIs.
- Move `OpenTelemetryEnricher` (which depends on `IExecutionContext` to read tenant / user / session tags) out of the shared bundle and into `AddApiExecutionContext`, where the dependency belongs. AppGateway has no per-request execution context, so the gateway emits transport-level traces while the APIs continue to emit user-scoped enrichment.
- Stamp every telemetry row -- backend Requests/Dependencies as well as PageViews/Exceptions/Metrics forwarded from the SPA via `/api/track` -- with the deployed binary's zero-padded date version (e.g. `2026.05.02.0914`) in `application_Version`, plus the full commit SHA and GitHub Actions run ID as the `deployment.commit_hash` and `deployment.github_action_id` custom dimensions. Previously this field rendered the Container Apps revision name (`back-office--2026-5-1-2111-6768`), which didn't map back to any commit. The deployment workflows now generate the version as `$(date +"%Y.%m.%d.%H%M")` so it's lexicographically sortable and unambiguous past midnight, and pass the commit SHA and run ID as MSBuild properties; a shared `Directory.Build.props` bakes them into every assembly as `AssemblyMetadata` attributes so the deployed binary carries its own provenance regardless of how or where it is run. The commit SHA is taken from `${{ github.event.pull_request.head.sha || github.sha }}` so pull-request builds stamp the actual PR head commit rather than the synthetic merge commit GitHub Actions creates by default for `pull_request` triggers (which doesn't exist on any branch and can't be checked out locally). `SharedInfrastructureConfiguration` reads the metadata at startup, a `DeploymentTagsProcessor` stamps the deployment values onto every OpenTelemetry span, and `ApplicationInsightsTelemetryInitializer` applies them on the AI SDK path so SPA telemetry gets the same treatment.
- Drop scanner-probe traffic from telemetry by extending `EndpointTelemetryFilter` with the path prefixes (e.g. `/wp-`, `/.git/`, `/.vercel/`, `/.vscode/`, `/.idea/`, `/Properties/`, `/appsettings.`, `/config/`, `/src/`, `/web/`, `/.well-known/`, `/sitemap`, ...) and file extensions (e.g. `.env`, `.php`, `.yml`, `.bak`, `.old`, `.local`, `.envrc`, ...) that bots use to probe for accidentally-deployed secrets and source code. Matched requests are dropped at OpenTelemetry's request-start filter so they never produce a span, never reach the Azure Monitor exporter, and never count against ingestion.
- Mark HTTP 4xx responses as success in telemetry so the Application Insights "Failures" view stops drowning real server-side errors in client-side noise. The default behaviour treats every non-2xx response as a failure, but for server spans 4xx is the client's problem -- validation rejections, expired tokens, missing routes, scanner probes -- not a server-side error. The fix wires an `EnrichWithHttpResponse` callback into the OpenTelemetry ASP.NET Core instrumentation that sets the activity status to `Ok` for 4xx; only 5xx remains a real failure. Aligns with the OpenTelemetry HTTP semantic conventions for server spans.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
