### PR TITLE
Stabilize backend tests and welcome flow

### DIFF
--- a/application/account/Core/Configuration.cs
+++ b/application/account/Core/Configuration.cs
@@ -38,7 +38,7 @@ public static class Configuration
             services.AddHttpClient<GravatarClient>(client =>
                 {
                     client.BaseAddress = new Uri("https://gravatar.com/");
-                    client.Timeout = TimeSpan.FromSeconds(5);
+                    client.Timeout = TimeSpan.FromSeconds(2);
                 }
             );
 

--- a/application/account/Core/Configuration.cs
+++ b/application/account/Core/Configuration.cs
@@ -53,6 +53,7 @@ public static class Configuration
             services.AddScoped<OAuthProviderFactory>();
 
             services.AddMemoryCache();
+            services.AddSingleton<MockStripeState>();
             services.AddKeyedScoped<IStripeClient, StripeClient>("stripe");
             services.AddKeyedScoped<IStripeClient, MockStripeClient>("mock-stripe");
             services.AddKeyedScoped<IStripeClient, UnconfiguredStripeClient>("unconfigured-stripe");

--- a/application/account/Core/Features/Tenants/Queries/GetTenantsForUser.cs
+++ b/application/account/Core/Features/Tenants/Queries/GetTenantsForUser.cs
@@ -30,12 +30,14 @@ internal sealed class GetTenantsForUserQueryHandler(
         var tenantIds = users.Select(u => u.TenantId).ToArray();
         var tenants = await tenantRepository.GetByIdsAsync(tenantIds, cancellationToken);
 
-        var tenantInfoList = tenants.Select(t =>
-            {
-                var user = users.Single(u => u.TenantId == t.Id);
-                return new TenantInfo(t.Id, t.Name, user.Id, t.Logo.Url, !user.EmailConfirmed);
-            }
-        ).ToArray();
+        var tenantInfoList = tenants
+            .OrderBy(t => t.Id)
+            .Select(t =>
+                {
+                    var user = users.Single(u => u.TenantId == t.Id);
+                    return new TenantInfo(t.Id, t.Name, user.Id, t.Logo.Url, !user.EmailConfirmed);
+                }
+            ).ToArray();
 
         return new GetTenantsForUserResponse(tenantInfoList);
     }

--- a/application/account/Core/Integrations/Gravatar/GravatarClient.cs
+++ b/application/account/Core/Integrations/Gravatar/GravatarClient.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using Polly.CircuitBreaker;
+using Polly.Timeout;
 using SharedKernel.Domain;
 
 namespace Account.Integrations.Gravatar;
@@ -35,9 +36,16 @@ public sealed class GravatarClient(HttpClient httpClient, ILogger<GravatarClient
                 response.Content.Headers.ContentType?.MediaType!
             );
         }
-        catch (TaskCanceledException ex)
+        catch (TimeoutRejectedException ex)
         {
-            logger.LogError(ex, "Timeout when fetching gravatar for user {UserId}", userId);
+            // Polly's AttemptTimeout / TotalRequestTimeout strategy raises this on a hung server before any HTTP response.
+            logger.LogError(ex, "Resilience timeout fetching gravatar for user {UserId}. Treating as unavailable", userId);
+            return null;
+        }
+        catch (BrokenCircuitException ex)
+        {
+            // Polly opened the circuit after repeated failures; subsequent calls fail fast until the circuit closes.
+            logger.LogError(ex, "Circuit open while fetching gravatar for user {UserId}. Treating as unavailable", userId);
             return null;
         }
         catch (HttpRequestException ex)
@@ -46,10 +54,12 @@ public sealed class GravatarClient(HttpClient httpClient, ILogger<GravatarClient
             logger.LogError(ex, "Failed to fetch gravatar for user {UserId} after retries. Treating as unavailable", userId);
             return null;
         }
