### PR TITLE
Fix false replay attack errors caused by client-side timeouts during cold starts

### DIFF
--- a/application/AppGateway/Program.cs
+++ b/application/AppGateway/Program.cs
@@ -72,6 +72,9 @@ builder.Services.AddHttpClient("Account", (sp, client) =>
         client.BaseAddress = !string.IsNullOrEmpty(productionUrl)
             ? new Uri(productionUrl)
             : new Uri($"https://localhost:{ports.AccountApi}");
+        // Allow cold-start refreshes to complete and deliver the new Set-Cookie back to the browser.
+        // The browser has no client-side timeout, so the gateway is the authoritative timeout for refresh.
+        client.Timeout = TimeSpan.FromSeconds(60);
     }
 );
 

--- a/application/account/Core/Features/Authentication/Domain/Session.cs
+++ b/application/account/Core/Features/Authentication/Domain/Session.cs
@@ -7,7 +7,6 @@ namespace Account.Features.Authentication.Domain;
 
 public sealed class Session : AggregateRoot<SessionId>, ITenantScopedEntity
 {
-    // Grace period must match DEFAULT_TIMEOUT in shared-webapp/infrastructure/http/httpClient.ts.
     // Allows in-flight requests using the previous token version to complete when a parallel request triggers a token refresh.
     public const int GracePeriodSeconds = 30;
 

--- a/application/account/WebApp/routes/-components/errorDisplay.tsx
+++ b/application/account/WebApp/routes/-components/errorDisplay.tsx
@@ -16,7 +16,6 @@ export type ErrorDisplay = {
 };
 
 export const errorLabelMap: Record<string, string> = {
-  [ErrorCode.ReplayAttack]: "Security alert",
   [ErrorCode.SessionRevoked]: "Session ended",
   [ErrorCode.SessionNotFound]: "Session expired",
   [ErrorCode.SessionExpired]: "Session expired",
@@ -31,23 +30,6 @@ export const errorLabelMap: Record<string, string> = {
 
 export function getErrorDisplay(error: string): ErrorDisplay {
   switch (error) {
-    case ErrorCode.ReplayAttack:
-      return {
-        icon: <ShieldAlert className="size-10 text-destructive" />,
-        iconBackground: "bg-destructive/10",
-        title: <Trans>Security alert</Trans>,
-        message: (
-          <>
-            <Trans>
-              We detected suspicious activity on your account. Someone may have attempted to take over your session.
-            </Trans>
-            <br />
-            <Trans>For your protection, you have been logged out. Please log in again to continue.</Trans>
-          </>
-        ),
-        action: "login"
-      };
-
     case ErrorCode.SessionRevoked:
       return {
         icon: <LogOut className="size-10 text-muted-foreground" />,

--- a/application/account/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account/WebApp/shared/translations/locale/da-DK.po
@@ -1172,9 +1172,6 @@ msgstr "Faste kolonner"
 msgid "For detailed compliance certifications and audit reports, visit Microsoft's official resources."
 msgstr "For detaljerede certificeringer og revisionsrapporter, besøg Microsofts officielle ressourcer."
 
-msgid "For your protection, you have been logged out. Please log in again to continue."
-msgstr "For din beskyttelse er du blevet logget ud. Log venligst ind igen for at fortsætte."
-
 msgid "Forward"
 msgstr "Fremad"
 
@@ -2240,9 +2237,6 @@ msgstr "Søgedrevet menu med grupperede elementer og inline-genveje. Pak den ind
 msgid "Secondary"
 msgstr "Sekundær"
 
-msgid "Security alert"
-msgstr "Sikkerhedsadvarsel"
-
 msgid "Security, privacy, and compliance information"
 msgstr "Sikkerheds-, privatlivs- og overholdelsesoplysninger"
 
@@ -2931,9 +2925,6 @@ msgstr "Advarselsbesked"
 
 msgid "We detected a security issue with your login attempt. Please try again."
 msgstr "Vi opdagede et sikkerhedsproblem med dit loginforsøg. Prøv venligst igen."
-
-msgid "We detected suspicious activity on your account. Someone may have attempted to take over your session."
-msgstr "Vi opdagede mistænkelig aktivitet på din konto. Nogen kan have forsøgt at overtage din session."
 
 msgid "What's at the market this week"
 msgstr "Hvad er på markedet denne uge"

--- a/application/account/WebApp/shared/translations/locale/en-US.po
+++ b/application/account/WebApp/shared/translations/locale/en-US.po
@@ -1174,9 +1174,6 @@ msgstr "Fixed columns"
 msgid "For detailed compliance certifications and audit reports, visit Microsoft's official resources."
 msgstr "For detailed compliance certifications and audit reports, visit Microsoft's official resources."
 
-msgid "For your protection, you have been logged out. Please log in again to continue."
-msgstr "For your protection, you have been logged out. Please log in again to continue."
-
 msgid "Forward"
 msgstr "Forward"
 
@@ -2242,9 +2239,6 @@ msgstr "Search-driven menu with grouped items and inline shortcuts. Wrap it in C
 msgid "Secondary"
 msgstr "Secondary"
 
-msgid "Security alert"
-msgstr "Security alert"
-
 msgid "Security, privacy, and compliance information"
 msgstr "Security, privacy, and compliance information"
 
@@ -2933,9 +2927,6 @@ msgstr "Warning alert"
 
 msgid "We detected a security issue with your login attempt. Please try again."
 msgstr "We detected a security issue with your login attempt. Please try again."
-
-msgid "We detected suspicious activity on your account. Someone may have attempted to take over your session."
-msgstr "We detected suspicious activity on your account. Someone may have attempted to take over your session."
 
 msgid "What's at the market this week"
 msgstr "What's at the market this week"

--- a/application/account/WebApp/tests/e2e/session-management-flows.spec.ts
+++ b/application/account/WebApp/tests/e2e/session-management-flows.spec.ts
@@ -233,10 +233,11 @@ test.describe("@comprehensive", () => {
   });
 
   /**
-   * REPLAY ATTACK DETECTION ERROR PAGE
+   * REPLAY ATTACK DETECTION REDIRECTS TO LOGIN
    *
    * Tests that when a refresh token is "stolen" and used from another browser,
-   * both browsers are eventually redirected to the replay_attack error page.
+   * both browsers are eventually redirected to the login page (server still records
+   * SessionReplayDetected for monitoring of genuine attacks).
    *
    * Flow:
    * 1. User logs in to browser A (refresh token version 1)
@@ -244,9 +245,9 @@ test.describe("@comprehensive", () => {
    * 3. Browser B uses stolen token twice (version becomes 3, grace period ends)
    * 4. Browser A tries to refresh (replay detected, session revoked)
    * 5. Browser B tries to refresh (session already revoked)
-   * 6. Both browsers see the replay_attack error page
+   * 6. Both browsers land on the login page
    */
-  test("should redirect to replay_attack error page when refresh token replay is detected", async ({ page }) => {
+  test("should redirect to login when refresh token replay is detected", async ({ page }) => {
     const context = createTestContext(page);
     const owner = testUser();
     const browser = page.context().browser() as Browser;
@@ -282,7 +283,7 @@ test.describe("@comprehensive", () => {
       await expect(secondPage.getByRole("heading", { name: "Users" })).toBeVisible();
     })();
 
-    await step("Navigate in victim browser after replay & verify replay_attack error page")(async () => {
+    await step("Navigate in victim browser after replay & verify redirect to login")(async () => {
       await secondPage.route("**/api/**", (route) => route.abort());
       await deleteAccessTokenCookie(page);
       context.monitoring.expectedStatusCodes.push(401);
@@ -293,13 +294,11 @@ test.describe("@comprehensive", () => {
         window.dispatchEvent(new Event("online"));
       });
 
-      await expect(page).toHaveURL(/\/error\?.*error=replay_attack/);
-      await expect(page.getByRole("heading", { name: "Security alert" })).toBeVisible();
-      await expect(page.getByText("We detected suspicious activity on your account.")).toBeVisible();
-      await expect(page.getByRole("button", { name: "Log in" })).toBeVisible();
+      await expect(page).toHaveURL(/\/login/);
+      await expect(page.getByRole("heading", { name: "Hi! Welcome back" })).toBeVisible();
     })();
 
-    await step("Attacker browser detects replay & shows replay_attack error page")(async () => {
+    await step("Attacker browser detects replay & redirects to login")(async () => {
       const secondPageContext = createTestContext(secondPage);
       secondPageContext.monitoring.expectedStatusCodes.push(401);
       await deleteAccessTokenCookie(secondPage);
@@ -310,16 +309,8 @@ test.describe("@comprehensive", () => {
         window.dispatchEvent(new Event("online"));
       });
 
-      await expect(secondPage).toHaveURL(/\/error\?.*error=replay_attack/);
-      await expect(secondPage.getByRole("heading", { name: "Security alert" })).toBeVisible();
-      await expect(secondPage.getByText("We detected suspicious activity on your account.")).toBeVisible();
-    })();
-
-    await step("Click login on replay_attack page & verify login page")(async () => {
-      await page.getByRole("button", { name: "Log in" }).click();
-
-      await expect(page).toHaveURL(/\/login/);
-      await expect(page.getByRole("heading", { name: "Hi! Welcome back" })).toBeVisible();
+      await expect(secondPage).toHaveURL(/\/login/);
+      await expect(secondPage.getByRole("heading", { name: "Hi! Welcome back" })).toBeVisible();
     })();
 
     await secondContext.close();

--- a/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
+++ b/application/shared-kernel/SharedKernel/Configuration/SharedInfrastructureConfiguration.cs
@@ -79,7 +79,21 @@ public static class SharedInfrastructureConfiguration
             builder.Services
                 .ConfigureHttpClientDefaults(http =>
                     {
-                        http.AddStandardResilienceHandler(); // Turn on resilience by default
+                        // 45s total request timeout for API-tier outbound calls (account-api, main-api).
+                        // Sized to absorb a downstream container scale-from-zero: ~31s P99 container start
+                        // plus ~12s P99 first-request slowness on account-api. Still tight enough to defend
+                        // against slow-loris / DoS upstream. AppGateway sets a longer per-client timeout for
+                        // its account-api refresh path because that path must deliver the rotated Set-Cookie
+                        // to the browser.
+                        // Retries are disabled: most 5xx errors during a bad release are persistent, so
+                        // retrying triples the load during incidents and inflates the failure rate in
+                        // Application Insights. Real transient errors are rare in same-region traffic.
+                        http.AddStandardResilienceHandler(options =>
+                            {
+                                options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(45);
+                                options.Retry.ShouldHandle = _ => ValueTask.FromResult(false);
+                            }
+                        );
                         http.AddServiceDiscovery(); // Turn on service discovery by default
                     }
                 );

--- a/application/shared-webapp/infrastructure/auth/AuthenticationMiddleware.ts
+++ b/application/shared-webapp/infrastructure/auth/AuthenticationMiddleware.ts
@@ -17,7 +17,6 @@ const UnauthorizedReason = {
 
 // Error codes used in /error page query parameter
 export const ErrorCode = {
-  ReplayAttack: "replay_attack",
   SessionRevoked: "session_revoked",
   SessionNotFound: "session_not_found",
   UserNotFound: "user_not_found",
@@ -35,7 +34,12 @@ const unauthorizedReasonHeaderKey = "x-unauthorized-reason";
 function getErrorCodeFromUnauthorizedReason(reason: string | null): string | null {
   switch (reason) {
     case UnauthorizedReason.ReplayAttackDetected:
-      return ErrorCode.ReplayAttack;
+      // Replay detection is overwhelmingly false-positive-driven for legitimate users (e.g. closing
+      // the browser mid cold-start refresh leaves their cookie stale and trips the grace check).
+      // Skipping the error page sends them straight to the login screen — same as if their session
+      // had simply expired. Server-side detection, telemetry, and session revocation remain intact
+      // for monitoring genuine attacks; the curious user can review their sessions at /user/sessions.
+      return null;
     case UnauthorizedReason.Revoked:
       return ErrorCode.SessionRevoked;
     case UnauthorizedReason.SessionNotFound:

--- a/application/shared-webapp/infrastructure/http/httpClient.ts
+++ b/application/shared-webapp/infrastructure/http/httpClient.ts
@@ -11,8 +11,16 @@
 import { getHasPendingAuthSync } from "../auth/AuthSyncService";
 import { normalizeError } from "./errorHandler";
 
-// Default timeout must match GracePeriodSeconds in account/Core/Features/Authentication/Domain/Session.cs
-export const DEFAULT_TIMEOUT = 30000;
+/**
+ * Client-side timeout. Must be strictly longer than the longest server-side request the browser
+ * waits on so it never fires before the server can return a response. Aborting before the server
+ * resolves causes cookie-rotation responses to be lost mid-flight and triggers false replay-attack
+ * revocations. Sized to absorb a full all-cold chain (AppGateway + account-api + main-api each
+ * scaling from zero in series), with extra margin for downstream projects whose main-api carries
+ * substantial first-request cost. This timeout exists only as a final safety net for network
+ * blackholes.
+ */
+export const DEFAULT_TIMEOUT = 120000;
 
 /**
  * Direct fetch wrapper for non-strongly-typed HTTP calls


### PR DESCRIPTION
### Summary & Motivation

A bug was revoking sessions with "Replay attack detected" on cold starts. The browser's 30-second client-side timeout was aborting in-flight cookie rotation responses before the AppGateway could deliver them. The rotation committed server-side, but the browser kept the old cookies. When the browser retried more than 30 seconds later, the grace window in `Session.IsRefreshTokenValid` had expired, the legitimate token was flagged as a replay, and the session was revoked. Depending on cold-start timing the user either saw the replay-attack error page or was logged out silently when that error page itself failed to load against a still-cold gateway.

Make the server authoritative for timeouts so the browser cannot abort a rotation response mid-flight, and size each timeout against measured cold-start data:

- **AppGateway → account-api refresh**: explicit 60-second timeout. The auth middleware must deliver the rotated Set-Cookie back to the browser even if account-api is scaling from zero.
- **API tier outbound (account-api, main-api)**: 45-second total request timeout configured on the standard resilience handler. Sized to absorb a downstream cold-start, which lands around ~43 s P99.
- **Browser client-side timeout**: 120 seconds. Acts only as a final safety net for network blackholes; sized to cover the full all-cold chain at P99. The chain runs every time a user opens main-api after idle: app-gateway, then account-api refresh, then main-api forward, each scaling from zero in series. PlatformPlatform's main-api is essentially empty, but downstream projects place ~90% of their endpoints in main-api, so the realistic main-api cold-start in production usage is closer to account-api's ~43 s P99 than to the ~29 s seen here. 120 s leaves headroom for that. A generous client-side timeout carries no slow-loris-style risk — that risk exists only on server-side timeouts. The new comment on `DEFAULT_TIMEOUT` documents the invariant that this must stay strictly longer than the longest server-side request the browser waits on.

Disable HTTP client retries in the API tier via `Retry.ShouldHandle = _ => ValueTask.FromResult(false)`. Most 5xx errors during a bad release are persistent, so retrying triples the load during incidents and inflates the failure rate in Application Insights. Real transient errors are rare in same-region traffic.

Remove the now-stale comment in `Session.cs` linking `GracePeriodSeconds` to the client-side timeout; the relevant invariant now lives between server-side timeouts and the client safety net, documented in `httpClient.ts`.

Soften the user-facing presentation. The replay-detection path is dominated by false positives — an impatient user closing the browser mid cold-start refresh leaves their cookie stale and trips the grace check on the next visit. The frontend now skips the interstitial error page entirely on `UnauthorizedReason.ReplayAttackDetected` and redirects straight to the login screen, matching how GitHub and Facebook handle invalidated sessions. Curious users can review and revoke active sessions at `/user/sessions`. Server-side detection is unchanged: the session is still revoked, the warning log still records "Replay attack detected", and the `SessionReplayDetected` telemetry event still fires for monitoring of genuine attacks.

### Cold-start measurements (staging, no deployments)

Sample: 157 cold-starts measured (86 app-gateway, 37 account-api, 34 main-api). Total cold-start time as seen by an upstream caller (container scheduling + image start + .NET process start + first-request slowness):

| stat | app-gateway | account-api | main-api |
|---|---|---|---|
| P50 | ~21 s | ~21 s | ~20 s |
| P90 | ~28 s | ~38 s | ~28 s |
| P99 | ~31 s | ~43 s | ~29 s |

Container startup itself is remarkably consistent across all three apps — 20 to 31 s from P50 to P99, regardless of whether the app has a database. Account-api's longer total cold-start comes from first-request slowness (Key Vault sign, DB connection, EF Core warm-up). PlatformPlatform's main-api is empty so its first request is negligible here; downstream projects that place the bulk of their endpoints in main-api should expect first-request cost similar to account-api.

Per-hop cold-start durations vary independently — typical chain combinations are around 20-25 s per hop, with occasional outliers, but no consistent "Azure is slow today, every hop hits P99" pattern. The full-chain (browser → app-gateway cold → account-api cold → main-api cold) at P99 fits within the 120 s client-side budget, with headroom for downstream projects where main-api carries substantial first-request cost.

Back-office is not in scope: it is fronted by its own ingress rather than the AppGateway and does not make outbound calls to the other APIs, so the timeout chain does not apply.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
