### PR TITLE
Refine shared-webapp components and add UI utilities

### DIFF
--- a/.claude/rules/frontend/frontend.md
+++ b/.claude/rules/frontend/frontend.md
@@ -58,6 +58,7 @@ Use browser MCP tools to test at `https://app.dev.localhost:<appGateway>`. Look 
    - **Icon-only buttons**: Must have a `Tooltip` wrapper. Use descriptive labels, e.g., "Account settings" not "Settings", "Log out" not "Logout"
    - **Active state feedback**: Add press feedback to interactive elements using `active:` pseudo-class with background color changes. Buttons/triggers: `active:bg-primary/70` (or variant-specific active backgrounds). Menu/list items: `active:bg-accent`. Small controls (checkbox, radio): `active:border-primary`
    - **Use BaseUI `render` prop** to customize underlying elements (not Radix's `asChild`): `<DialogClose render={<Button />}>Close</DialogClose>`
+   - **Charts**: Import all chart primitives from `@repo/ui/components/Chart` — direct `recharts` imports are lint-blocked. Wrappers default `accessibilityLayer={true}` so Tab focuses data points, not the SVG (otherwise Chrome paints an unstyleable blue ring)
 
 ## Implementation
 

--- a/.github/workflows/account.yml
+++ b/.github/workflows/account.yml
@@ -220,8 +220,8 @@ jobs:
         run: npm run build
 
       - name: Run Lint
-        working-directory: application/account/WebApp
-        run: npm run lint
+        working-directory: developer-cli
+        run: dotnet run -- lint --frontend
 
       - name: Check for Frontend Formatting Issues
         working-directory: application/account/WebApp
@@ -233,10 +233,6 @@ jobs:
             echo "Formatting issues detected. Please run 'npm run format' from /application/account/WebApp folder locally and commit the formatted code."
             exit 1
           }
-
-      - name: Run Back Office Lint
-        working-directory: application/account/BackOffice
-        run: npm run lint
 
       - name: Check for Back Office Formatting Issues
         working-directory: application/account/BackOffice

--- a/.github/workflows/account.yml
+++ b/.github/workflows/account.yml
@@ -223,25 +223,14 @@ jobs:
         working-directory: developer-cli
         run: dotnet run -- lint --frontend
 
-      - name: Check for Frontend Formatting Issues
-        working-directory: application/account/WebApp
+      - name: Run Format
+        working-directory: developer-cli
         run: |
-          npm run format
+          dotnet run -- format --frontend
 
           # Check for any changes made by the code formatter
           git diff --exit-code || {
-            echo "Formatting issues detected. Please run 'npm run format' from /application/account/WebApp folder locally and commit the formatted code."
-            exit 1
-          }
-
-      - name: Check for Back Office Formatting Issues
-        working-directory: application/account/BackOffice
-        run: |
-          npm run format
-
-          # Check for any changes made by the code formatter
-          git diff --exit-code || {
-            echo "Formatting issues detected. Please run 'npm run format' from /application/account/BackOffice folder locally and commit the formatted code."
+            echo "Formatting issues detected. Please run 'dotnet run --project developer-cli -- format --frontend' locally and commit the formatted code."
             exit 1
           }
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,8 +215,8 @@ jobs:
         run: npm run build
 
       - name: Run Lint
-        working-directory: application/main/WebApp
-        run: npm run lint
+        working-directory: developer-cli
+        run: dotnet run -- lint --frontend
 
       - name: Check for Frontend Formatting Issues
         working-directory: application/main/WebApp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,14 +218,14 @@ jobs:
         working-directory: developer-cli
         run: dotnet run -- lint --frontend
 
-      - name: Check for Frontend Formatting Issues
-        working-directory: application/main/WebApp
+      - name: Run Format
+        working-directory: developer-cli
         run: |
-          npm run format
+          dotnet run -- format --frontend
 
           # Check for any changes made by the code formatter
           git diff --exit-code || {
-            echo "Formatting issues detected. Please run 'npm run format' from /application/main/WebApp folder locally and commit the formatted code."
+            echo "Formatting issues detected. Please run 'dotnet run --project developer-cli -- format --frontend' locally and commit the formatted code."
             exit 1
           }
 

--- a/application/.oxlintrc.json
+++ b/application/.oxlintrc.json
@@ -87,7 +87,11 @@
       "error",
       {
         "paths": [
-          { "name": "clsx", "message": "Use cn() from @repo/ui/utils instead." }
+          { "name": "clsx", "message": "Use cn() from @repo/ui/utils instead." },
+          {
+            "name": "recharts",
+            "message": "Import chart components from @repo/ui/components/Chart instead. The shared wrappers default accessibilityLayer={true} on chart types so Tab routes to data points and the focus ring matches our theme — importing recharts directly bypasses this and Chrome will paint its native blue focus ring on the SVG."
+          }
         ]
       }
     ]