-        catch (BrokenCircuitException ex)
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
-            // Polly opened the circuit after repeated failures; subsequent calls fail fast until the circuit closes.
-            logger.LogError(ex, "Circuit open while fetching gravatar for user {UserId}. Treating as unavailable", userId);
+            // HttpClient.Timeout and the resilience pipeline raise OperationCanceledException subtypes
+            // (notably TaskCanceledException) on internal timeouts. The when-clause re-throws genuine
+            // caller-driven cancellation so MediatR sees it as a real cancellation, not an avatar miss.
+            logger.LogError(ex, "Timeout fetching gravatar for user {UserId}. Treating as unavailable", userId);
             return null;
         }
     }

--- a/application/account/Core/Integrations/Gravatar/GravatarClient.cs
+++ b/application/account/Core/Integrations/Gravatar/GravatarClient.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
+using Polly.CircuitBreaker;
 using SharedKernel.Domain;
 
 namespace Account.Integrations.Gravatar;
@@ -37,6 +38,18 @@ public sealed class GravatarClient(HttpClient httpClient, ILogger<GravatarClient
         catch (TaskCanceledException ex)
         {
             logger.LogError(ex, "Timeout when fetching gravatar for user {UserId}", userId);
+            return null;
+        }
+        catch (HttpRequestException ex)
+        {
+            // Surfaced by the standard resilience handler after retries exhaust on transient failures (5xx, network errors).
+            logger.LogError(ex, "Failed to fetch gravatar for user {UserId} after retries. Treating as unavailable", userId);
+            return null;
+        }
+        catch (BrokenCircuitException ex)
+        {
+            // Polly opened the circuit after repeated failures; subsequent calls fail fast until the circuit closes.
+            logger.LogError(ex, "Circuit open while fetching gravatar for user {UserId}. Treating as unavailable", userId);
             return null;
         }
     }

--- a/application/account/Core/Integrations/Stripe/MockStripeClient.cs
+++ b/application/account/Core/Integrations/Stripe/MockStripeClient.cs
@@ -3,7 +3,18 @@ using Microsoft.Extensions.Configuration;
 
 namespace Account.Integrations.Stripe;
 
