### PR TITLE
Show duration in quiet mode, add format/lint caching, and fix deploy prompt

### DIFF
--- a/developer-cli/Commands/BuildCommand.cs
+++ b/developer-cli/Commands/BuildCommand.cs
@@ -108,7 +108,7 @@ public class BuildCommand : Command
 
             if (quiet)
             {
-                Console.WriteLine("Build succeeded.");
+                Console.WriteLine($"Build succeeded in {Stopwatch.GetElapsedTime(startTime).Format()}.");
             }
             else
             {

--- a/developer-cli/Commands/DeployCommand.cs
+++ b/developer-cli/Commands/DeployCommand.cs
@@ -577,7 +577,7 @@ public class DeployCommand : Command
 
                 [yellow]** All variables can be changed on the GitHub Settings page. For example, if you want to deploy production or staging to different locations.[/]
 
-             4. Disable the reusable GitHub workflows [blue]Deploy Container[/] and [blue]Plan and Deploy Infrastructure[/].
+             4. Disable the reusable GitHub workflows [blue]Deploy Container[/], [blue]Deploy Infrastructure[/], and [blue]Migrate Database[/].
 
              5. The [blue]Cloud Infrastructure - Deployment[/] GitHub Actions will be triggered deployment of Azure Infrastructure. This will take [yellow]between 15 and 45 minutes[/].
 

--- a/developer-cli/Commands/End2EndCommand.cs
+++ b/developer-cli/Commands/End2EndCommand.cs
@@ -226,7 +226,14 @@ public partial class End2EndCommand : Command
 
         stopwatch.Stop();
 
-        if (!quiet)
+        if (quiet)
+        {
+            Console.WriteLine(overallSuccess
+                ? $"All tests completed in {stopwatch.Elapsed.TotalSeconds:F1}s."
+                : $"Some tests failed in {stopwatch.Elapsed.TotalSeconds:F1}s."
+            );
+        }
+        else
         {
             AnsiConsole.MarkupLine(overallSuccess
                 ? $"[green]All tests completed in {stopwatch.Elapsed.TotalSeconds:F1} seconds[/]"

--- a/developer-cli/Commands/FormatCommand.cs
+++ b/developer-cli/Commands/FormatCommand.cs
@@ -86,7 +86,7 @@ public class FormatCommand : Command
 
             if (quiet)
             {
-                Console.WriteLine("Code formatted successfully.");
+                Console.WriteLine($"Code formatted successfully in {Stopwatch.GetElapsedTime(startTime).Format()}.");
             }
             else
             {

--- a/developer-cli/Commands/FormatCommand.cs
+++ b/developer-cli/Commands/FormatCommand.cs
@@ -52,6 +52,21 @@ public class FormatCommand : Command
 
         try
         {
+            const string cacheKey = "format";
+            if (SourceStateCache.IsUpToDate(cacheKey))
+            {
+                if (quiet)
+                {
+                    Console.WriteLine("No changes since last format run, skipping.");
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine("[green]No changes since last format run, skipping.[/]");
+                }
+
+                return;
+            }
+
             var initialUncommittedFiles = quiet ? null : GitHelper.GetChangedFiles();
             if (!quiet && initialUncommittedFiles!.Count > 0)
             {
@@ -83,6 +98,8 @@ public class FormatCommand : Command
                 RunDeveloperCliFormat(noBuild, allFiles, quiet);
                 developerCliTime = Stopwatch.GetElapsedTime(startTime) - backendTime - frontendTime;
             }
+
+            SourceStateCache.Save(cacheKey);
 
             if (quiet)
             {

--- a/developer-cli/Commands/LintCommand.cs
+++ b/developer-cli/Commands/LintCommand.cs
@@ -90,7 +90,7 @@ public class LintCommand : Command
                     Environment.Exit(1);
                 }
 
-                Console.WriteLine("Linting completed successfully. No issues found.");
+                Console.WriteLine($"Linting completed successfully in {Stopwatch.GetElapsedTime(startTime).Format()}. No issues found.");
             }
             else
             {

--- a/developer-cli/Commands/LintCommand.cs
+++ b/developer-cli/Commands/LintCommand.cs
@@ -53,6 +53,21 @@ public class LintCommand : Command
 
         try
         {
+            const string cacheKey = "lint";
+            if (SourceStateCache.IsUpToDate(cacheKey))
+            {
+                if (quiet)
+                {
+                    Console.WriteLine("No changes since last lint run, skipping.");
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine("[green]No changes since last lint run, skipping.[/]");
+                }
+
+                return;
+            }
+
             var startTime = Stopwatch.GetTimestamp();
             var backendTime = TimeSpan.Zero;
             var frontendTime = TimeSpan.Zero;
@@ -81,6 +96,8 @@ public class LintCommand : Command
                 hasIssues = hasIssues || developerCliHasIssues;
                 developerCliTime = Stopwatch.GetElapsedTime(startTime) - backendTime - frontendTime;
             }
+
+            if (!hasIssues) SourceStateCache.Save(cacheKey);
 
             if (quiet)
             {

--- a/developer-cli/Utilities/SourceStateCache.cs
+++ b/developer-cli/Utilities/SourceStateCache.cs
@@ -1,0 +1,51 @@
+using System.Security.Cryptography;
+using System.Text;
+using DeveloperCli.Installation;
+
+namespace DeveloperCli.Utilities;
+
+public static class SourceStateCache
+{
+    private static readonly string CacheDirectory = Path.Combine(Configuration.WorkspaceFolder, "developer-cli", "cache");
+
+    public static bool IsUpToDate(string cacheKey)
+    {
+        var cachePath = GetCachePath(cacheKey);
+        if (!File.Exists(cachePath)) return false;
+
+        try
+        {
+            var savedState = File.ReadAllText(cachePath).Trim();
+            return savedState == ComputeStateKey();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static void Save(string cacheKey)
+    {
+        try
+        {
+            Directory.CreateDirectory(CacheDirectory);
+            File.WriteAllText(GetCachePath(cacheKey), ComputeStateKey());
+        }
+        catch
+        {
+            // Caching is best-effort; failures should not break the workflow
+        }
+    }
+
+    private static string GetCachePath(string cacheKey)
+    {
+        return Path.Combine(CacheDirectory, $"{cacheKey}.hash");
+    }
+
+    private static string ComputeStateKey()
+    {
+        var head = ProcessHelper.StartProcess("git rev-parse HEAD", Configuration.SourceCodeFolder, true, exitOnError: false).Trim();
+        var stash = ProcessHelper.StartProcess("git stash create", Configuration.SourceCodeFolder, true, exitOnError: false).Trim();
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes($"{head}:{stash}")));
+    }
+}


### PR DESCRIPTION
### Summary & Motivation

Show command duration in `--quiet` mode output for build, format, lint, and e2e commands. Previously quiet mode suppressed all timing information, making it hard to spot slow runs in agent workflows.

- Add source state caching to format and lint commands so redundant runs are skipped when no code has changed since the last successful run. This avoids the engineer, reviewer, and guardian all paying the cost of the slow backend format and lint.
- Update the deploy command confirmation prompt to list all three disabled workflows (Deploy Container, Deploy Infrastructure, and Migrate Database) instead of only two.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