@@ -156,6 +160,12 @@
     },
     {
       "files": ["**/shared-webapp/ui/utils.ts"],
+      "rules": {
+        "no-restricted-imports": "off"
+      }
+    },
+    {
+      "files": ["**/shared-webapp/ui/components/Chart.tsx"],
       "rules": {
         "no-restricted-imports": "off"
       }

--- a/application/account/BackOffice/shared/lib/api/labels.ts
+++ b/application/account/BackOffice/shared/lib/api/labels.ts
@@ -1,0 +1,29 @@
+import { t } from "@lingui/core/macro";
+
+import { SubscriptionPlan, UserRole } from "@/shared/lib/api/client";
+
+export function getSubscriptionPlanLabel(plan: SubscriptionPlan): string {
+  switch (plan) {
+    case SubscriptionPlan.Basis:
+      return t`Basis`;
+    case SubscriptionPlan.Standard:
+      return t`Standard`;
+    case SubscriptionPlan.Premium:
+      return t`Premium`;
+    default:
+      return String(plan);
+  }
+}
+
+export function getUserRoleLabel(role: UserRole): string {
+  switch (role) {
+    case UserRole.Owner:
+      return t`Owner`;
+    case UserRole.Admin:
+      return t`Admin`;
+    case UserRole.Member:
+      return t`Member`;
+    default:
+      return String(role);
+  }
+}

--- a/application/account/BackOffice/shared/translations/locale/da-DK.po
+++ b/application/account/BackOffice/shared/translations/locale/da-DK.po
@@ -31,6 +31,9 @@ msgstr "Back Office"
 msgid "BackOffice - Localhost"
 msgstr "BackOffice - Localhost"
 
+msgid "Basis"
+msgstr "Basis"
+
 msgid "Change language"
 msgstr "Skift sprog"
 
@@ -106,11 +109,17 @@ msgstr "Hovednavigation"
 msgid "Manage accounts, view system data, see exceptions, and perform various tasks for operational and support teams."
 msgstr "Administrer konti, se systemdata, se undtagelser og udfør forskellige opgaver for drifts- og supportteams."
 
+msgid "Member"
+msgstr "Medlem"
+
 msgid "Navigation"
 msgstr "Navigation"
 
 msgid "No back-office access"
 msgstr "Ingen adgang til Back Office"
+
+msgid "Owner"
+msgstr "Ejer"
 
 msgid "Page not found"
 msgstr "Siden blev ikke fundet"
@@ -124,6 +133,9 @@ msgstr "Tjek venligst URL'en eller vend tilbage til forsiden."
 msgid "Please try again or return to the home page."
 msgstr "Prøv venligst igen eller vend tilbage til forsiden."
 
+msgid "Premium"
+msgstr "Premium"
+
 msgid "Screenshots of the dashboard project with desktop and mobile versions"
 msgstr "Skærmbilleder af dashboard-projektet i desktop- og mobilversioner"
 
@@ -135,6 +147,9 @@ msgstr "Lille"
 
 msgid "Something went wrong"
 msgstr "Noget gik galt"
+
+msgid "Standard"
+msgstr "Standard"
 
 msgid "Support"
 msgstr "Support"

--- a/application/account/BackOffice/shared/translations/locale/en-US.po
+++ b/application/account/BackOffice/shared/translations/locale/en-US.po
@@ -31,6 +31,9 @@ msgstr "Back Office"
 msgid "BackOffice - Localhost"
 msgstr "BackOffice - Localhost"
 
+msgid "Basis"
+msgstr "Basis"
+
 msgid "Change language"
 msgstr "Change language"
 
@@ -106,11 +109,17 @@ msgstr "Main navigation"
 msgid "Manage accounts, view system data, see exceptions, and perform various tasks for operational and support teams."
 msgstr "Manage accounts, view system data, see exceptions, and perform various tasks for operational and support teams."
 
+msgid "Member"
+msgstr "Member"
+
 msgid "Navigation"
 msgstr "Navigation"
 
 msgid "No back-office access"
 msgstr "No back-office access"
+
+msgid "Owner"
+msgstr "Owner"
 
 msgid "Page not found"
 msgstr "Page not found"
@@ -124,6 +133,9 @@ msgstr "Please check the URL or return to the home page."
 msgid "Please try again or return to the home page."
 msgstr "Please try again or return to the home page."
 
+msgid "Premium"
+msgstr "Premium"
+
 msgid "Screenshots of the dashboard project with desktop and mobile versions"
 msgstr "Screenshots of the dashboard project with desktop and mobile versions"
 
@@ -135,6 +147,9 @@ msgstr "Small"
 
 msgid "Something went wrong"
 msgstr "Something went wrong"
+
+msgid "Standard"
+msgstr "Standard"
 
 msgid "Support"
 msgstr "Support"

--- a/application/account/WebApp/routes/account/index.tsx
+++ b/application/account/WebApp/routes/account/index.tsx
@@ -1,8 +1,9 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { AppLayout } from "@repo/ui/components/AppLayout";
+import { LinkCard } from "@repo/ui/components/LinkCard";
 import { getDateDaysAgo, getTodayIsoDate } from "@repo/utils/date/formatDate";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 
 import { api, UserStatus } from "@/shared/lib/api/client";
 
@@ -22,11 +23,7 @@ export default function Home() {
       subtitle={t`A quick summary of your account activity.`}
     >
       <div className="grid w-full grid-cols-1 gap-4 pt-8 md:grid-cols-2 lg:grid-cols-3">
-        <Link
-          to="/account/users"
-          className="flex flex-col justify-between rounded-xl bg-card p-6 outline-ring transition-[background-color] hover:bg-hover-background focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
-          aria-label={t`View users`}
-        >
+        <LinkCard to="/account/users" aria-label={t`View users`} className="justify-between">
           <div>
             <div className="text-sm font-medium text-foreground">
               <Trans>Total users</Trans>
@@ -36,16 +33,16 @@ export default function Home() {
             </div>
           </div>
           <div className="mt-4 text-2xl font-semibold text-foreground">{usersSummary?.totalUsers ?? "-"}</div>
-        </Link>
-        <Link
+        </LinkCard>
+        <LinkCard
           to="/account/users"
           search={{
             userStatus: UserStatus.Active,
             startDate: getDateDaysAgo(30),
             endDate: getTodayIsoDate()
           }}
-          className="flex flex-col justify-between rounded-xl bg-card p-6 outline-ring transition-[background-color] hover:bg-hover-background focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
           aria-label={t`View active users`}
+          className="justify-between"
         >
           <div>
             <div className="text-sm font-medium text-foreground">
@@ -56,12 +53,12 @@ export default function Home() {
             </div>
           </div>
           <div className="mt-4 text-2xl font-semibold text-foreground">{usersSummary?.activeUsers ?? "-"}</div>
-        </Link>
-        <Link
+        </LinkCard>
+        <LinkCard
           to="/account/users"
           search={{ userStatus: UserStatus.Pending }}
-          className="flex flex-col justify-between rounded-xl bg-card p-6 outline-ring transition-[background-color] hover:bg-hover-background focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
           aria-label={t`View invited users`}
+          className="justify-between"
         >
           <div>
             <div className="text-sm font-medium text-foreground">
@@ -72,7 +69,7 @@ export default function Home() {
             </div>
           </div>
           <div className="mt-4 text-2xl font-semibold text-foreground">{usersSummary?.pendingUsers ?? "-"}</div>
-        </Link>
+        </LinkCard>
       </div>
     </AppLayout>
   );

--- a/application/account/WebApp/routes/components/-components/AlertsBadgesPreview.tsx
+++ b/application/account/WebApp/routes/components/-components/AlertsBadgesPreview.tsx
@@ -150,6 +150,9 @@ export function AlertsBadgesPreview() {
           <Badge variant="destructive">
             <Trans>Destructive</Trans>
           </Badge>
+          <Badge variant="warning">
+            <Trans>Warning</Trans>
+          </Badge>
           <Badge variant="outline">
             <Trans>Outline</Trans>
           </Badge>

--- a/application/account/WebApp/routes/components/-components/ChartAreaInteractivePreview.tsx
+++ b/application/account/WebApp/routes/components/-components/ChartAreaInteractivePreview.tsx
@@ -2,17 +2,20 @@ import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@repo/ui/components/Card";
 import {
+  Area,
+  AreaChart,
+  CartesianGrid,
   type ChartConfig,
   ChartContainer,
   ChartLegend,
   ChartLegendContent,
   ChartTooltip,
-  ChartTooltipContent
+  ChartTooltipContent,
+  XAxis
 } from "@repo/ui/components/Chart";
 import { SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui/components/Select";
 import { SelectField } from "@repo/ui/components/SelectField";
 import { useState } from "react";
-import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
 
 import { dailyVisitors as chartData } from "./chartSampleData";
 

--- a/application/account/WebApp/routes/components/-components/ChartBarInteractivePreview.tsx
+++ b/application/account/WebApp/routes/components/-components/ChartBarInteractivePreview.tsx
@@ -2,9 +2,17 @@ import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { Button } from "@repo/ui/components/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@repo/ui/components/Card";
-import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@repo/ui/components/Chart";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  XAxis
+} from "@repo/ui/components/Chart";
 import { useMemo, useState } from "react";
-import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
 
 import { dailyVisitors as chartData } from "./chartSampleData";
 

--- a/application/account/WebApp/routes/components/-components/ChartBarStackedPreview.tsx
+++ b/application/account/WebApp/routes/components/-components/ChartBarStackedPreview.tsx
@@ -2,15 +2,18 @@ import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@repo/ui/components/Card";
 import {
+  Bar,
+  BarChart,
+  CartesianGrid,
   type ChartConfig,
   ChartContainer,
   ChartLegend,
   ChartLegendContent,
   ChartTooltip,
-  ChartTooltipContent
+  ChartTooltipContent,
+  XAxis
 } from "@repo/ui/components/Chart";
 import { TrendingUpIcon } from "lucide-react";
-import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
 
 const chartData = [
   { month: "January", desktop: 186, mobile: 80 },

--- a/application/account/WebApp/routes/components/-components/ChartPieDonutTextPreview.tsx
+++ b/application/account/WebApp/routes/components/-components/ChartPieDonutTextPreview.tsx
@@ -1,10 +1,17 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@repo/ui/components/Card";
-import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@repo/ui/components/Chart";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  Label,
+  Pie,
+  PieChart
+} from "@repo/ui/components/Chart";
 import { TrendingUpIcon } from "lucide-react";
 import { useMemo } from "react";
-import { Label, Pie, PieChart } from "recharts";
 
 const chartData = [
   { browser: "chrome", visitors: 275, fill: "var(--color-chrome)" },

--- a/application/account/WebApp/routes/components/-components/ChartRadialShapePreview.tsx
+++ b/application/account/WebApp/routes/components/-components/ChartRadialShapePreview.tsx
@@ -1,9 +1,16 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@repo/ui/components/Card";
-import { type ChartConfig, ChartContainer } from "@repo/ui/components/Chart";
+import {
+  type ChartConfig,
+  ChartContainer,
+  Label,
+  PolarGrid,
+  PolarRadiusAxis,
+  RadialBar,
+  RadialBarChart
+} from "@repo/ui/components/Chart";
 import { TrendingUpIcon } from "lucide-react";
-import { Label, PolarGrid, PolarRadiusAxis, RadialBar, RadialBarChart } from "recharts";
 
 const chartData = [{ browser: "safari", visitors: 1260, fill: "var(--color-safari)" }];
 

--- a/application/account/WebApp/routes/components/-components/ChartRadialStackedPreview.tsx
+++ b/application/account/WebApp/routes/components/-components/ChartRadialStackedPreview.tsx
@@ -1,9 +1,17 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@repo/ui/components/Card";
-import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@repo/ui/components/Chart";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  Label,
+  PolarRadiusAxis,
+  RadialBar,
+  RadialBarChart
+} from "@repo/ui/components/Chart";
 import { TrendingUpIcon } from "lucide-react";
-import { Label, PolarRadiusAxis, RadialBar, RadialBarChart } from "recharts";
 
 const chartData = [{ month: "january", mobile: 570, desktop: 1260 }];
 

--- a/application/account/WebApp/routes/components/-components/LinkCardPreview.tsx
+++ b/application/account/WebApp/routes/components/-components/LinkCardPreview.tsx
@@ -1,0 +1,41 @@
+import { Trans } from "@lingui/react/macro";
+import { LinkCard } from "@repo/ui/components/LinkCard";
+
+export function LinkCardPreview() {
+  return (
+    <div className="flex flex-col gap-2">
+      <h4>
+        <Trans>Link card</Trans>
+      </h4>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <LinkCard to="/components" className="gap-2 p-4">
+          <span className="text-sm font-medium">
+            <Trans>Total users</Trans>
+          </span>
+          <span className="text-xs text-muted-foreground">
+            <Trans>Add more in the Users menu</Trans>
+          </span>
+          <span className="text-2xl font-semibold tabular-nums">2</span>
+        </LinkCard>
+        <LinkCard to="/components" className="gap-2 p-4">
+          <span className="text-sm font-medium">
+            <Trans>Active users</Trans>
+          </span>
+          <span className="text-xs text-muted-foreground">
+            <Trans>Active users in the past 30 days</Trans>
+          </span>
+          <span className="text-2xl font-semibold tabular-nums">2</span>
+        </LinkCard>
+        <LinkCard to="/components" className="gap-2 p-4">
+          <span className="text-sm font-medium">
+            <Trans>Invited users</Trans>
+          </span>
+          <span className="text-xs text-muted-foreground">
+            <Trans>Users who haven't confirmed their email</Trans>
+          </span>
+          <span className="text-2xl font-semibold tabular-nums">0</span>
+        </LinkCard>
+      </div>
+    </div>
+  );
+}

--- a/application/account/WebApp/routes/components/-components/NavigationPreview.tsx
+++ b/application/account/WebApp/routes/components/-components/NavigationPreview.tsx
@@ -29,6 +29,7 @@ import { useState } from "react";
 
 import { CommandPreview } from "./CommandPreview";
 import { KbdPreview } from "./KbdPreview";
+import { LinkCardPreview } from "./LinkCardPreview";
 import { NavigationMenuPreview } from "./NavigationMenuPreview";
 
 export function NavigationPreview() {
@@ -178,6 +179,7 @@ export function NavigationPreview() {
           </ContextMenuContent>
         </ContextMenu>
       </div>
+      <LinkCardPreview />
       <NavigationMenuPreview />
       <CommandPreview />
       <KbdPreview />

--- a/application/account/WebApp/routes/components/-components/TextAreaFields.tsx
+++ b/application/account/WebApp/routes/components/-components/TextAreaFields.tsx
@@ -32,7 +32,7 @@ export function TextAreaFields({
         tooltip={tooltip ? tooltips.textAreaFixed : undefined}
         name={`textarea-fixed-${suffix}`}
         placeholder={placeholders ? t`Street address` : undefined}
-        defaultValue={hasValues ? t`1 Infinite Loop\nCupertino, CA 95014` : undefined}
+        defaultValue={hasValues ? t`123 Example Street\nAnytown, AA 12345` : undefined}
         lines={2}
         resizable={false}
         disabled={disabled}

--- a/application/account/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account/WebApp/shared/translations/locale/da-DK.po
@@ -69,11 +69,6 @@ msgstr "© {currentYear} PlatformPlatform. Alle rettigheder forbeholdes."
 msgid "+39 06 555 0000"
 msgstr "+39 06 555 0000"
 
-msgid ""
-"1 Infinite Loop\n"
-"Cupertino, CA 95014"
-msgstr ""
-
 msgid "1 TB storage"
 msgstr "1 TB lagerplads"
 
@@ -91,6 +86,13 @@ msgstr "100 GB lagerplads"
 
 msgid "100% Security Score"
 msgstr "100% sikkerhedsscore"
+
+msgid ""
+"123 Example Street\n"
+"Anytown, AA 12345"
+msgstr ""
+"123 Example Street\n"
+"Anytown, AA 12345"
 
 msgid "14 h 30 min logged"
 msgstr "14 t 30 min logget"
@@ -1471,6 +1473,9 @@ msgstr "Lineær fremskridtsbjælke til determinerede, forgrundsopgaver som uploa
 
 msgid "Link"
 msgstr "Link"
+
+msgid "Link card"
+msgstr "Linkkort"
 
 msgid "Link sizes"
 msgstr "Linkstørrelser"

--- a/application/account/WebApp/shared/translations/locale/da-DK.po
+++ b/application/account/WebApp/shared/translations/locale/da-DK.po
@@ -2929,6 +2929,9 @@ msgstr "Se brugere"
 msgid "Visitors"
 msgstr "Besøgende"
 
+msgid "Warning"
+msgstr "Advarsel"
+
 msgid "Warning alert"
 msgstr "Advarselsbesked"
 

--- a/application/account/WebApp/shared/translations/locale/en-US.po
+++ b/application/account/WebApp/shared/translations/locale/en-US.po
@@ -69,13 +69,6 @@ msgstr "© {currentYear} PlatformPlatform. All rights reserved."
 msgid "+39 06 555 0000"
 msgstr "+39 06 555 0000"
 
-msgid ""
-"1 Infinite Loop\n"
-"Cupertino, CA 95014"
-msgstr ""
-"1 Infinite Loop\n"
-"Cupertino, CA 95014"
-
 msgid "1 TB storage"
 msgstr "1 TB storage"
 
@@ -93,6 +86,13 @@ msgstr "100 GB storage"
 
 msgid "100% Security Score"
 msgstr "100% Security Score"
+
+msgid ""
+"123 Example Street\n"
+"Anytown, AA 12345"
+msgstr ""
+"123 Example Street\n"
+"Anytown, AA 12345"
 
 msgid "14 h 30 min logged"
 msgstr "14 h 30 min logged"
@@ -1473,6 +1473,9 @@ msgstr "Linear progress bar for determinate, foreground tasks like uploads or on
 
 msgid "Link"
 msgstr "Link"
+
+msgid "Link card"
+msgstr "Link card"
 
 msgid "Link sizes"
 msgstr "Link sizes"

--- a/application/account/WebApp/shared/translations/locale/en-US.po
+++ b/application/account/WebApp/shared/translations/locale/en-US.po
@@ -2931,6 +2931,9 @@ msgstr "View users"
 msgid "Visitors"
 msgstr "Visitors"
 
+msgid "Warning"
+msgstr "Warning"
+
 msgid "Warning alert"
 msgstr "Warning alert"
 

--- a/application/shared-webapp/ui/components/Alert.tsx
+++ b/application/shared-webapp/ui/components/Alert.tsx
@@ -9,7 +9,7 @@ const alertVariants = cva(
       variant: {
         default: "border-border bg-muted/50 text-foreground [&>svg]:text-foreground",
         destructive: "border-destructive/50 bg-destructive/10 text-destructive [&>svg]:text-destructive",
-        warning: "border-warning/50 bg-warning/10 text-warning-foreground [&>svg]:text-warning",
+        warning: "border-warning/50 bg-warning/10 text-warning [&>svg]:text-warning",
         info: "border-info/50 bg-info/10 text-info-foreground [&>svg]:text-info"
       }
     },

--- a/application/shared-webapp/ui/components/AppLayout.tsx
+++ b/application/shared-webapp/ui/components/AppLayout.tsx
@@ -309,7 +309,7 @@ export function AppLayout({
   }, [browserTitle, title]);
 
   return (
-    <div className="flex min-h-dvh flex-1 flex-col">
+    <div className="flex min-h-[calc(100dvh-var(--banner-offset,0rem))] flex-1 flex-col">
       {/* Row layout: main takes remaining width, sidePane reserves its own column.
           When the pane opens, main naturally shrinks because it has `min-w-0 flex-1`. */}
       <div className="flex min-h-0 flex-1 overflow-hidden">

--- a/application/shared-webapp/ui/components/Badge.tsx
+++ b/application/shared-webapp/ui/components/Badge.tsx
@@ -13,6 +13,7 @@ const badgeVariants = cva(
         secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive outline-destructive dark:bg-destructive/20 [a]:hover:bg-destructive/20",
+        warning: "bg-warning/15 text-warning outline-warning dark:bg-warning/30 [a]:hover:bg-warning/25",
         outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline"

--- a/application/shared-webapp/ui/components/Card.tsx
+++ b/application/shared-webapp/ui/components/Card.tsx
@@ -5,7 +5,8 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "flex min-w-0 flex-col gap-6 overflow-hidden rounded-xl border bg-card py-6 text-card-foreground shadow-sm transition-colors active:bg-muted",
+        // Overflow-safety contract: min-w-0 + overflow-hidden + [&>*]:min-w-0 [&>*]:max-w-full [&_*]:break-words prevent flex/grid overflow paths.
+        "flex min-w-0 flex-col gap-6 overflow-hidden rounded-xl border bg-card py-6 text-card-foreground shadow-sm transition-colors active:bg-muted [&_*]:break-words [&>*]:max-w-full [&>*]:min-w-0",
         className
       )}
       {...props}
@@ -45,7 +46,7 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="card-content" className={cn("px-6", className)} {...props} />;
+  return <div data-slot="card-content" className={cn("min-w-0 px-6", className)} {...props} />;
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {

--- a/application/shared-webapp/ui/components/Chart.tsx
+++ b/application/shared-webapp/ui/components/Chart.tsx
@@ -306,4 +306,79 @@ function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key:
   return configLabelKey in config ? config[configLabelKey] : config[key];
 }
 
-export { ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent, ChartStyle };
+// Chart-type wrappers with `accessibilityLayer={true}` defaulted on. Recharts ships this prop
+// off-by-default; without it, Tab focuses the entire <svg role="application"> which Chrome
+// paints with its native blue focus ring (un-styleable on SVG). With it, Tab routes to
+// individual data points and our Tailwind `--ring` outline takes effect. Spread last so
+// consumers can still pass `accessibilityLayer={false}` to opt out.
+function AreaChart(props: React.ComponentProps<typeof RechartsPrimitive.AreaChart>) {
+  return <RechartsPrimitive.AreaChart accessibilityLayer={true} {...props} />;
+}
+function BarChart(props: React.ComponentProps<typeof RechartsPrimitive.BarChart>) {
+  return <RechartsPrimitive.BarChart accessibilityLayer={true} {...props} />;
+}
+function LineChart(props: React.ComponentProps<typeof RechartsPrimitive.LineChart>) {
+  return <RechartsPrimitive.LineChart accessibilityLayer={true} {...props} />;
+}
+function PieChart(props: React.ComponentProps<typeof RechartsPrimitive.PieChart>) {
+  return <RechartsPrimitive.PieChart accessibilityLayer={true} {...props} />;
+}
+function RadialBarChart(props: React.ComponentProps<typeof RechartsPrimitive.RadialBarChart>) {
+  return <RechartsPrimitive.RadialBarChart accessibilityLayer={true} {...props} />;
+}
+
+// Plain re-exports of the recharts primitives consumers compose inside the chart wrappers.
+// Consumers must import these from `@repo/ui/components/Chart` rather than `recharts` directly
+// (enforced via `no-restricted-imports`) so the wrapped chart types are always picked up.
+const Area = RechartsPrimitive.Area;
+const Bar = RechartsPrimitive.Bar;
+const Cell = RechartsPrimitive.Cell;
+const CartesianGrid = RechartsPrimitive.CartesianGrid;
+const Label = RechartsPrimitive.Label;
+const Legend = RechartsPrimitive.Legend;
+const Line = RechartsPrimitive.Line;
+const Pie = RechartsPrimitive.Pie;
+const PolarAngleAxis = RechartsPrimitive.PolarAngleAxis;
+const PolarGrid = RechartsPrimitive.PolarGrid;
+const PolarRadiusAxis = RechartsPrimitive.PolarRadiusAxis;
+const RadialBar = RechartsPrimitive.RadialBar;
+const Rectangle = RechartsPrimitive.Rectangle;
+const ReferenceLine = RechartsPrimitive.ReferenceLine;
+const ResponsiveContainer = RechartsPrimitive.ResponsiveContainer;
+const Sector = RechartsPrimitive.Sector;
+const Tooltip = RechartsPrimitive.Tooltip;
+const XAxis = RechartsPrimitive.XAxis;
+const YAxis = RechartsPrimitive.YAxis;
+
+export {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+  ChartTooltip,
+  ChartTooltipContent,
+  Label,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  RadialBar,
+  RadialBarChart,
+  Rectangle,
+  ReferenceLine,
+  ResponsiveContainer,
+  Sector,
+  Tooltip,
+  XAxis,
+  YAxis
+};

--- a/application/shared-webapp/ui/components/LinkCard.tsx
+++ b/application/shared-webapp/ui/components/LinkCard.tsx
@@ -1,0 +1,20 @@
+import { Link, type LinkComponentProps } from "@tanstack/react-router";
+
+import { cn } from "../utils";
+
+// A navigable card. Combines Card's visual styling with a TanStack Router <Link> so the
+// whole card is the focusable element — keyboard focus ring lands on the card itself
+// (via the global `a:focus-visible` rule in tailwind.css) without being clipped by a
+// surrounding `<Card>`'s overflow-hidden.
+export function LinkCard({ className, ...props }: LinkComponentProps) {
+  return (
+    <Link
+      data-slot="card"
+      className={cn(
+        "flex min-w-0 flex-col gap-6 rounded-xl border bg-card p-6 text-card-foreground shadow-sm transition-[background-color] hover:bg-accent active:bg-muted [&_*]:break-words [&>*]:max-w-full [&>*]:min-w-0",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/application/shared-webapp/ui/components/MultiSelect.tsx
+++ b/application/shared-webapp/ui/components/MultiSelect.tsx
@@ -157,7 +157,7 @@ export function MultiSelect({
             </span>
             <ChevronDownIcon className="size-4 shrink-0 opacity-50" />
           </PopoverTrigger>
-          <PopoverContent className="w-(--anchor-width) p-1" align="start">
+          <PopoverContent className="min-w-(--anchor-width) p-1" align="start">
             <div
               id={`${name}-listbox`}
               ref={listRef}
@@ -181,7 +181,7 @@ export function MultiSelect({
                     )}
                   >
                     {item.icon && <span className="shrink-0 [&_svg:not([class*='size-'])]:size-4">{item.icon}</span>}
-                    <span className="truncate">{item.label}</span>
+                    <span className="whitespace-nowrap">{item.label}</span>
                     {checked && (
                       <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
                         <CheckIcon className="size-4" />

--- a/application/shared-webapp/ui/components/Sidebar.tsx
+++ b/application/shared-webapp/ui/components/Sidebar.tsx
@@ -128,8 +128,8 @@ function SidebarProvider({
     if (typeof window === "undefined") {
       return persistedOpenRef.current;
     }
-    // On initial load below `lg`, force-collapsed regardless of stored preference.
-    return window.matchMedia(MEDIA_QUERIES.lg).matches ? persistedOpenRef.current : false;
+    // On initial load below `xl`, force-collapsed regardless of stored preference.
+    return window.matchMedia(MEDIA_QUERIES.xl).matches ? persistedOpenRef.current : false;
   });
   const open = openProp ?? internalOpen;
   const setOpen = React.useCallback(
@@ -140,9 +140,9 @@ function SidebarProvider({
       } else {
         setInternalOpen(openState);
       }
-      // Only persist user choices made at `lg+`. Toggles below `lg` are overlay-mode
+      // Only persist user choices made at `xl+`. Toggles below `xl` are overlay-mode
       // interactions — transient, never written to localStorage.
-      if (typeof window !== "undefined" && window.matchMedia(MEDIA_QUERIES.lg).matches) {
+      if (typeof window !== "undefined" && window.matchMedia(MEDIA_QUERIES.xl).matches) {
         persistedOpenRef.current = openState;
         localStorage.setItem(SIDEBAR_STORAGE_KEY_COLLAPSED, String(!openState));
       }
@@ -175,14 +175,14 @@ function SidebarProvider({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [toggleSidebar]);
 
-  // Auto-collapse when the viewport drops below `lg`, restore user preference when it grows back.
-  // Below `lg` the sidebar overlays content (rarely desirable on narrow screens). Transitions
+  // Auto-collapse when the viewport drops below `xl`, restore user preference when it grows back.
+  // Below `xl` the sidebar overlays content (rarely desirable on narrow screens). Transitions
   // use setInternalOpen directly so they do NOT touch the persisted preference.
   React.useEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
-    const mediaQuery = window.matchMedia(MEDIA_QUERIES.lg);
+    const mediaQuery = window.matchMedia(MEDIA_QUERIES.xl);
     const handleChange = (event: MediaQueryListEvent) => {
       setInternalOpen(event.matches ? persistedOpenRef.current : false);
     };
@@ -236,7 +236,11 @@ function SidebarProvider({
                 } as React.CSSProperties
               }
               className={cn(
-                "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+                // Subtract --banner-offset so the wrapper fits inside the viewport's content area when a banner
+                // pushes body content down via padding-top. Without this, the wrapper overflows the viewport bottom
+                // by --banner-offset, and any descendant pinned to the wrapper's bottom (e.g., a SidePane footer)
+                // ends up below the visible frame.
+                "group/sidebar-wrapper flex min-h-[calc(100svh-var(--banner-offset,0rem))] w-full has-data-[variant=inset]:bg-sidebar",
                 className
               )}
               {...props}
@@ -344,8 +348,8 @@ function Sidebar({
       data-side={side}
       data-slot="sidebar"
     >
-      {/* Backdrop: dims content behind the expanded sidebar in overlay mode (below `lg`).
-          Hidden at `lg+` where the sidebar pushes content instead of overlaying. Click to collapse.
+      {/* Backdrop: dims content behind the expanded sidebar in overlay mode (below `xl`).
+          Hidden at `xl+` where the sidebar pushes content instead of overlaying. Click to collapse.
           Starts below any banner strip so banners (which push all top-positioned UI down) stay visible. */}
       <button
         type="button"
@@ -353,19 +357,19 @@ function Sidebar({
         tabIndex={-1}
         onClick={() => setOpen(false)}
         className={cn(
-          "pointer-events-none fixed top-(--banner-offset,0rem) right-0 bottom-0 left-0 z-[35] bg-black/50 opacity-0 transition-opacity duration-100 ease-linear lg:hidden",
+          "pointer-events-none fixed top-(--banner-offset,0rem) right-0 bottom-0 left-0 z-[35] bg-black/50 opacity-0 transition-opacity duration-100 ease-linear xl:hidden",
           "group-data-[state=expanded]:pointer-events-auto group-data-[state=expanded]:opacity-100"
         )}
       />
       {/* Placeholder width:
-          - Below `lg`: stays at icon-rail width so the expanded sidebar OVERLAYS content.
-          - At `lg`+: follows sidebar width so main content pushes right (no overlay).
+          - Below `xl`: stays at icon-rail width so the expanded sidebar OVERLAYS content.
+          - At `xl`+: follows sidebar width so main content pushes right (no overlay).
           Transitions disabled during drag via `[data-resizing]` on the wrapper. */}
       <div
         data-slot="sidebar-gap"
         className={cn(
           "relative w-(--sidebar-width-icon) bg-transparent transition-[width] duration-100 ease-linear",
-          "lg:w-(--sidebar-width) lg:group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
+          "xl:w-(--sidebar-width) xl:group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
           "group-data-[resizing=true]/sidebar-wrapper:transition-none"

--- a/application/shared-webapp/ui/components/Table.tsx
+++ b/application/shared-webapp/ui/components/Table.tsx
@@ -29,7 +29,7 @@ const INTERACTIVE_SELECTOR =
 
 function parseRowKey(value: string): RowKey {
   const numeric = Number(value);
-  return value !== "" && !Number.isNaN(numeric) && String(numeric) === value ? numeric : value;
+  return value !== "" && Number.isSafeInteger(numeric) && String(numeric) === value ? numeric : value;
 }
 
 function rowSelector(key: RowKey): string {

--- a/application/shared-webapp/ui/components/Table.tsx
+++ b/application/shared-webapp/ui/components/Table.tsx
@@ -189,6 +189,7 @@ interface TableProps extends React.ComponentProps<"table"> {
   activateOnNavigate?: boolean;
   scrollToKey?: RowKey;
   stickyHeader?: boolean;
+  containerClassName?: string;
 }
 
 function Table({
@@ -201,6 +202,7 @@ function Table({
   activateOnNavigate = false,
   scrollToKey,
   stickyHeader = false,
+  containerClassName,
   ...props
 }: TableProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -440,7 +442,11 @@ function Table({
   }, [hasSelection]);
 
   const table = (
-    <div ref={containerRef} data-slot="table-container" className="relative w-full overflow-x-auto">
+    <div
+      ref={containerRef}
+      data-slot="table-container"
+      className={cn("relative w-full overflow-x-auto rounded-md border bg-card", containerClassName)}
+    >
       <table data-slot="table" className={cn("w-full caption-bottom text-sm", className)} {...props} />
     </div>
   );
@@ -466,7 +472,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
     <TableRowSizeContext value="compact">
       <thead
         data-slot="table-header"
-        className={cn("[&_tr]:border-b", sticky && "sticky top-0 z-10 [&_tr]:bg-background", className)}
+        className={cn("[&_tr]:border-b [&_tr]:bg-card", sticky && "sticky top-0 z-10", className)}
         {...props}
       />
     </TableRowSizeContext>
@@ -510,7 +516,10 @@ function TableRow({ className, rowKey, ...props }: TableRowProps) {
       data-row-key={rowKey != null ? String(rowKey) : undefined}
       data-state={isSelected ? "selected" : undefined}
       className={cn(
-        "rounded-md border-b outline-ring transition-colors focus-visible:outline-2 focus-visible:-outline-offset-2 active:bg-muted data-[state=selected]:bg-active-background",
+        // Selected and keyboard-focused rows are marked with a 4px primary-colored bar on the
+        // left edge (drawn via inset box-shadow so it doesn't shift content). No outline ring —
+        // the bar replaces it for both states. Mouse-selected and keyboard-focused look identical.
+        "border-b transition-colors focus-visible:shadow-[inset_4px_0_0_var(--primary)] focus-visible:outline-none active:bg-muted data-[state=selected]:bg-active-background data-[state=selected]:shadow-[inset_4px_0_0_var(--primary)]",
         !suppressHover && "hover:bg-hover-background data-[state=selected]:hover:bg-active-background",
         rowSizeStyles[rowSize],
         isSelectable && "cursor-pointer select-none",

--- a/application/shared-webapp/ui/components/TenantLogo.tsx
+++ b/application/shared-webapp/ui/components/TenantLogo.tsx
@@ -1,7 +1,5 @@
 import type { ComponentProps } from "react";
 
-import { Building2Icon } from "lucide-react";
-
 import { cn } from "../utils";
 import { Avatar, AvatarFallback, AvatarImage } from "./Avatar";
 
@@ -30,15 +28,30 @@ const sizeMap = {
   lg: "size-16"
 };
 
-export function TenantLogo({ logoUrl, tenantName: _, size = "md", className, ...props }: Readonly<TenantLogoProps>) {
-  const iconSize = size === "lg" ? "size-12" : size === "md" ? "size-7" : "size-5";
-  const iconPadding = "p-0.5";
+const fallbackTextSize = {
+  sm: "text-[0.625rem]",
+  md: "text-xs",
+  lg: "text-xl"
+};
 
+function getTenantInitials(tenantName: string): string {
+  const cleaned = tenantName.trim();
+  if (cleaned.length === 0) {
+    return "?";
+  }
+  const parts = cleaned.split(/\s+/);
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+}
+
+export function TenantLogo({ logoUrl, tenantName, size = "md", className, ...props }: Readonly<TenantLogoProps>) {
   return (
     <Avatar className={cn(sizeMap[size], "shrink-0 rounded-lg after:hidden", className)} {...props}>
       <AvatarImage src={logoUrl ?? undefined} className="rounded-lg object-contain" />
-      <AvatarFallback className={cn("rounded-lg bg-transparent", iconPadding)}>
-        <Building2Icon className={`${iconSize} text-muted-foreground`} />
+      <AvatarFallback className={cn("rounded-lg bg-muted font-medium text-muted-foreground", fallbackTextSize[size])}>
+        {getTenantInitials(tenantName)}
       </AvatarFallback>
     </Avatar>
   );

--- a/application/shared-webapp/ui/hooks/useSmartDate.ts
+++ b/application/shared-webapp/ui/hooks/useSmartDate.ts
@@ -10,14 +10,26 @@ export interface SmartDateResult {
   formatted: string;
 }
 
-function formatDate(input: string, locale: string, includeTime = false, longMonth = false): string {
+function formatDate(
+  input: string,
+  locale: string,
+  includeTime = false,
+  longMonth = false,
+  omitCurrentYear = false,
+  omitYear = false
+): string {
   const date = new Date(input);
+  // The year always renders as 4 digits when shown ("May 7, 2026", never "May 7, 26").
+  // Callers that know they're rendering recent dates can pass `omitCurrentYear` to drop
+  // the year for dates in the current calendar year ("May 7"); other years still show
+  // the full 4-digit year so "May 7, 2025" stays unambiguous. Pass `omitYear` (e.g., for
+  // narrow mobile cells) to drop the year unconditionally.
+  const isCurrentYear = date.getFullYear() === new Date().getFullYear();
+  const showYear = !omitYear && !(omitCurrentYear && isCurrentYear);
   const options: Intl.DateTimeFormatOptions = {
-    // Short format uses a 2-digit year for compactness ("Apr 19, 26"); long format keeps the
-    // 4-digit year for prose readability ("April 19, 2026").
-    year: longMonth ? "numeric" : "2-digit",
     month: longMonth ? "long" : "short",
     day: "numeric",
+    ...(showYear ? { year: "numeric" } : {}),
     ...(includeTime && {
       hour: "2-digit",
       minute: "2-digit"
@@ -77,13 +89,12 @@ export function useSmartDate(date: string | undefined | null): SmartDateResult |
  * Returns a locale-aware date formatting function based on the app's current locale.
  * Uses the browser's built-in Intl.DateTimeFormat API, so any locale is automatically supported.
  *
- * Short format (default):
- * - English (en-US): "Jan 31, 2026" or "Jan 31, 2026, 2:30 PM"
- * - Danish (da-DK): "31. jan. 2026" or "31. jan. 2026 14.30"
+ * Always shows a 4-digit year by default. Callers can pass `omitCurrentYear: true` to drop the
+ * year for dates in the current calendar year (other years still show the 4-digit year).
  *
- * Long format:
- * - English (en-US): "January 31, 2026"
- * - Danish (da-DK): "31. januar 2026"
+ * Short format, assuming current year is 2026:
+ * - English (en-US): "May 7, 2026" or "May 7, 2026, 8:19 PM"; with omitCurrentYear: "May 7" or "May 7, 8:19 PM"
+ * - Danish (da-DK): "7. maj 2026" or "7. maj 2026 20.19"; with omitCurrentYear: "7. maj" or "7. maj 20.19"
  *
  * - Any other locale: Automatically formatted according to browser's locale data
  */
@@ -92,11 +103,11 @@ export function useFormatDate() {
   const locale = i18n.locale;
 
   return useCallback(
-    (input: string | undefined | null, includeTime = false): string => {
+    (input: string | undefined | null, includeTime = false, omitCurrentYear = false, omitYear = false): string => {
       if (!input) {
         return "";
       }
-      return formatDate(input, locale, includeTime);
+      return formatDate(input, locale, includeTime, false, omitCurrentYear, omitYear);
     },
     [locale]
   );
@@ -106,20 +117,23 @@ export function useFormatDate() {
  * Returns a locale-aware date formatting function that uses the full month name.
  * Use this in prose/banner text where space is not constrained.
  *
- * Formats:
- * - English (en-US): "January 31, 2026"
- * - Danish (da-DK): "31. januar 2026"
+ * Always shows a 4-digit year by default. Callers can pass `omitCurrentYear: true` to drop the
+ * year for dates in the current calendar year (other years still show the 4-digit year).
+ *
+ * Formats, assuming current year is 2026:
+ * - English (en-US): "January 31, 2026"; with omitCurrentYear: "January 31"
+ * - Danish (da-DK): "31. januar 2026"; with omitCurrentYear: "31. januar"
  */
 export function useFormatLongDate() {
   const { i18n } = useLingui();
   const locale = i18n.locale;
 
   return useCallback(
-    (input: string | undefined | null): string => {
+    (input: string | undefined | null, omitCurrentYear = false): string => {
       if (!input) {
         return "";
       }
-      return formatDate(input, locale, false, true);
+      return formatDate(input, locale, false, true, omitCurrentYear);
     },
     [locale]
   );

--- a/application/shared-webapp/ui/tailwind.css
+++ b/application/shared-webapp/ui/tailwind.css
@@ -131,6 +131,46 @@
     * {
         @apply border-border;
     }
+    /* App-wide focus ring on native <a> and <button> so raw anchors/buttons never fall back
+       to the browser default blue ring. Lives in @layer base, so any component using Tailwind
+       focus-visible utilities (@layer utilities) still wins. outline-color is pre-set on the
+       base state so Chrome doesn't briefly paint the user-agent default outline color when
+       focus first lands. */
+    a,
+    button {
+        outline-color: var(--ring);
+    }
+    a:focus-visible,
+    button:focus-visible {
+        outline: 2px solid var(--ring);
+        outline-offset: 2px;
+        border-radius: var(--radius-md);
+    }
+    /* Mirror ChartContainer's focus styling for raw recharts charts (dashboard cards bypass
+       ChartContainer because of a recharts ResizeObserver bug in their flex layout). The SVG
+       surface itself stays unfocused; instead, recharts' accessibilityLayer={true} routes Tab
+       to individual data points and the wrapper, where a 1px --ring outline shows just like
+       the /components/charts demo. */
+    .recharts-surface {
+        outline: none;
+    }
+    .recharts-wrapper *:focus-visible {
+        outline: 1px solid var(--ring);
+        outline-offset: 0;
+        border-radius: var(--radius-md);
+    }
+    /* Mouse click on legend/data-point elements triggers :focus without :focus-visible —
+       suppress the browser-default blue ring so click doesn't show one while keyboard tab
+       still gets the styled ring above. */
+    .recharts-wrapper *:focus:not(:focus-visible) {
+        outline: none;
+    }
+    /* App-wide spacing between recharts legends and the chart axes/dates underneath. Fixes
+       the Current/Prior period legend colliding with X-axis tick labels. Applies to every
+       chart in the app, whether it uses the shared ChartContainer or a raw ResponsiveContainer. */
+    .recharts-legend-wrapper {
+        padding-top: 0.75rem;
+    }
     body {
         @apply bg-background font-sans text-foreground;
         font-feature-settings:

--- a/application/shared-webapp/ui/theme.css
+++ b/application/shared-webapp/ui/theme.css
@@ -43,8 +43,8 @@
     --danger-foreground: var(--destructive-foreground);
     --success: oklch(0.45 0.15 145);
     --success-foreground: oklch(0.985 0 0);
-    --warning: oklch(0.75 0.18 70);
-    --warning-foreground: oklch(0.13 0.028 261.692);
+    --warning: oklch(0.5 0.18 55);
+    --warning-foreground: oklch(0.985 0 0);
     --info: oklch(0.55 0.2 260);
     --info-foreground: oklch(0.13 0.028 261.692);
     --panel-opacity: 0.5;

--- a/application/shared-webapp/ui/translations/locale/da-DK.po
+++ b/application/shared-webapp/ui/translations/locale/da-DK.po
@@ -60,7 +60,7 @@ msgid "Leave"
 msgstr "Forlad"
 
 msgid "Loading"
-msgstr ""
+msgstr "Indlæser"
 
 msgid "Main content"
 msgstr "Hovedindhold"
@@ -78,7 +78,7 @@ msgid "No results found"
 msgstr "Ingen resultater fundet"
 
 msgid "Open calendar"
-msgstr ""
+msgstr "Åbn kalender"
 
 msgid "Open navigation menu"
 msgstr "Åbn navigationsmenu"

--- a/application/shared-webapp/ui/utils/countryFlag.ts
+++ b/application/shared-webapp/ui/utils/countryFlag.ts
@@ -1,0 +1,15 @@
+const REGIONAL_INDICATOR_OFFSET = 0x1f1e6 - "A".charCodeAt(0);
+
+export function getCountryFlagEmoji(countryCode: string | null | undefined): string {
+  if (!countryCode || countryCode.length !== 2) {
+    return "";
+  }
+  const upper = countryCode.toUpperCase();
+  if (!/^[A-Z]{2}$/.test(upper)) {
+    return "";
+  }
+  return String.fromCodePoint(
+    upper.charCodeAt(0) + REGIONAL_INDICATOR_OFFSET,
+    upper.charCodeAt(1) + REGIONAL_INDICATOR_OFFSET
+  );
+}


### PR DESCRIPTION

### Summary & Motivation

A bundle of small, independent shared-webapp improvements consumed by `account` and back-office surfaces.

New shared components:

- `LinkCard` — stylized card with link affordance, used on the account index page.
- `Chart` — wraps `recharts` primitives with a consistent focus ring and accessibility-layer defaults. Direct `recharts` imports are now lint-blocked via `.oxlintrc.json` and the frontend rules.
- `Badge` — adds a `warning` variant and ties it into the `TenantLogo` initials fallback.

Component fixes:

- `Table` styling consolidated into the shared component (`bg-background`, rounded corners, `<TableHeader>` row styling), so consumers no longer need to re-apply utilities. Back-office tenant overview side-pane sizing tweaked alongside.
- `MultiSelect` popover can now expand beyond the anchor width so long labels render without clipping.
- `useSmartDate` always renders a 4-digit year and exposes `omitYear` / `omitCurrentYear` options for callers that need a shorter display.
- `Sidebar` overlay breakpoint raised from `lg` to `xl`; layout heights now offset by the banner so content isn't clipped behind it.

New utilities:

- Country flag emoji helper in `shared-webapp/ui/utils/countryFlag.ts`.
- Label helpers in `account/BackOffice/shared/lib/api/labels.ts`.

CI:

- Replace the `npm run lint` step in `main.yml` and `account.yml` with `dotnet run --project developer-cli -- lint --frontend`. The dev-CLI lint runs `npm run lint` internally and adds the missing-translation check, so it both lints and gates `.po` completeness in CI. Drops the now-redundant per-WebApp `Run Back Office Lint` step.
- Replace the per-WebApp `npm run format` + `git diff --exit-code` steps with a single `dotnet run --project developer-cli -- format --frontend` + diff check, since the dev-CLI format runs across all workspaces in one go.
- Fill in 2 missing Danish translations in `application/shared-webapp/ui/translations/locale/da-DK.po` ("Loading", "Open calendar") that were exposed once the dev-CLI lint started running.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