-public sealed class MockStripeClient(IConfiguration configuration, TimeProvider timeProvider) : IStripeClient
+public sealed class MockStripeState
+{
+    public string? OverrideSubscriptionStatus { get; set; }
+
+    public bool SimulateSubscriptionDeleted { get; set; }
+
+    public bool SimulateCustomerDeleted { get; set; }
+
+    public bool SimulateOpenInvoice { get; set; }
+}
+
+public sealed class MockStripeClient(IConfiguration configuration, TimeProvider timeProvider, MockStripeState state) : IStripeClient
 {
     public const string MockCustomerId = "cus_mock_12345";
     public const string MockSubscriptionId = "sub_mock_12345";
@@ -13,14 +24,6 @@ public sealed class MockStripeClient(IConfiguration configuration, TimeProvider 
     public const string MockWebhookEventId = "evt_mock_12345";
 
     private readonly bool _isEnabled = configuration.GetValue<bool>("Stripe:AllowMockProvider");
-
-    public static string? OverrideSubscriptionStatus { get; set; }
-
-    public static bool SimulateSubscriptionDeleted { get; set; }
-
-    public static bool SimulateCustomerDeleted { get; set; }
-
-    public static bool SimulateOpenInvoice { get; set; }
 
     public Task<StripeCustomerId?> CreateCustomerAsync(string tenantName, string email, long tenantId, CancellationToken cancellationToken)
     {
@@ -38,7 +41,7 @@ public sealed class MockStripeClient(IConfiguration configuration, TimeProvider 
     {
         EnsureEnabled();
 
-        if (SimulateSubscriptionDeleted)
+        if (state.SimulateSubscriptionDeleted)
         {
             return Task.FromResult<SubscriptionSyncResult?>(null);
         }
@@ -70,7 +73,7 @@ public sealed class MockStripeClient(IConfiguration configuration, TimeProvider 
             null,
             transactions,
             new PaymentMethod("visa", "4242", 12, 2026),
-            OverrideSubscriptionStatus ?? StripeSubscriptionStatus.Active
+            state.OverrideSubscriptionStatus ?? StripeSubscriptionStatus.Active
         );
 
         return Task.FromResult<SubscriptionSyncResult?>(result);
@@ -151,12 +154,12 @@ public sealed class MockStripeClient(IConfiguration configuration, TimeProvider 
     {
         EnsureEnabled();
 
-        if (SimulateCustomerDeleted)
+        if (state.SimulateCustomerDeleted)
         {
             return Task.FromResult<CustomerBillingResult?>(new CustomerBillingResult(null, true));
         }
 
-        var billingInfo = new BillingInfo("Test Organization", new BillingAddress("Vestergade 12", null, "1456", "K\u00f8benhavn K", null, "DK"), "billing@example.com", null);
+        var billingInfo = new BillingInfo("Test Organization", new BillingAddress("Vestergade 12", null, "1456", "København K", null, "DK"), "billing@example.com", null);
         var paymentMethod = new PaymentMethod("visa", "4242", 12, 2026);
         return Task.FromResult<CustomerBillingResult?>(new CustomerBillingResult(billingInfo, false, paymentMethod));
     }
@@ -205,7 +208,7 @@ public sealed class MockStripeClient(IConfiguration configuration, TimeProvider 
     public Task<OpenInvoiceResult?> GetOpenInvoiceAsync(StripeSubscriptionId stripeSubscriptionId, CancellationToken cancellationToken)
     {
         EnsureEnabled();
-        if (SimulateOpenInvoice)
+        if (state.SimulateOpenInvoice)
         {
             return Task.FromResult<OpenInvoiceResult?>(new OpenInvoiceResult(29.99m, "USD"));
         }
@@ -216,7 +219,7 @@ public sealed class MockStripeClient(IConfiguration configuration, TimeProvider 
     public Task<InvoiceRetryResult?> RetryOpenInvoicePaymentAsync(StripeSubscriptionId stripeSubscriptionId, string? paymentMethodId, CancellationToken cancellationToken)
     {
         EnsureEnabled();
-        if (SimulateOpenInvoice)
+        if (state.SimulateOpenInvoice)
         {
             return Task.FromResult<InvoiceRetryResult?>(new InvoiceRetryResult(true, null));
         }
@@ -258,14 +261,6 @@ public sealed class MockStripeClient(IConfiguration configuration, TimeProvider 
                 new PaymentTransaction(PaymentTransactionId.NewId(), 29.99m, "USD", PaymentTransactionStatus.Succeeded, now, null, MockInvoiceUrl, null)
             ]
         );
-    }
-
-    public static void ResetOverrides()
-    {
-        OverrideSubscriptionStatus = null;
-        SimulateSubscriptionDeleted = false;
-        SimulateCustomerDeleted = false;
-        SimulateOpenInvoice = false;
     }
 
     private void EnsureEnabled()

--- a/application/account/Tests/Billing/RetryPendingInvoicePaymentTests.cs
+++ b/application/account/Tests/Billing/RetryPendingInvoicePaymentTests.cs
@@ -3,7 +3,6 @@ using System.Net.Http.Json;
 using Account.Database;
 using Account.Features.Billing.Commands;
 using Account.Features.Subscriptions.Domain;
-using Account.Integrations.Stripe;
 using FluentAssertions;
 using SharedKernel.Tests;
 using SharedKernel.Tests.Persistence;
@@ -11,15 +10,8 @@ using Xunit;
 
 namespace Account.Tests.Billing;
 
-[Collection("StripeTests")]
 public sealed class RetryPendingInvoicePaymentTests : EndpointBaseTest<AccountDbContext>
 {
-    protected override void Dispose(bool disposing)
-    {
-        MockStripeClient.ResetOverrides();
-        base.Dispose(disposing);
-    }
-
     [Fact]
     public async Task RetryPendingInvoicePayment_WhenOpenInvoicePaid_ShouldReturnPaid()
     {
@@ -31,7 +23,7 @@ public sealed class RetryPendingInvoicePaymentTests : EndpointBaseTest<AccountDb
                 ("current_period_end", TimeProvider.GetUtcNow().AddDays(30))
             ]
         );
-        MockStripeClient.SimulateOpenInvoice = true;
+        StripeState.SimulateOpenInvoice = true;
 
         // Act
         var response = await AuthenticatedOwnerHttpClient.PostAsync("/api/account/billing/retry-pending-invoice", null);

--- a/application/account/Tests/EndpointBaseTest.cs
+++ b/application/account/Tests/EndpointBaseTest.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using Account.Features.Users.Domain;
 using Account.Integrations.OAuth;
+using Account.Integrations.Stripe;
 using Bogus;
 using JetBrains.Annotations;
 using Microsoft.ApplicationInsights;
@@ -181,6 +182,8 @@ public abstract class EndpointBaseTest<TContext> : IDisposable where TContext : 
     protected HttpClient AuthenticatedOwnerHttpClient { get; }
 
     protected HttpClient AuthenticatedMemberHttpClient { get; }
+
+    protected MockStripeState StripeState => _webApplicationFactory.Services.GetRequiredService<MockStripeState>();
 
     public void Dispose()
     {

--- a/application/account/Tests/Integrations/Gravatar/GravatarClientTests.cs
+++ b/application/account/Tests/Integrations/Gravatar/GravatarClientTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using Account.Integrations.Gravatar;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Polly.CircuitBreaker;
+using SharedKernel.Domain;
+using Xunit;
+
+namespace Account.Tests.Integrations.Gravatar;
+
+public sealed class GravatarClientTests
+{
+    [Fact]
+    public async Task GetGravatar_WhenHandlerThrowsHttpRequestException_ShouldReturnNull()
+    {
+        // Arrange
+        var client = CreateClient(new ThrowingHandler(new HttpRequestException("Simulated upstream failure")));
+
+        // Act
+        var result = await client.GetGravatar(UserId.NewId(), "user@example.com", CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetGravatar_WhenHandlerThrowsBrokenCircuitException_ShouldReturnNull()
+    {
+        // Arrange
+        var client = CreateClient(new ThrowingHandler(new BrokenCircuitException("Simulated open circuit")));
+
+        // Act
+        var result = await client.GetGravatar(UserId.NewId(), "user@example.com", CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetGravatar_WhenHandlerThrowsTaskCanceledException_ShouldReturnNull()
+    {
+        // Arrange
+        var client = CreateClient(new ThrowingHandler(new TaskCanceledException("Simulated timeout")));
+
+        // Act
+        var result = await client.GetGravatar(UserId.NewId(), "user@example.com", CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetGravatar_WhenHandlerReturns503_ShouldReturnNull()
+    {
+        // Arrange
+        var client = CreateClient(new StatusCodeHandler(HttpStatusCode.ServiceUnavailable));
+
+        // Act
+        var result = await client.GetGravatar(UserId.NewId(), "user@example.com", CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    private static GravatarClient CreateClient(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://gravatar.com/") };
+        return new GravatarClient(httpClient, NullLogger<GravatarClient>.Instance);
+    }
+
+    private sealed class ThrowingHandler(Exception exception) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw exception;
+        }
+    }
+
+    private sealed class StatusCodeHandler(HttpStatusCode statusCode) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(statusCode));
+        }
+    }
+}

--- a/application/account/Tests/Integrations/Gravatar/GravatarClientTests.cs
+++ b/application/account/Tests/Integrations/Gravatar/GravatarClientTests.cs
@@ -1,8 +1,10 @@
 using System.Net;
 using Account.Integrations.Gravatar;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Polly.CircuitBreaker;
+using Polly.Timeout;
 using SharedKernel.Domain;
 using Xunit;
 
@@ -50,10 +52,58 @@ public sealed class GravatarClientTests
     }
 
     [Fact]
+    public async Task GetGravatar_WhenHandlerThrowsTimeoutRejectedException_ShouldReturnNull()
+    {
+        // Arrange
+        var client = CreateClient(new ThrowingHandler(new TimeoutRejectedException("Simulated Polly timeout")));
+
+        // Act
+        var result = await client.GetGravatar(UserId.NewId(), "user@example.com", CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public async Task GetGravatar_WhenHandlerReturns503_ShouldReturnNull()
     {
         // Arrange
         var client = CreateClient(new StatusCodeHandler(HttpStatusCode.ServiceUnavailable));
+
+        // Act
+        var result = await client.GetGravatar(UserId.NewId(), "user@example.com", CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetGravatar_WhenHandlerHangsThroughResiliencePipeline_ShouldReturnNullViaTimeoutRejected()
+    {
+        // Arrange
+        // Wires the real AddStandardResilienceHandler() pipeline around a hung handler so the production
+        // exception type (TimeoutRejectedException after AttemptTimeout fires) actually surfaces. Timeouts
+        // are shrunk to keep the test fast (~1s), but the exception-shape contract is identical to prod.
+        var services = new ServiceCollection();
+        services.AddHttpClient<GravatarClient>(httpClient =>
+                {
+                    httpClient.BaseAddress = new Uri("https://gravatar.com/");
+                    httpClient.Timeout = TimeSpan.FromSeconds(30);
+                }
+            ).ConfigurePrimaryHttpMessageHandler(() => new HangingHandler())
+            .AddStandardResilienceHandler(options =>
+                {
+                    options.AttemptTimeout.Timeout = TimeSpan.FromMilliseconds(500);
+                    options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(1);
+                    options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(5);
+                    options.Retry.MaxRetryAttempts = 1;
+                    options.Retry.Delay = TimeSpan.FromMilliseconds(50);
+                }
+            );
+        services.AddSingleton(NullLogger<GravatarClient>.Instance);
+
+        await using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<GravatarClient>();
 
         // Act
         var result = await client.GetGravatar(UserId.NewId(), "user@example.com", CancellationToken.None);
@@ -81,6 +131,15 @@ public sealed class GravatarClientTests
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return Task.FromResult(new HttpResponseMessage(statusCode));
+        }
+    }
+
+    private sealed class HangingHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
         }
     }
 }

--- a/application/account/Tests/Subscriptions/AcknowledgeStripeWebhookTests.cs
+++ b/application/account/Tests/Subscriptions/AcknowledgeStripeWebhookTests.cs
@@ -11,16 +11,9 @@ using Xunit;
 
 namespace Account.Tests.Subscriptions;
 
-[Collection("StripeTests")]
 public sealed class AcknowledgeStripeWebhookTests : EndpointBaseTest<AccountDbContext>
 {
     private const string WebhookUrl = "/api/account/subscriptions/stripe-webhook";
-
-    protected override void Dispose(bool disposing)
-    {
-        MockStripeClient.ResetOverrides();
-        base.Dispose(disposing);
-    }
 
     private void SetupSubscription(string? stripeCustomerId = MockStripeClient.MockCustomerId, string? stripeSubscriptionId = MockStripeClient.MockSubscriptionId, string plan = nameof(SubscriptionPlan.Standard), DateTimeOffset? firstPaymentFailedAt = null, string? cancellationReason = null)
     {
@@ -139,7 +132,7 @@ public sealed class AcknowledgeStripeWebhookTests : EndpointBaseTest<AccountDbCo
     public async Task AcknowledgeStripeWebhook_WhenFirstPaymentFailed_ShouldSetFailure()
     {
         // Arrange
-        MockStripeClient.OverrideSubscriptionStatus = StripeSubscriptionStatus.PastDue;
+        StripeState.OverrideSubscriptionStatus = StripeSubscriptionStatus.PastDue;
         SetupSubscription();
         TelemetryEventsCollectorSpy.Reset();
 
@@ -165,7 +158,7 @@ public sealed class AcknowledgeStripeWebhookTests : EndpointBaseTest<AccountDbCo
     public async Task AcknowledgeStripeWebhook_WhenSubsequentPaymentFailed_ShouldNotUpdateFailureTimestamp()
     {
         // Arrange
-        MockStripeClient.OverrideSubscriptionStatus = StripeSubscriptionStatus.PastDue;
+        StripeState.OverrideSubscriptionStatus = StripeSubscriptionStatus.PastDue;
         var now = TimeProvider.GetUtcNow();
         SetupSubscription(firstPaymentFailedAt: now.AddHours(-48));
         TelemetryEventsCollectorSpy.Reset();
@@ -189,7 +182,7 @@ public sealed class AcknowledgeStripeWebhookTests : EndpointBaseTest<AccountDbCo
     public async Task AcknowledgeStripeWebhook_WhenSubscriptionDeletedInvoluntarily_ShouldSuspendTenant()
     {
         // Arrange
-        MockStripeClient.SimulateSubscriptionDeleted = true;
+        StripeState.SimulateSubscriptionDeleted = true;
         var now = TimeProvider.GetUtcNow();
         SetupSubscription(firstPaymentFailedAt: now.AddDays(-5));
         TelemetryEventsCollectorSpy.Reset();
@@ -216,7 +209,7 @@ public sealed class AcknowledgeStripeWebhookTests : EndpointBaseTest<AccountDbCo
     public async Task AcknowledgeStripeWebhook_WhenSubscriptionDeletedVoluntarily_ShouldKeepTenantActive()
     {
         // Arrange
-        MockStripeClient.SimulateSubscriptionDeleted = true;
+        StripeState.SimulateSubscriptionDeleted = true;
         SetupSubscription(cancellationReason: nameof(CancellationReason.NoLongerNeeded));
         TelemetryEventsCollectorSpy.Reset();
 
@@ -265,7 +258,7 @@ public sealed class AcknowledgeStripeWebhookTests : EndpointBaseTest<AccountDbCo
     public async Task AcknowledgeStripeWebhook_WhenCustomerDeleted_ShouldSuspendTenant()
     {
         // Arrange
-        MockStripeClient.SimulateCustomerDeleted = true;
+        StripeState.SimulateCustomerDeleted = true;
         SetupSubscription();
         TelemetryEventsCollectorSpy.Reset();
 
@@ -291,7 +284,7 @@ public sealed class AcknowledgeStripeWebhookTests : EndpointBaseTest<AccountDbCo
     public async Task AcknowledgeStripeWebhook_WhenSubscriptionDeletedAndTenantAlreadySuspended_ShouldNotOverrideSuspension()
     {
         // Arrange - tenant already suspended with CustomerDeleted (e.g., customer.deleted processed in previous batch)
-        MockStripeClient.SimulateSubscriptionDeleted = true;
+        StripeState.SimulateSubscriptionDeleted = true;
         SetupSubscription(cancellationReason: nameof(CancellationReason.NoLongerNeeded));
         Connection.Update("tenants", "id", DatabaseSeeder.Tenant1.Id.Value, [("state", nameof(TenantState.Suspended)), ("suspension_reason", nameof(SuspensionReason.CustomerDeleted))]);
         TelemetryEventsCollectorSpy.Reset();
@@ -318,7 +311,7 @@ public sealed class AcknowledgeStripeWebhookTests : EndpointBaseTest<AccountDbCo
     public async Task AcknowledgeStripeWebhook_WhenCustomerDeletedAndSubscriptionDeletedInSameBatch_ShouldSuspendWithCustomerDeleted()
     {
         // Arrange - pre-insert a pending customer.deleted event so both events process in the same batch
-        MockStripeClient.SimulateCustomerDeleted = true;
+        StripeState.SimulateCustomerDeleted = true;
         SetupSubscription(cancellationReason: nameof(CancellationReason.NoLongerNeeded));
         Connection.Insert("stripe_events", [
                 ("tenant_id", null),

--- a/application/account/WebApp/routes/login/index.tsx
+++ b/application/account/WebApp/routes/login/index.tsx
@@ -23,6 +23,7 @@ import { clearLoginState, getLoginState, setLoginState } from "./-shared/loginSt
 
 export const Route = createFileRoute("/login/")({
   staticData: { trackingTitle: "Log in" },
+  beforeLoad: () => ({ disableAuthSync: true }),
   validateSearch: (search) => {
     const returnPath = search.returnPath as string | undefined;
     return {

--- a/application/account/WebApp/routes/login/verify.tsx
+++ b/application/account/WebApp/routes/login/verify.tsx
@@ -17,6 +17,7 @@ import { useLoginVerification } from "./-shared/useLoginVerification";
 
 export const Route = createFileRoute("/login/verify")({
   staticData: { trackingTitle: "Verify login" },
+  beforeLoad: () => ({ disableAuthSync: true }),
   validateSearch: (search) => {
     const returnPath = search.returnPath as string | undefined;
     return {

--- a/application/account/WebApp/routes/signup/index.tsx
+++ b/application/account/WebApp/routes/signup/index.tsx
@@ -27,6 +27,7 @@ import { clearSignupState, getSignupState, setSignupState } from "./-shared/sign
 
 export const Route = createFileRoute("/signup/")({
   staticData: { trackingTitle: "Sign up" },
+  beforeLoad: () => ({ disableAuthSync: true }),
   component: function SignupRoute() {
     const { isAuthenticated } = import.meta.user_info_env;
     const { navigateToHome } = useMainNavigation();

--- a/application/account/WebApp/routes/signup/verify.tsx
+++ b/application/account/WebApp/routes/signup/verify.tsx
@@ -16,6 +16,7 @@ import { useSignupVerification } from "./-shared/useSignupVerification";
 
 export const Route = createFileRoute("/signup/verify")({
   staticData: { trackingTitle: "Verify sign up" },
+  beforeLoad: () => ({ disableAuthSync: true }),
   component: function SignupVerifyRoute() {
     const { isAuthenticated } = import.meta.user_info_env;
     const navigate = useNavigate();

--- a/application/account/WebApp/shared/components/AccountFields.tsx
+++ b/application/account/WebApp/shared/components/AccountFields.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { TextField } from "@repo/ui/components/TextField";
+import { useState } from "react";
 
 import type { Schemas } from "@/shared/lib/api/client";
 
@@ -35,6 +36,14 @@ export function AccountFields({
   layout = "stacked",
   infoFields
 }: AccountFieldsProps) {
+  // Snapshot tenant once so TextField defaultValue stays stable. A later refetch (e.g. after
+  // saving account settings) would otherwise change defaultValue between renders and trigger
+  // Base UI's "default value of an uncontrolled FieldControl after being initialized" warning.
+  const [initialTenant, setInitialTenant] = useState(tenant);
+  if (initialTenant === undefined && tenant !== undefined) {
+    setInitialTenant(tenant);
+  }
+
   const logoSection = (
     <TenantLogoPicker
       logoUrl={tenant?.logoUrl}
@@ -52,7 +61,7 @@ export function AccountFields({
       autoFocus={autoFocus}
       required={true}
       name="name"
-      defaultValue={tenant?.name ?? ""}
+      defaultValue={initialTenant?.name ?? ""}
       disabled={isPending}
       readOnly={readOnly}
       label={t`Account name`}

--- a/application/account/WebApp/shared/components/UserProfileFields.tsx
+++ b/application/account/WebApp/shared/components/UserProfileFields.tsx
@@ -2,6 +2,7 @@ import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { TextField } from "@repo/ui/components/TextField";
 import { MailIcon } from "lucide-react";
+import { useState } from "react";
 
 import type { Schemas } from "@/shared/lib/api/client";
 
@@ -24,6 +25,14 @@ export function UserProfileFields({
   autoFocus,
   layout = "stacked"
 }: UserProfileFieldsProps) {
+  // Snapshot user once so TextField defaultValue stays stable. A later refetch (e.g. after
+  // saving the profile) would otherwise change defaultValue between renders and trigger
+  // Base UI's "default value of an uncontrolled FieldControl after being initialized" warning.
+  const [initialUser, setInitialUser] = useState(user);
+  if (initialUser === undefined && user !== undefined) {
+    setInitialUser(user);
+  }
+
   const avatarSection = (
     <UserAvatarPicker
       avatarUrl={user?.avatarUrl}
@@ -42,7 +51,7 @@ export function UserProfileFields({
           required={true}
           name="firstName"
           label={t`First name`}
-          defaultValue={user?.firstName}
+          defaultValue={initialUser?.firstName ?? ""}
           placeholder={t`E.g. Alex`}
           className="sm:flex-1"
         />
@@ -50,7 +59,7 @@ export function UserProfileFields({
           required={true}
           name="lastName"
           label={t`Last name`}
-          defaultValue={user?.lastName}
+          defaultValue={initialUser?.lastName ?? ""}
           placeholder={t`E.g. Taylor`}
           className="sm:flex-1"
         />
@@ -60,12 +69,17 @@ export function UserProfileFields({
         name="email"
         label={t`Email`}
         tooltip={t`Your email address cannot be changed. An owner must delete your account and reinvite you with the new email address.`}
-        value={user?.email}
+        value={initialUser?.email ?? ""}
         readOnly={true}
         startIcon={<MailIcon className="size-4" />}
       />
 
-      <TextField name="title" label={t`Title`} defaultValue={user?.title} placeholder={t`E.g. Software engineer`} />
+      <TextField
+        name="title"
+        label={t`Title`}
+        defaultValue={initialUser?.title ?? ""}
+        placeholder={t`E.g. Software engineer`}
+      />
     </>
   );
 


### PR DESCRIPTION
### Summary & Motivation

Address a cluster of stability issues surfaced during regression testing of the welcome flow and the backend test suite. The welcome flow returned 503s when `gravatar.com` was degraded, the backend test suite raced under parallel execution due to static mutable state in `MockStripeClient`, the User menu showed the wrong tenant after switching on Firefox when a user belonged to many tenants (a regression introduced by the Postgres switch where row order was no longer deterministic), and a Base UI input warning appeared during signup.

- Catch `HttpRequestException`, `BrokenCircuitException`, `TimeoutRejectedException`, and timeout-related `OperationCanceledException` in `GravatarClient` so a degraded `gravatar.com` no longer propagates 5xx into `POST /api/account/authentication/email/signup/{id}/complete`, `PUT /api/account/tenants/current`, or `PUT /api/account/users/me`. Lower the Gravatar `HttpClient.Timeout` from 5 s to 2 s so the worst-case best-effort lookup stays well inside Playwright's toast assertion budget.
- Replace static mutable override fields on `MockStripeClient` with a per-test `MockStripeState` singleton resolved through DI. Each `EndpointBaseTest`'s `WebApplicationFactory` gets its own instance, so parallel tests no longer observe each other's mutations. Removes the now-unnecessary `[Collection("StripeTests")]` markers and `Dispose` reset code.
- Order tenants by `Id` in `GetTenantsForUser` so the response is deterministic. Postgres returns rows in heap order without an explicit `ORDER BY`, which surfaced as a Firefox-only flaky e2e where the User menu still displayed the previous tenant after switching. Disable `AuthSyncModal` on `/login`, `/login/verify`, `/signup`, and `/signup/verify` so the cross-tab sync modal cannot fire during partial-auth flows.
- Default `value` to an empty string on the welcome-flow `AccountFields` and `UserProfileFields` text inputs so React no longer logs a controlled-vs-uncontrolled console warning when the form mounts before its data has loaded.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
