### PR TITLE
Fix Aspire AppHost not building email templates before APIs become ready

### DIFF
--- a/application/account/WebApp/tests/e2e/localized-email-flows.spec.ts
+++ b/application/account/WebApp/tests/e2e/localized-email-flows.spec.ts
@@ -238,10 +238,10 @@ test.describe("@comprehensive", () => {
     await step("Fetch en-US unknown user email from Mailpit & assert subject, HTML, and plaintext")(async () => {
       const mail = await fetchLatestMailByRecipient(enUnknownEmail);
 
-      expect(mail.subject).toBe("Unknown user tried to login to PlatformPlatform");
-      expect(mail.html).toContain("You or someone else tried to login to PlatformPlatform");
+      expect(mail.subject).toBe("No account found");
+      expect(mail.html).toContain("Is this the right email address?");
       expect(mail.html).toContain(enUnknownEmail);
-      expect(mail.text).toContain("You or someone else tried to login to PlatformPlatform");
+      expect(mail.text).toContain("Is this the right email address?");
       expect(mail.text).toContain(enUnknownEmail);
     })();
 
@@ -261,10 +261,10 @@ test.describe("@comprehensive", () => {
       async () => {
         const mail = await fetchLatestMailByRecipient(daUnknownEmail);
 
-        expect(mail.subject).toBe("Ukendt bruger forsøgte at logge ind på PlatformPlatform");
-        expect(mail.html).toContain("Du eller en anden forsøgte at logge ind på PlatformPlatform");
+        expect(mail.subject).toBe("Ingen konto fundet");
+        expect(mail.html).toContain("Er det den rigtige e-mailadresse?");
         expect(mail.html).toContain(daUnknownEmail);
-        expect(mail.text).toContain("Du eller en anden forsøgte at logge ind på PlatformPlatform");
+        expect(mail.text).toContain("Er det den rigtige e-mailadresse?");
         expect(mail.text).toContain(daUnknownEmail);
       }
     )();

--- a/application/turbo.json
+++ b/application/turbo.json
@@ -37,7 +37,7 @@
       "dependsOn": ["dev:setup"]
     },
     "dev:setup": {
-      "dependsOn": ["^dev:setup"],
+      "dependsOn": ["^dev:setup", "@repo/emails#build"],
       "inputs": ["$TURBO_DEFAULT$", "shared/lib/api/*.Api.json", "shared/lib/api/*.Api_*.json"],
       "outputs": ["dist/**", "shared/lib/api/*.generated.d.ts"]
     },


### PR DESCRIPTION
### Summary & Motivation

After the localized-emails feature merged to main, starting Aspire on a fresh clone (or any environment without a populated `application/account/WebApp/emails/dist/` folder) returned HTTP 500 from every email-sending endpoint with `System.IO.FileNotFoundException: Email template 'StartSignup.en-US.html' not found`. The crash cascaded through 11 of 14 e2e smoke tests. The dist folder is a gitignored build artifact only populated by the `@repo/emails#build` turbo task; nothing in the dev pipeline triggered that task before the AppGateway accepted requests.

- Add `@repo/emails#build` to `dev:setup`'s `dependsOn` in `application/turbo.json`. The Aspire AppHost's `frontendBuild` resource runs `npm start` → `turbo dev`, and `dev` depends on `dev:setup`. Hooking `@repo/emails#build` into `dev:setup` makes turbo block every package's dev server until the email dist exists. The same flow protects every entry point that funnels through `turbo dev` — `pp restart`, `pp run`, `pp e2e`, `dotnet run --project AppHost`, and any IDE-launched AppHost.
- Update the UnknownUser e2e assertions in `application/account/WebApp/tests/e2e/localized-email-flows.spec.ts` to match the Slack-style copy the email template was rewritten to use ("No account found" / "Is this the right email address?" in English, "Ingen konto fundet" / "Er det den rigtige e-mailadresse?" in Danish). The previous strings ("Unknown user tried to login to PlatformPlatform" / "You or someone else tried to login to PlatformPlatform") no longer exist in the rendered emails.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary