### PR TITLE
Stop format command from converting local clones to shallow clones

### DIFF
--- a/developer-cli/Utilities/GitHelper.cs
+++ b/developer-cli/Utilities/GitHelper.cs
@@ -142,11 +142,10 @@ public static class GitHelper
     }
 
     // Returns relative paths (relative to solutionDirectory) of .cs files changed compared to
-    // origin/main. Fetches origin/main first so this works on shallow CI clones; the fetch is
-    // best-effort and silent on failure.
+    // origin/main. Relies on the caller's environment to keep origin/main reasonably current:
+    // CI checkouts in this repo use fetch-depth: 0 and local developers fetch on the usual cadence.
     public static string[] GetChangedCsFilesInDirectory(string solutionDirectory)
     {
-        ProcessHelper.StartProcess("git fetch origin main --depth=1", Configuration.SourceCodeFolder, true, exitOnError: false);
         var output = ProcessHelper.StartProcess("git diff --name-only origin/main -- \"*.cs\"", Configuration.SourceCodeFolder, true, exitOnError: false);
         if (string.IsNullOrWhiteSpace(output)) return [];
 


### PR DESCRIPTION
### Summary & Motivation

The developer CLI's `format` command silently converted full local clones into shallow clones. `GitHelper.GetChangedCsFilesInDirectory` ran `git fetch origin main --depth=1` before computing the changed-`.cs` diff, with the stated goal of supporting shallow CI checkouts. Against a full clone, that fetch creates `.git/shallow` containing the tip of `origin/main` — truncating `main`'s reachable history to a single commit on the developer's machine. The change is silent and only becomes visible later when a Git GUI renders `main` as disconnected from its own history. Recovery requires `git fetch --unshallow`, which is not discoverable.

Auditing the workflows that actually call `format` (`code-style.yml`, `account.yml`, `main.yml`), every one of them already checks out with `fetch-depth: 0`. The shallow workaround is dead code in every environment in which it runs — it cannot help CI (CI is already full) and only harms local developers. If a future workflow ever needs to run `format` against a shallow checkout, the right place to fix that is at the checkout step, not in `GitHelper`.

The depth-1 fetch is removed outright and the inline comment rewritten to make the new contract explicit: the method relies on the caller's environment to keep `origin/main` reasonably current.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary