### PR TITLE
Make react and lingui eager module-federation singletons to stabilize the federated i18n context

### DIFF
--- a/application/shared-webapp/build/plugin/ModuleFederationPlugin.ts
+++ b/application/shared-webapp/build/plugin/ModuleFederationPlugin.ts
@@ -41,33 +41,41 @@ export function ModuleFederationPlugin({
               filename: manifestFile,
               shared: {
                 ...dependencies,
+                // `react`, `react-dom`, `@lingui/core` and `@lingui/react` are EAGER singletons: they are
+                // placed in the shared scope during the host's synchronous startup, before any remote's
+                // federated module consumes them. Without eager, a remote loaded early (e.g. account's
+                // AuthSyncModal on a direct page load) falls back to its own bundled copy, producing a second
+                // `@lingui` `i18n`/`LinguiContext` — which makes `useLingui` in a federated
+                // `withSystemTranslations` gate throw "used without I18nProvider". Lingui's eager modules
+                // synchronously require react, so react/react-dom must be eager too.
                 react: {
                   singleton: true,
+                  eager: true,
                   requiredVersion: dependencies.react
                 },
                 "react-dom": {
                   singleton: true,
+                  eager: true,
                   requiredVersion: dependencies["react-dom"]
                 },
-                // Lingui's `i18n` is a module-level singleton exported from @lingui/core. It must be a
-                // single instance across every remote so the merged catalog activated by one system is
-                // the same object every other system's `<Trans>`/`useLingui` reads from.
                 "@lingui/core": {
                   singleton: true,
+                  eager: true,
                   requiredVersion: dependencies["@lingui/core"]
                 },
                 "@lingui/react": {
                   singleton: true,
+                  eager: true,
                   requiredVersion: dependencies["@lingui/react"]
                 },
-                // Router instances, route objects, and router context cross the federation boundary,
-                // so every remote must bind the exact same router module instance.
+                // Router instances, route objects, and router context cross the federation boundary, so every
+                // remote must bind the exact same router module instance.
                 "@tanstack/react-router": {
                   singleton: true,
                   requiredVersion: dependencies["@tanstack/react-router"]
                 },
-                // Federated components resolve their QueryClient from the host's provider; the context
-                // object doing that lookup must come from a single module instance.
+                // Federated components resolve their QueryClient from the host's provider; the context object
+                // doing that lookup must come from a single module instance.
                 "@tanstack/react-query": {
                   singleton: true,
                   requiredVersion: dependencies["@tanstack/react-query"]


### PR DESCRIPTION
### Summary & Motivation

Make the federated translation context a single instance so a federated component's `useLingui` can no longer throw `used without I18nProvider` on a direct or reloaded page load.

- Root cause, detected empirically: despite `singleton: true`, `@lingui/core` and `@lingui/react` were duplicated at runtime — a probe recorded two distinct `i18n`/`LinguiContext`/`useLingui` instances across the remote loads. A remote consumed early on a direct load (account's `AuthSyncModal` via the `withSystemTranslations` gate) fell back to its own bundled copy, getting a second `LinguiContext` with no provider. `react`/`react-dom` were not duplicated (`pluginReact` handles those), which is why only the Lingui path broke.
- The change marks `react`, `react-dom`, `@lingui/core`, and `@lingui/react` as `eager` singletons in the module-federation `shared` map (in `ModuleFederationPlugin.ts`). `eager` places them in the shared scope during the host's synchronous startup, before any remote consumes them, so there is no per-remote fallback copy. The four are required together — eager Lingui synchronously requires react, so react/react-dom must be eager too. `@tanstack/react-router` and `@tanstack/react-query` stay non-eager singletons.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
