### PR TITLE
Fix staging deployment broken by renamed Azure CLI firewall arguments

### DIFF
--- a/cloud-infrastructure/cluster/firewall.sh
+++ b/cloud-infrastructure/cluster/firewall.sh
@@ -8,8 +8,8 @@ FIREWALL_RULE_NAME="github-action-${DATABASE_NAME}"
 if [[ "$1" == "open" ]]
 then
     echo "$(date +"%Y-%m-%dT%H:%M:%S") Add the IP $IP_ADDRESS to the PostgreSQL server firewall on server $POSTGRES_SERVER_NAME for database $DATABASE_NAME"
-    az postgres flexible-server firewall-rule create --resource-group $CLUSTER_RESOURCE_GROUP_NAME --name $POSTGRES_SERVER_NAME --rule-name "$FIREWALL_RULE_NAME" --start-ip-address $IP_ADDRESS --end-ip-address $IP_ADDRESS
+    az postgres flexible-server firewall-rule create --resource-group $CLUSTER_RESOURCE_GROUP_NAME --server-name $POSTGRES_SERVER_NAME --name "$FIREWALL_RULE_NAME" --start-ip-address $IP_ADDRESS --end-ip-address $IP_ADDRESS
 else
     echo "$(date +"%Y-%m-%dT%H:%M:%S") Delete the IP $IP_ADDRESS from the PostgreSQL server firewall on server $POSTGRES_SERVER_NAME for database $DATABASE_NAME"
-    az postgres flexible-server firewall-rule delete --resource-group $CLUSTER_RESOURCE_GROUP_NAME --name $POSTGRES_SERVER_NAME --rule-name "$FIREWALL_RULE_NAME" --yes
+    az postgres flexible-server firewall-rule delete --resource-group $CLUSTER_RESOURCE_GROUP_NAME --server-name $POSTGRES_SERVER_NAME --name "$FIREWALL_RULE_NAME" --yes
 fi


### PR DESCRIPTION

### Summary & Motivation

The staging deployment fails at the database migration step because the Azure CLI on the GitHub-hosted runner adopted a breaking change that repurposes the `az postgres flexible-server firewall-rule` arguments. `--name` now identifies the firewall rule instead of the server, `--server-name` is the new required argument for the server, and `--rule-name` was removed. The cluster firewall script still passed the server via `--name` and the rule via `--rule-name`, so the command aborted with "the following arguments are required: --server-name/-s" before any migration could run.

- Pass the server through `--server-name` and the firewall rule through `--name` in both the create and delete paths of the cluster firewall script

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
